### PR TITLE
Implement ARN validation HTTP API

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -39,3 +39,5 @@ jobs:
           path: rabbitmq-server/deps/aws
       - run: |
           make -C ${{ github.workspace }}/rabbitmq-server/deps/aws
+      - run: |
+          make -C ${{ github.workspace }}/rabbitmq-server/deps/aws tests

--- a/src/aws_arn_config.erl
+++ b/src/aws_arn_config.erl
@@ -22,7 +22,7 @@
 %% @end
 process_arns() ->
     try
-        ok = application:ensure_started(rabbitmq_aws),
+        _ = application:ensure_all_started(rabbitmq_aws),
         case process_arn_config({handle_env_arn_config, application:get_env(aws, arn_config)}) of
             {ok, {iam_role_result, assumed}} ->
                 ?AWS_LOG_INFO("success"),

--- a/src/aws_arn_mgmt.erl
+++ b/src/aws_arn_mgmt.erl
@@ -1,0 +1,133 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+-module(aws_arn_mgmt).
+
+-behaviour(rabbit_mgmt_extension).
+
+-export([dispatcher/0, web_ui/0]).
+
+-export([
+    init/2,
+    content_types_accepted/2,
+    allowed_methods/2,
+    resource_exists/2,
+    is_authorized/2,
+    accept_content/2
+]).
+
+-include_lib("rabbitmq_web_dispatch/include/rabbitmq_web_dispatch_records.hrl").
+-include("aws.hrl").
+
+dispatcher() -> [{"/aws/arn/validate", ?MODULE, []}].
+
+web_ui() -> [].
+
+%%--------------------------------------------------------------------
+
+init(Req, _Opts) ->
+    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+
+content_types_accepted(ReqData, Context) ->
+    {[{'*', accept_content}], ReqData, Context}.
+
+allowed_methods(ReqData, Context) ->
+    {[<<"PUT">>, <<"OPTIONS">>], ReqData, Context}.
+
+resource_exists(ReqData, Context) ->
+    {true, ReqData, Context}.
+
+is_authorized(ReqData, Context) ->
+    rabbit_mgmt_util:is_authorized(ReqData, Context).
+
+accept_content(Req0, Context) ->
+    {ok, Region} = rabbitmq_aws_config:region(),
+    ok = rabbitmq_aws:set_region(Region),
+    F = fun(_Values, BodyMap, Req1) ->
+        try
+            {ok, AssumeRoleResult} = maybe_assume_role({map, BodyMap}),
+            {ok, Results} = maybe_process_arns({map, BodyMap}),
+            Body = rabbit_json:encode(rabbit_mgmt_format:format_nulls(Results)),
+            Headers = #{<<"content-type">> => <<"application/json">>},
+            Req2 = cowboy_req:reply(200, Headers, Body, Req1),
+            ok = maybe_reset_credentials(AssumeRoleResult),
+            {stop, Req2, Context}
+        catch
+            throw:{bad_request, ErrMsg0} ->
+                rabbit_mgmt_util:bad_request(ErrMsg0, Req1, Context);
+            throw:{unprocessable_entity, ErrMsg} ->
+                aws_mgmt_util:unprocessable_entity(ErrMsg, Req1, Context);
+            Class:Reason:Stacktrace ->
+                ?AWS_LOG_ERROR("~tp", [{Class, Reason}]),
+                ?AWS_LOG_ERROR("~tp", [Stacktrace]),
+                rabbit_mgmt_util:bad_request({Class, Reason}, Req1, Context)
+        end
+    end,
+    rabbit_mgmt_util:with_decode([], Req0, Context, F).
+
+maybe_assume_role({map, BodyMap}) when is_map_key(assume_role_arn, BodyMap) ->
+    AssumeRoleArn = maps:get(assume_role_arn, BodyMap),
+    maybe_assume_role({assume_role_arn, AssumeRoleArn});
+maybe_assume_role({map, BodyMap}) when not is_map_key(assume_role_arn, BodyMap) ->
+    %% Note: not assuming role
+    {ok, not_assumed};
+maybe_assume_role({assume_role_arn, AssumeRoleArn}) ->
+    maybe_assume_role({validate_arn_result, validate_arn(AssumeRoleArn)});
+maybe_assume_role({validate_arn_result, {ok, AssumeRoleArn}}) ->
+    case aws_iam:assume_role(AssumeRoleArn) of
+        {error, Error} ->
+            throw({bad_request, {assume_role_failed, Error}});
+        ok ->
+            {ok, assumed}
+    end;
+maybe_assume_role({validate_arn_result, Error}) ->
+    throw({bad_request, Error});
+maybe_assume_role(_) ->
+    throw({bad_request, "unknown error processing assume role ARN"}).
+
+maybe_reset_credentials(assumed) ->
+    aws_util:reset_aws_credentials();
+maybe_reset_credentials(_) ->
+    ok.
+
+maybe_process_arns({map, BodyMap}) when is_map_key(arns, BodyMap) ->
+    Arns = maps:get(arns, BodyMap),
+    maybe_process_arns({arns, Arns});
+maybe_process_arns({arns, Arns}) when length(Arns) > 0 ->
+    process_arns(Arns);
+maybe_process_arns({arns, _Arns}) ->
+    throw({unprocessable_entity, "one or more ARNs to resolve are required"});
+maybe_process_arns(_) ->
+    throw({bad_request, "unknown error processing ARNs"}).
+
+process_arns(Arns) ->
+    process_arns(Arns, []).
+
+process_arns([], Acc) ->
+    {ok, Acc};
+process_arns([Arn | Rest], Acc0) ->
+    case aws_arn_util:resolve_arn(Arn) of
+        {ok, ArnValue} ->
+            R = #{arn => Arn, value => ArnValue},
+            Acc1 = [R | Acc0],
+            process_arns(Rest, Acc1);
+        {error, {Reason, Msg}} ->
+            throw({unprocessable_entity, fmt(Reason, Msg)});
+        {error, Error} ->
+            throw({unprocessable_entity, Error});
+        Unexpected ->
+            throw({bad_request, Unexpected})
+    end.
+
+validate_arn(Arn) ->
+    case aws_arn_util:parse_arn(Arn) of
+        {ok, Map} when is_map(Map) ->
+            {ok, Arn};
+        Error ->
+            Error
+    end.
+
+fmt(Reason, Msg) ->
+    rabbit_data_coercion:to_utf8_binary(io_lib:format("~tp: ~ts", [Reason, Msg])).

--- a/src/aws_arn_util.erl
+++ b/src/aws_arn_util.erl
@@ -8,7 +8,7 @@
 -ifdef(TEST).
 -compile(export_all).
 -else.
--export([resolve_arn/1]).
+-export([resolve_arn/1, parse_arn/1]).
 -endif.
 
 -spec resolve_arn(string()) -> {ok, binary()} | {error, term()}.
@@ -44,7 +44,7 @@ parse_arn(Arn) ->
                     resource => Resource
                 }};
             UnexpectedMatch ->
-                {error, {invalid_arn_format, UnexpectedMatch}}
+                {error, {invalid_arn_format, rabbit_data_coercion:to_utf8_binary(UnexpectedMatch)}}
         end
     catch
         Class:Reason ->

--- a/src/aws_iam.erl
+++ b/src/aws_iam.erl
@@ -14,7 +14,9 @@
     {no_match, make_request/2}
 ]).
 
--spec assume_role(string()) -> ok | {error, term()}.
+-spec assume_role(string() | binary()) -> ok | {error, term()}.
+assume_role(RoleArn) when is_binary(RoleArn) ->
+    assume_role(binary_to_list(RoleArn));
 assume_role(RoleArn) ->
     SessionName = "rabbitmq-aws-" ++ integer_to_list(erlang:system_time(second)),
     Body =

--- a/test/aws_arn_mgmt_SUITE.erl
+++ b/test/aws_arn_mgmt_SUITE.erl
@@ -1,0 +1,176 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+-module(aws_arn_mgmt_SUITE).
+
+-export([all/0, init_per_suite/1, end_per_suite/1, init_per_testcase/2, end_per_testcase/2]).
+
+-export([
+    bad_resource_name_returns_405/1,
+    invalid_json_returns_400/1,
+    http_get_returns_405/1,
+    http_head_returns_405/1,
+    http_post_returns_405/1,
+    http_delete_returns_405/1,
+    http_options_returns_200/1,
+    empty_arns_returns_422/1,
+    malformed_assume_role_arn_returns_400/1
+]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("rabbitmq_ct_helpers/include/rabbit_mgmt_test.hrl").
+-include("aws.hrl").
+
+-import(rabbit_ct_helpers, [get_config/2]).
+-import(rabbit_mgmt_test_util, [http_put/4]).
+
+all() ->
+    [
+        bad_resource_name_returns_405,
+        invalid_json_returns_400,
+        http_get_returns_405,
+        http_head_returns_405,
+        http_post_returns_405,
+        http_delete_returns_405,
+        http_options_returns_200,
+        empty_arns_returns_422,
+        malformed_assume_role_arn_returns_400
+    ].
+
+init_per_suite(Config0) ->
+    ok = inets:start(),
+    Config1 = init_config(Config0),
+    rabbit_ct_helpers:log_environment(),
+    rabbit_ct_helpers:run_setup_steps(
+        Config1,
+        rabbit_ct_broker_helpers:setup_steps()
+    ).
+
+end_per_suite(Config) ->
+    ok = inets:stop(),
+    rabbit_ct_helpers:run_teardown_steps(
+        Config,
+        rabbit_ct_broker_helpers:teardown_steps()
+    ).
+
+init_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
+
+end_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
+
+init_config(Config) ->
+    C = [
+        {api, "/aws/arn/validate"},
+        {assume_role_arn, <<"arn:aws:iam::111111111111:role/MyCustomRole">>},
+        {arn0, <<"arn:aws:secretsmanager:us-east-1:999999999999:secret:the-secret-AAAA">>},
+        {arn1, <<"arn:aws:secretsmanager:us-east-1:999999999999:secret:another-secret-BBBB">>},
+        {invalid_arn, <<"foo-baz-bat">>}
+    ],
+    rabbit_ct_helpers:set_config(Config, C).
+
+bad_resource_name_returns_405(Config) ->
+    AssumeRoleArn = get_config(Config, assume_role_arn),
+    Arn0 = get_config(Config, arn0),
+    Arn1 = get_config(Config, arn1),
+    %% NB: bad resource name
+    http_put(
+        Config,
+        "/aws/arn/validate-foobar",
+        #{
+            'assume_role_arn' => AssumeRoleArn,
+            'arns' => [Arn0, Arn1]
+        },
+        ?METHOD_NOT_ALLOWED
+    ).
+
+invalid_json_returns_400(Config) ->
+    Api = get_config(Config, api),
+    %% Invalid JSON should return 400 Bad Request
+    rabbit_mgmt_test_util:http_put_raw(
+        Config,
+        Api,
+        "{invalid json",
+        ?BAD_REQUEST
+    ).
+
+http_get_returns_405(Config) ->
+    assert_405(get, Config).
+
+http_head_returns_405(Config) ->
+    assert_405(head, Config).
+
+http_post_returns_405(Config) ->
+    assert_405(post, Config).
+
+http_delete_returns_405(Config) ->
+    assert_405(delete, Config).
+
+http_options_returns_200(Config) ->
+    Api = get_config(Config, api),
+    {ok, {{_, OptionsCode, _}, OptionsHeaders, _OptionsResBody}} =
+        rabbit_mgmt_test_util:req(
+            Config,
+            0,
+            options,
+            Api,
+            [rabbit_mgmt_test_util:auth_header("guest", "guest")]
+        ),
+    ?assertEqual(?OK, OptionsCode),
+    AllowHeader = proplists:get_value("allow", OptionsHeaders),
+    ?assert(string:str(string:to_upper(AllowHeader), "PUT") > 0),
+    ?assert(string:str(string:to_upper(AllowHeader), "OPTIONS") > 0),
+    %% Should NOT contain GET or HEAD
+    ?assertEqual(0, string:str(string:to_upper(AllowHeader), "GET")),
+    ?assertEqual(0, string:str(string:to_upper(AllowHeader), "HEAD")).
+
+empty_arns_returns_422(Config) ->
+    Api = get_config(Config, api),
+    %% Empty arns array -> 422
+    http_put(Config, Api, #{arns => []}, ?UNPROCESSABLE_ENTITY).
+
+malformed_assume_role_arn_returns_400(Config) ->
+    Api = get_config(Config, api),
+    Arn0 = get_config(Config, arn0),
+    Arn1 = get_config(Config, arn1),
+    InvalidArn = get_config(Config, invalid_arn),
+    %% Malformed assume_role_arn field -> 400
+    http_put(
+        Config,
+        Api,
+        #{
+            'assume_role_arn' => InvalidArn,
+            'arns' => [Arn0, Arn1]
+        },
+        ?BAD_REQUEST
+    ).
+
+assert_405(post, Config) ->
+    %% NB: post requires a body or httpc complains.
+    Api = get_config(Config, api),
+    ?assertMatch(
+        {ok, {{_, ?METHOD_NOT_ALLOWED, _}, _Headers, _ResBody}},
+        rabbit_mgmt_test_util:req(
+            Config,
+            0,
+            post,
+            Api,
+            [rabbit_mgmt_test_util:auth_header("guest", "guest")],
+            "{}"
+        )
+    );
+assert_405(Method, Config) ->
+    Api = get_config(Config, api),
+    ?assertMatch(
+        {ok, {{_, ?METHOD_NOT_ALLOWED, _}, _Headers, _ResBody}},
+        rabbit_mgmt_test_util:req(
+            Config,
+            0,
+            Method,
+            Api,
+            [rabbit_mgmt_test_util:auth_header("guest", "guest")]
+        )
+    ).


### PR DESCRIPTION
This endpoint will allow JSON input to fetch ARNs, potentially after assuming a specific role.