### PR TITLE
rabbitmq-aws 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.2.0](https://github.com/amazon-mq/rabbitmq-aws/tree/0.2.0) (2026-02-16)
+
+[Full Changelog](https://github.com/amazon-mq/rabbitmq-aws/compare/0.1.0...0.2.0)
+
+**Fixed bugs:**
+
+- Schema translation mismatch for `aws.arns.management.oauth_client_secret` [\#27](https://github.com/amazon-mq/rabbitmq-aws/issues/27)
+
+**Merged pull requests:**
+
+- Fix schema translation key for `management.oauth_client_secret` [\#28](https://github.com/amazon-mq/rabbitmq-aws/pull/28) ([lukebakken](https://github.com/lukebakken))
+- Update GH actions refs [\#26](https://github.com/amazon-mq/rabbitmq-aws/pull/26) ([lukebakken](https://github.com/lukebakken))
+- Fix error encoding validation api [\#25](https://github.com/amazon-mq/rabbitmq-aws/pull/25) ([sunfinite](https://github.com/sunfinite))
+- Add aws.arns.amqp\_client and amqp10\_client ssl\_options support [\#24](https://github.com/amazon-mq/rabbitmq-aws/pull/24) ([sunfinite](https://github.com/sunfinite))
+- Use dependabot to update actions refs [\#21](https://github.com/amazon-mq/rabbitmq-aws/pull/21) ([lukebakken](https://github.com/lukebakken))
+- Update GHA actions [\#20](https://github.com/amazon-mq/rabbitmq-aws/pull/20) ([lukebakken](https://github.com/lukebakken))
+- Update GHA actions refs [\#19](https://github.com/amazon-mq/rabbitmq-aws/pull/19) ([lukebakken](https://github.com/lukebakken))
+- Add workflow to indicate when GHA actions need updates [\#18](https://github.com/amazon-mq/rabbitmq-aws/pull/18) ([lukebakken](https://github.com/lukebakken))
+- Add workflow to automatically update GHA refs [\#17](https://github.com/amazon-mq/rabbitmq-aws/pull/17) ([lukebakken](https://github.com/lukebakken))
+- Add codebase summary document [\#16](https://github.com/amazon-mq/rabbitmq-aws/pull/16) ([lukebakken](https://github.com/lukebakken))
+
 ## [0.1.0](https://github.com/amazon-mq/rabbitmq-aws/tree/0.1.0) (2025-11-14)
 
 [Full Changelog](https://github.com/amazon-mq/rabbitmq-aws/compare/137a38241cfa5dd5f3d430a50db3f45afda69af2...0.1.0)
@@ -10,4 +31,5 @@
 
 **Merged pull requests:**
 
+- rabbitmq-aws 0.1.0 [\#14](https://github.com/amazon-mq/rabbitmq-aws/pull/14) ([lukebakken](https://github.com/lukebakken))
 - Add list of supported keys to README [\#13](https://github.com/amazon-mq/rabbitmq-aws/pull/13) ([sunfinite](https://github.com/sunfinite))

--- a/CODEBASE_SUMMARY.md
+++ b/CODEBASE_SUMMARY.md
@@ -4,8 +4,8 @@
 
 The `rabbitmq-aws` plugin enables RabbitMQ to fetch sensitive configuration data (certificates, secrets, passwords) from AWS services at startup instead of storing them on disk. It resolves AWS ARNs specified in RabbitMQ configuration and injects the retrieved values directly into the application environment.
 
-**Version:** 0.1.0  
-**License:** Apache-2.0  
+**Version:** 0.2.0
+**License:** Apache-2.0
 **Compatibility:** RabbitMQ 4.2.0+
 
 ## Core Architecture
@@ -97,6 +97,12 @@ Each handler module implements the `run/3` or `run/4` function to process resolv
 #### `aws_arn_config_rabbit.erl`
 Handles core RabbitMQ `ssl_options` configuration.
 
+#### `aws_arn_config_amqp_client.erl`
+Handles `amqp_client` application `ssl_options` configuration.
+
+#### `aws_arn_config_amqp10_client.erl`
+Handles `amqp10_client` application `ssl_options` configuration.
+
 #### `aws_arn_config_management.erl`
 Handles `rabbitmq_management` plugin SSL and OAuth client secrets.
 
@@ -131,6 +137,9 @@ Low-level application environment manipulation (update/delete operations).
 
 #### `aws_util.erl`
 Credential management utilities, primarily for resetting AWS credentials after role assumption.
+
+#### `aws_mgmt_util.erl`
+HTTP error response helpers for the management API, including 422 Unprocessable Entity responses.
 
 ### Management API Module
 
@@ -179,6 +188,16 @@ The plugin uses Cuttlefish schema (`priv/schema/aws.schema`) to translate `rabbi
 - `aws.arns.ssl_options.cacertfile`
 - `aws.arns.ssl_options.certfile`
 - `aws.arns.ssl_options.keyfile`
+
+**AMQP Client SSL:**
+- `aws.arns.amqp_client.ssl_options.cacertfile`
+- `aws.arns.amqp_client.ssl_options.certfile`
+- `aws.arns.amqp_client.ssl_options.keyfile`
+
+**AMQP 1.0 Client SSL:**
+- `aws.arns.amqp10_client.ssl_options.cacertfile`
+- `aws.arns.amqp10_client.ssl_options.certfile`
+- `aws.arns.amqp10_client.ssl_options.keyfile`
 
 **Management Plugin:**
 - `aws.arns.management.ssl.cacertfile`
@@ -332,7 +351,7 @@ application:set_env()
 - Project name: `aws`
 - Module: `aws_app`
 - Registered process: `aws_sup`
-- Version: 0.1.0
+- Version: 0.2.0
 
 ## CI/CD
 
@@ -342,9 +361,9 @@ application:set_env()
    - Tests against RabbitMQ versions: v3.13.7, v4.2.x, main
    - Matrix builds with different OTP/Elixir versions
    - Runs daily at 16:00 UTC
-   - Caches RabbitMQ server builds
+   - Restores cached RabbitMQ server builds
 
-2. **build-rabbitmq-server.yaml** - Builds RabbitMQ server for testing
+2. **build-rabbitmq-server.yaml** - Builds and caches RabbitMQ server for testing
 
 3. **format-check.yaml** - Code formatting validation
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PROJECT = aws
 PROJECT_DESCRIPTION = RabbitMQ - AWS integration plugin
 PROJECT_MOD = aws_app
 PROJECT_REGISTERED = aws_sup
-PROJECT_VERSION = 0.1.0
+PROJECT_VERSION = 0.2.0
 
 define PROJECT_ENV
 []

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,7 +3,7 @@
 Here are the commands to run when releasing a new version of this project:
 
 ```
-readonly VER=0.1.0
+readonly VER=0.2.0
 git checkout -b "rabbitmq-aws-$VER"
 sed -i.bak "s/^PROJECT_VERSION =.*/PROJECT_VERSION = $VER/" Makefile
 github_changelog_generator --future-release "$VER" --user amazon-mq --project rabbitmq-aws --token "$GITHUB_API_TOKEN"


### PR DESCRIPTION
Prepare the 0.2.0 release.

- Update `CHANGELOG.md` for 0.2.0
- Bump `PROJECT_VERSION` to 0.2.0 in `Makefile`
- Update `CODEBASE_SUMMARY.md` for 0.2.0 (add missing modules, config keys, fix CI description, remove trailing whitespace)
- Update `RELEASE.md` version to 0.2.0