### PR TITLE
Add aws.arns.amqp_client and amqp10_client ssl_options support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ instead of literal values:
 - `aws.arns.ssl_options.cacertfile`
 - `aws.arns.ssl_options.certfile`
 - `aws.arns.ssl_options.keyfile`
+- `aws.arns.amqp_client.ssl_options.cacertfile`
+- `aws.arns.amqp_client.ssl_options.certfile`
+- `aws.arns.amqp_client.ssl_options.keyfile`
+- `aws.arns.amqp10_client.ssl_options.cacertfile`
+- `aws.arns.amqp10_client.ssl_options.certfile`
+- `aws.arns.amqp10_client.ssl_options.keyfile`
 - `aws.arns.management.ssl.cacertfile`
 - `aws.arns.management.ssl.certfile`
 - `aws.arns.management.ssl.keyfile`

--- a/priv/schema/aws.schema
+++ b/priv/schema/aws.schema
@@ -31,6 +31,26 @@
     [{datatype, string}]}.
 
 %%--------------------------------------------------------------------------------------------------
+%% amqp_client
+%%
+{mapping, "aws.arns.amqp_client.ssl_options.cacertfile", "aws.arn_config.arns",
+    [{datatype, string}]}.
+{mapping, "aws.arns.amqp_client.ssl_options.certfile", "aws.arn_config.arns",
+    [{datatype, string}]}.
+{mapping, "aws.arns.amqp_client.ssl_options.keyfile", "aws.arn_config.arns",
+    [{datatype, string}]}.
+
+%%--------------------------------------------------------------------------------------------------
+%% amqp10_client
+%%
+{mapping, "aws.arns.amqp10_client.ssl_options.cacertfile", "aws.arn_config.arns",
+    [{datatype, string}]}.
+{mapping, "aws.arns.amqp10_client.ssl_options.certfile", "aws.arn_config.arns",
+    [{datatype, string}]}.
+{mapping, "aws.arns.amqp10_client.ssl_options.keyfile", "aws.arn_config.arns",
+    [{datatype, string}]}.
+
+%%--------------------------------------------------------------------------------------------------
 %% rabbitmq_management plugin
 %%
 {mapping, "aws.arns.management.ssl.cacertfile", "aws.arn_config.arns",
@@ -128,6 +148,16 @@ fun(Conf) ->
         {"aws.arns.ssl_options.cacertfile", aws_arn_config_rabbit, ssl_options, cacertfile},
         {"aws.arns.ssl_options.certfile",   aws_arn_config_rabbit, ssl_options, certfile},
         {"aws.arns.ssl_options.keyfile",    aws_arn_config_rabbit, ssl_options, keyfile},
+
+        %% amqp_client
+        {"aws.arns.amqp_client.ssl_options.cacertfile", aws_arn_config_amqp_client, ssl_options, cacertfile},
+        {"aws.arns.amqp_client.ssl_options.certfile",   aws_arn_config_amqp_client, ssl_options, certfile},
+        {"aws.arns.amqp_client.ssl_options.keyfile",    aws_arn_config_amqp_client, ssl_options, keyfile},
+
+        %% amqp10_client
+        {"aws.arns.amqp10_client.ssl_options.cacertfile", aws_arn_config_amqp10_client, ssl_options, cacertfile},
+        {"aws.arns.amqp10_client.ssl_options.certfile",   aws_arn_config_amqp10_client, ssl_options, certfile},
+        {"aws.arns.amqp10_client.ssl_options.keyfile",    aws_arn_config_amqp10_client, ssl_options, keyfile},
 
         %% rabbitmq_management
         {"aws.arns.management.ssl.cacertfile",          aws_arn_config_management, ssl_options, cacertfile},

--- a/src/aws_arn_config_amqp10_client.erl
+++ b/src/aws_arn_config_amqp10_client.erl
@@ -1,0 +1,36 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+-module(aws_arn_config_amqp10_client).
+
+-export([run/4]).
+
+run(ArnData, _KeyStr, ssl_options, ConfigSubKey) ->
+    handle_content(ConfigSubKey, ArnData).
+
+handle_content(cacertfile, PemData) ->
+    aws_arn_env:replace(
+        amqp10_client,
+        ssl_options,
+        cacertfile,
+        cacerts,
+        aws_pem_util:decode_data(PemData)
+    );
+handle_content(certfile, PemData) ->
+    aws_arn_env:replace(
+        amqp10_client,
+        ssl_options,
+        certfile,
+        certs_keys,
+        aws_pem_util:decode_data(PemData)
+    );
+handle_content(keyfile, PemData) ->
+    aws_arn_env:replace(
+        amqp10_client,
+        ssl_options,
+        keyfile,
+        certs_keys,
+        aws_pem_util:decode_key_data(PemData)
+    ).

--- a/src/aws_arn_config_amqp_client.erl
+++ b/src/aws_arn_config_amqp_client.erl
@@ -1,0 +1,36 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+-module(aws_arn_config_amqp_client).
+
+-export([run/4]).
+
+run(ArnData, _KeyStr, ssl_options, ConfigSubKey) ->
+    handle_content(ConfigSubKey, ArnData).
+
+handle_content(cacertfile, PemData) ->
+    aws_arn_env:replace(
+        amqp_client,
+        ssl_options,
+        cacertfile,
+        cacerts,
+        aws_pem_util:decode_data(PemData)
+    );
+handle_content(certfile, PemData) ->
+    aws_arn_env:replace(
+        amqp_client,
+        ssl_options,
+        certfile,
+        certs_keys,
+        aws_pem_util:decode_data(PemData)
+    );
+handle_content(keyfile, PemData) ->
+    aws_arn_env:replace(
+        amqp_client,
+        ssl_options,
+        keyfile,
+        certs_keys,
+        aws_pem_util:decode_key_data(PemData)
+    ).

--- a/test/config_schema_SUITE_data/aws.snippets
+++ b/test/config_schema_SUITE_data/aws.snippets
@@ -17,6 +17,36 @@
         ],
         [aws_arn_config]},
 
+    {aws_arn_config_arns_amqp_client_ssl_options_cacertfile,
+        "aws.arns.amqp_client.ssl_options.cacertfile = arn:aws:s3:::private-ca-42/cacertfile.pem",
+        [{aws, [
+            {arn_config, [
+                {arns, [
+                    {aws_arn_config_amqp_client,
+                    "arn:aws:s3:::private-ca-42/cacertfile.pem",
+                    "aws.arns.amqp_client.ssl_options.cacertfile",
+                    ["aws.arns.amqp_client.ssl_options.cacertfile", ssl_options, cacertfile]}
+                ]}
+            ]}
+         ]}
+        ],
+        [aws_arn_config]},
+
+    {aws_arn_config_arns_amqp10_client_ssl_options_cacertfile,
+        "aws.arns.amqp10_client.ssl_options.cacertfile = arn:aws:s3:::private-ca-42/cacertfile.pem",
+        [{aws, [
+            {arn_config, [
+                {arns, [
+                    {aws_arn_config_amqp10_client,
+                    "arn:aws:s3:::private-ca-42/cacertfile.pem",
+                    "aws.arns.amqp10_client.ssl_options.cacertfile",
+                    ["aws.arns.amqp10_client.ssl_options.cacertfile", ssl_options, cacertfile]}
+                ]}
+            ]}
+         ]}
+        ],
+        [aws_arn_config]},
+
     {aws_arn_config_arns_oauth2_cacertfile,
         "aws.arns.auth_oauth2.https.cacertfile = arn:aws:s3:::private-ca-42/cacertfile.pem",
         [{aws, [


### PR DESCRIPTION
Allow configuring amqp_client and amqp10_client SSL options (cacertfile, certfile, keyfile) via AWS ARNs, enabling shovel and federation plugins to use TLS certificates fetched from S3 or Secrets Manager at boot.

- amqp_client: used by AMQP 0-9-1 shovels and federation
- amqp10_client: used by AMQP 1.0 shovels


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
