### PR TITLE
Auth Validation Endpoint: add rate limiter + concurrency semaphore + config knobs

### DIFF
--- a/priv/schema/aws.schema
+++ b/priv/schema/aws.schema
@@ -96,6 +96,52 @@
     [{datatype, string}]}.
 
 %%--------------------------------------------------------------------------------------------------
+%% auth validation endpoint (PUT /api/aws/auth/validate/:method)
+%%
+
+%% @doc Master toggle. When false (the default) the validation
+%% subsystem starts no workers and the endpoint returns 404.
+{mapping, "aws.auth_validation.enabled", "aws.auth_validation_enabled",
+    [{datatype, {enum, [true, false]}}, {default, false}]}.
+
+%% @doc Per-method enable flag. Methods are enabled by default; set
+%% explicit false to disable a specific method even when the master
+%% toggle is on. Example:
+%%   aws.auth_validation.enabled_methods.ldap = false
+{mapping, "aws.auth_validation.enabled_methods.$name", "aws.auth_validation_enabled_methods",
+    [{datatype, {enum, [true, false]}}]}.
+
+{translation, "aws.auth_validation_enabled_methods",
+ fun(Conf) ->
+     Settings = cuttlefish_variable:filter_by_prefix("aws.auth_validation.enabled_methods", Conf),
+     [{list_to_binary(lists:last(Key)), Value} || {Key, Value} <- Settings]
+ end}.
+
+%% @doc Maximum HTTP request body size in bytes.
+{mapping, "aws.auth_validation.max_body_size", "aws.auth_validation_max_body_size",
+    [{datatype, integer}, {default, 65536}]}.
+
+%% @doc Maximum concurrent outbound auth-validation connections.
+{mapping, "aws.auth_validation.max_concurrent", "aws.auth_validation_max_concurrent",
+    [{datatype, integer}, {default, 5}]}.
+
+%% @doc Per-connection timeout in milliseconds for outbound calls.
+{mapping, "aws.auth_validation.connection_timeout_ms", "aws.auth_validation_connection_timeout_ms",
+    [{datatype, integer}, {default, 5000}]}.
+
+%% @doc Rate limiter window in seconds (per source IP).
+{mapping, "aws.auth_validation.rate_limit.window_seconds", "aws.auth_validation_rate_limit_window_seconds",
+    [{datatype, integer}, {default, 60}]}.
+
+%% @doc Rate limiter max successful requests per window per source IP.
+{mapping, "aws.auth_validation.rate_limit.max_requests", "aws.auth_validation_rate_limit_max_requests",
+    [{datatype, integer}, {default, 10}]}.
+
+%% @doc Required management user tag to access the endpoint.
+{mapping, "aws.auth_validation.required_user_tag", "aws.auth_validation_required_user_tag",
+    [{datatype, atom}, {default, administrator}]}.
+
+%%--------------------------------------------------------------------------------------------------
 %% misc
 %%
 %% @doc Custom headers for AWS STS calls. Header name should be the exact case-sensitive headername

--- a/priv/schema/aws.schema
+++ b/priv/schema/aws.schema
@@ -102,7 +102,7 @@
 %% @doc Master toggle. When false (the default) the validation
 %% subsystem starts no workers and the endpoint returns 404.
 {mapping, "aws.auth_validation.enabled", "aws.auth_validation_enabled",
-    [{datatype, {enum, [true, false]}}, {default, false}]}.
+    [{datatype, {enum, [true, false]}}, {default, false}, {include_default, false}]}.
 
 %% @doc Per-method enable flag. Methods are enabled by default; set
 %% explicit false to disable a specific method even when the master
@@ -119,27 +119,27 @@
 
 %% @doc Maximum HTTP request body size in bytes.
 {mapping, "aws.auth_validation.max_body_size", "aws.auth_validation_max_body_size",
-    [{datatype, integer}, {default, 65536}]}.
+    [{datatype, integer}, {default, 65536}, {include_default, false}]}.
 
 %% @doc Maximum concurrent outbound auth-validation connections.
 {mapping, "aws.auth_validation.max_concurrent", "aws.auth_validation_max_concurrent",
-    [{datatype, integer}, {default, 5}]}.
+    [{datatype, integer}, {default, 5}, {include_default, false}]}.
 
 %% @doc Per-connection timeout in milliseconds for outbound calls.
 {mapping, "aws.auth_validation.connection_timeout_ms", "aws.auth_validation_connection_timeout_ms",
-    [{datatype, integer}, {default, 5000}]}.
+    [{datatype, integer}, {default, 5000}, {include_default, false}]}.
 
 %% @doc Rate limiter window in seconds (per source IP).
 {mapping, "aws.auth_validation.rate_limit.window_seconds", "aws.auth_validation_rate_limit_window_seconds",
-    [{datatype, integer}, {default, 60}]}.
+    [{datatype, integer}, {default, 60}, {include_default, false}]}.
 
 %% @doc Rate limiter max successful requests per window per source IP.
 {mapping, "aws.auth_validation.rate_limit.max_requests", "aws.auth_validation_rate_limit_max_requests",
-    [{datatype, integer}, {default, 10}]}.
+    [{datatype, integer}, {default, 10}, {include_default, false}]}.
 
 %% @doc Required management user tag to access the endpoint.
 {mapping, "aws.auth_validation.required_user_tag", "aws.auth_validation_required_user_tag",
-    [{datatype, atom}, {default, administrator}]}.
+    [{datatype, atom}, {default, administrator}, {include_default, false}]}.
 
 %%--------------------------------------------------------------------------------------------------
 %% misc

--- a/priv/schema/aws.schema
+++ b/priv/schema/aws.schema
@@ -99,10 +99,13 @@
 %% auth validation endpoint (PUT /api/aws/auth/validate/:method)
 %%
 
-%% @doc Master toggle. When false (the default) the validation
-%% subsystem starts no workers and the endpoint returns 404.
+%% @doc Master toggle. When unset (the effective default) the validation
+%% subsystem starts no workers and the endpoint returns 404. The default
+%% lives in code (aws_sup reads this with a `false' fallback); it is
+%% intentionally NOT declared here so the key is only emitted into the
+%% generated config when an operator sets it.
 {mapping, "aws.auth_validation.enabled", "aws.auth_validation_enabled",
-    [{datatype, {enum, [true, false]}}, {default, false}]}.
+    [{datatype, {enum, [true, false]}}]}.
 
 %% @doc Per-method enable flag. Methods are enabled by default; set
 %% explicit false to disable a specific method even when the master
@@ -117,29 +120,40 @@
      [{list_to_binary(lists:last(Key)), Value} || {Key, Value} <- Settings]
  end}.
 
-%% @doc Maximum HTTP request body size in bytes.
+%% Note: none of the settings below declare a schema {default, ...}. A
+%% defaulted mapping is emitted into every generated config, which breaks
+%% config_schema_SUITE's exact-match snippets. Effective defaults are
+%% applied by the consuming code when the key is unset, so the key reaches
+%% the app env only when an operator sets it explicitly.
+
+%% @doc Maximum HTTP request body size in bytes (effective default 65536).
 {mapping, "aws.auth_validation.max_body_size", "aws.auth_validation_max_body_size",
-    [{datatype, integer}, {default, 65536}]}.
+    [{datatype, integer}]}.
 
-%% @doc Maximum concurrent outbound auth-validation connections.
+%% @doc Maximum concurrent outbound auth-validation connections (effective
+%% default 5; applied by aws_sup).
 {mapping, "aws.auth_validation.max_concurrent", "aws.auth_validation_max_concurrent",
-    [{datatype, integer}, {default, 5}]}.
+    [{datatype, integer}]}.
 
-%% @doc Per-connection timeout in milliseconds for outbound calls.
+%% @doc Per-connection timeout in milliseconds for outbound calls
+%% (effective default 5000).
 {mapping, "aws.auth_validation.connection_timeout_ms", "aws.auth_validation_connection_timeout_ms",
-    [{datatype, integer}, {default, 5000}]}.
+    [{datatype, integer}]}.
 
-%% @doc Rate limiter window in seconds (per source IP).
+%% @doc Rate limiter window in seconds, per source IP (effective default
+%% 60; applied by aws_sup).
 {mapping, "aws.auth_validation.rate_limit.window_seconds", "aws.auth_validation_rate_limit_window_seconds",
-    [{datatype, integer}, {default, 60}]}.
+    [{datatype, integer}]}.
 
-%% @doc Rate limiter max successful requests per window per source IP.
+%% @doc Rate limiter max successful requests per window per source IP
+%% (effective default 10; applied by aws_sup).
 {mapping, "aws.auth_validation.rate_limit.max_requests", "aws.auth_validation_rate_limit_max_requests",
-    [{datatype, integer}, {default, 10}]}.
+    [{datatype, integer}]}.
 
-%% @doc Required management user tag to access the endpoint.
+%% @doc Required management user tag to access the endpoint (effective
+%% default administrator).
 {mapping, "aws.auth_validation.required_user_tag", "aws.auth_validation_required_user_tag",
-    [{datatype, atom}, {default, administrator}]}.
+    [{datatype, atom}]}.
 
 %%--------------------------------------------------------------------------------------------------
 %% misc

--- a/src/aws_auth_validate_rate_limiter.erl
+++ b/src/aws_auth_validate_rate_limiter.erl
@@ -62,11 +62,15 @@ init(Config) when is_map(Config) ->
     schedule_sweep(State#rate_state.sweep_interval_ms),
     {ok, State}.
 
-handle_call({check, IP}, _From, #rate_state{
-    counters = Counters0,
-    window_ms = WindowMs,
-    max_per_window = Max
-} = State) ->
+handle_call(
+    {check, IP},
+    _From,
+    #rate_state{
+        counters = Counters0,
+        window_ms = WindowMs,
+        max_per_window = Max
+    } = State
+) ->
     Now = erlang:monotonic_time(millisecond),
     case maps:get(IP, Counters0, undefined) of
         undefined ->
@@ -87,11 +91,14 @@ handle_call(_Request, _From, State) ->
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
-handle_info(sweep, #rate_state{
-    counters = Counters0,
-    window_ms = WindowMs,
-    sweep_interval_ms = SweepMs
-} = State) ->
+handle_info(
+    sweep,
+    #rate_state{
+        counters = Counters0,
+        window_ms = WindowMs,
+        sweep_interval_ms = SweepMs
+    } = State
+) ->
     Now = erlang:monotonic_time(millisecond),
     Counters1 = maps:filter(
         fun(_IP, {_Count, WindowStart}) -> (Now - WindowStart) < WindowMs end,

--- a/src/aws_auth_validate_rate_limiter.erl
+++ b/src/aws_auth_validate_rate_limiter.erl
@@ -1,0 +1,114 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% Per-source-IP fixed-window rate limiter. A periodic sweep evicts
+%% stale entries whose window has fully expired, bounding state size.
+-module(aws_auth_validate_rate_limiter).
+
+-behaviour(gen_server).
+
+-export([start_link/1, check/1, reset/0]).
+
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
+
+-record(rate_state, {
+    counters = #{} :: #{inet:ip_address() => {non_neg_integer(), integer()}},
+    window_ms :: pos_integer(),
+    max_per_window :: pos_integer(),
+    sweep_interval_ms :: pos_integer()
+}).
+
+-type config() :: #{
+    window_ms => pos_integer(),
+    max_per_window => pos_integer(),
+    sweep_interval_ms => pos_integer()
+}.
+
+-define(DEFAULT_WINDOW_MS, 60_000).
+-define(DEFAULT_MAX_PER_WINDOW, 10).
+-define(DEFAULT_SWEEP_INTERVAL_MS, 30_000).
+
+-spec start_link(config()) -> {ok, pid()} | {error, term()}.
+start_link(Config) ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, Config, []).
+
+-spec check(inet:ip_address()) -> ok | {error, rate_limited}.
+check(IP) ->
+    gen_server:call(?MODULE, {check, IP}).
+
+-spec reset() -> ok.
+reset() ->
+    gen_server:call(?MODULE, reset).
+
+%%--------------------------------------------------------------------
+%% gen_server callbacks
+%%--------------------------------------------------------------------
+
+init(Config) when is_map(Config) ->
+    State = #rate_state{
+        window_ms = maps:get(window_ms, Config, ?DEFAULT_WINDOW_MS),
+        max_per_window = maps:get(max_per_window, Config, ?DEFAULT_MAX_PER_WINDOW),
+        sweep_interval_ms = maps:get(sweep_interval_ms, Config, ?DEFAULT_SWEEP_INTERVAL_MS)
+    },
+    schedule_sweep(State#rate_state.sweep_interval_ms),
+    {ok, State}.
+
+handle_call({check, IP}, _From, #rate_state{
+    counters = Counters0,
+    window_ms = WindowMs,
+    max_per_window = Max
+} = State) ->
+    Now = erlang:monotonic_time(millisecond),
+    case maps:get(IP, Counters0, undefined) of
+        undefined ->
+            {reply, ok, State#rate_state{counters = maps:put(IP, {1, Now}, Counters0)}};
+        {_Count, WindowStart} when (Now - WindowStart) >= WindowMs ->
+            {reply, ok, State#rate_state{counters = maps:put(IP, {1, Now}, Counters0)}};
+        {Count, _WindowStart} when Count >= Max ->
+            {reply, {error, rate_limited}, State};
+        {Count, WindowStart} ->
+            Counters1 = maps:put(IP, {Count + 1, WindowStart}, Counters0),
+            {reply, ok, State#rate_state{counters = Counters1}}
+    end;
+handle_call(reset, _From, State) ->
+    {reply, ok, State#rate_state{counters = #{}}};
+handle_call(_Request, _From, State) ->
+    {reply, {error, unknown_request}, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(sweep, #rate_state{
+    counters = Counters0,
+    window_ms = WindowMs,
+    sweep_interval_ms = SweepMs
+} = State) ->
+    Now = erlang:monotonic_time(millisecond),
+    Counters1 = maps:filter(
+        fun(_IP, {_Count, WindowStart}) -> (Now - WindowStart) < WindowMs end,
+        Counters0
+    ),
+    schedule_sweep(SweepMs),
+    {noreply, State#rate_state{counters = Counters1}};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%--------------------------------------------------------------------
+
+schedule_sweep(SweepMs) ->
+    erlang:send_after(SweepMs, self(), sweep).

--- a/src/aws_auth_validate_semaphore.erl
+++ b/src/aws_auth_validate_semaphore.erl
@@ -1,0 +1,113 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% Counting semaphore that bounds concurrent outbound auth-validation
+%% requests. Holders are monitored so a crashed handler frees its slot
+%% automatically.
+-module(aws_auth_validate_semaphore).
+
+-behaviour(gen_server).
+
+-export([start_link/1, acquire/0, release/1, current/0]).
+
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
+
+-record(sem_state, {
+    max :: pos_integer(),
+    current = 0 :: non_neg_integer(),
+    holders = #{} :: #{reference() => pid()}
+}).
+
+-type config() :: #{max => pos_integer()}.
+
+-define(DEFAULT_MAX, 5).
+
+-spec start_link(config()) -> {ok, pid()} | {error, term()}.
+start_link(Config) ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, Config, []).
+
+-spec acquire() -> {ok, reference()} | {error, full}.
+acquire() ->
+    gen_server:call(?MODULE, acquire).
+
+-spec release(reference()) -> ok.
+release(Ref) ->
+    gen_server:call(?MODULE, {release, Ref}).
+
+-spec current() -> non_neg_integer().
+current() ->
+    gen_server:call(?MODULE, get_current).
+
+%%--------------------------------------------------------------------
+%% gen_server callbacks
+%%--------------------------------------------------------------------
+
+init(Config) when is_map(Config) ->
+    {ok, #sem_state{max = maps:get(max, Config, ?DEFAULT_MAX)}}.
+
+handle_call(acquire, _From, #sem_state{max = Max, current = Current} = State)
+    when Current >= Max ->
+    {reply, {error, full}, State};
+handle_call(acquire, {Pid, _Tag}, #sem_state{
+    current = Current,
+    holders = Holders0
+} = State) ->
+    Ref = erlang:monitor(process, Pid),
+    Holders1 = maps:put(Ref, Pid, Holders0),
+    {reply, {ok, Ref}, State#sem_state{
+        current = Current + 1,
+        holders = Holders1
+    }};
+handle_call({release, Ref}, _From, #sem_state{
+    current = Current,
+    holders = Holders0
+} = State) ->
+    case maps:take(Ref, Holders0) of
+        {_Pid, Holders1} ->
+            erlang:demonitor(Ref, [flush]),
+            {reply, ok, State#sem_state{
+                current = Current - 1,
+                holders = Holders1
+            }};
+        error ->
+            %% Already released (e.g. via DOWN). Treat idempotently.
+            {reply, ok, State}
+    end;
+handle_call(get_current, _From, #sem_state{current = Current} = State) ->
+    {reply, Current, State};
+handle_call(_Request, _From, State) ->
+    {reply, {error, unknown_request}, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info({'DOWN', Ref, process, _Pid, _Reason}, #sem_state{
+    current = Current,
+    holders = Holders0
+} = State) ->
+    case maps:take(Ref, Holders0) of
+        {_Holder, Holders1} ->
+            {noreply, State#sem_state{
+                current = Current - 1,
+                holders = Holders1
+            }};
+        error ->
+            {noreply, State}
+    end;
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.

--- a/src/aws_auth_validate_semaphore.erl
+++ b/src/aws_auth_validate_semaphore.erl
@@ -54,23 +54,32 @@ current() ->
 init(Config) when is_map(Config) ->
     {ok, #sem_state{max = maps:get(max, Config, ?DEFAULT_MAX)}}.
 
-handle_call(acquire, _From, #sem_state{max = Max, current = Current} = State)
-    when Current >= Max ->
+handle_call(acquire, _From, #sem_state{max = Max, current = Current} = State) when
+    Current >= Max
+->
     {reply, {error, full}, State};
-handle_call(acquire, {Pid, _Tag}, #sem_state{
-    current = Current,
-    holders = Holders0
-} = State) ->
+handle_call(
+    acquire,
+    {Pid, _Tag},
+    #sem_state{
+        current = Current,
+        holders = Holders0
+    } = State
+) ->
     Ref = erlang:monitor(process, Pid),
     Holders1 = maps:put(Ref, Pid, Holders0),
     {reply, {ok, Ref}, State#sem_state{
         current = Current + 1,
         holders = Holders1
     }};
-handle_call({release, Ref}, _From, #sem_state{
-    current = Current,
-    holders = Holders0
-} = State) ->
+handle_call(
+    {release, Ref},
+    _From,
+    #sem_state{
+        current = Current,
+        holders = Holders0
+    } = State
+) ->
     case maps:take(Ref, Holders0) of
         {_Pid, Holders1} ->
             erlang:demonitor(Ref, [flush]),
@@ -90,10 +99,13 @@ handle_call(_Request, _From, State) ->
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
-handle_info({'DOWN', Ref, process, _Pid, _Reason}, #sem_state{
-    current = Current,
-    holders = Holders0
-} = State) ->
+handle_info(
+    {'DOWN', Ref, process, _Pid, _Reason},
+    #sem_state{
+        current = Current,
+        holders = Holders0
+    } = State
+) ->
     case maps:take(Ref, Holders0) of
         {_Holder, Holders1} ->
             {noreply, State#sem_state{

--- a/src/aws_sup.erl
+++ b/src/aws_sup.erl
@@ -16,10 +16,15 @@ start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 init([]) ->
+    %% Tolerate a few transient worker crashes before giving up: a single
+    %% restart within 5s (intensity => 1) would tear down the whole
+    %% supervisor -- and with it ARN resolution -- on a second crash. The
+    %% validation workers are independent gen_servers, so allow several
+    %% restarts in a slightly wider window before escalating.
     SupFlags = #{
         strategy => one_for_one,
-        intensity => 1,
-        period => 5
+        intensity => 5,
+        period => 10
     },
     ChildSpecs = auth_validation_children(),
     {ok, {SupFlags, ChildSpecs}}.

--- a/src/aws_sup.erl
+++ b/src/aws_sup.erl
@@ -21,5 +21,58 @@ init([]) ->
         intensity => 1,
         period => 5
     },
-    ChildSpecs = [],
+    ChildSpecs = auth_validation_children(),
     {ok, {SupFlags, ChildSpecs}}.
+
+%%--------------------------------------------------------------------
+%% Auth validation feature: workers are started only when the feature
+%% toggle is on. With the toggle off, the supervisor remains empty and
+%% the validation route returns 404, leaving the rest of the plugin
+%% (ARN resolution) entirely undisturbed.
+%%--------------------------------------------------------------------
+
+auth_validation_children() ->
+    case application:get_env(aws, auth_validation_enabled, false) of
+        true -> [rate_limiter_spec(), semaphore_spec()];
+        _ -> []
+    end.
+
+rate_limiter_spec() ->
+    Config = rate_limiter_config(),
+    #{
+        id => aws_auth_validate_rate_limiter,
+        start => {aws_auth_validate_rate_limiter, start_link, [Config]},
+        restart => permanent,
+        shutdown => 5_000,
+        type => worker,
+        modules => [aws_auth_validate_rate_limiter]
+    }.
+
+semaphore_spec() ->
+    Config = semaphore_config(),
+    #{
+        id => aws_auth_validate_semaphore,
+        start => {aws_auth_validate_semaphore, start_link, [Config]},
+        restart => permanent,
+        shutdown => 5_000,
+        type => worker,
+        modules => [aws_auth_validate_semaphore]
+    }.
+
+rate_limiter_config() ->
+    WindowSecs = get_int_env(auth_validation_rate_limit_window_seconds, 60),
+    Max = get_int_env(auth_validation_rate_limit_max_requests, 10),
+    #{
+        window_ms => WindowSecs * 1_000,
+        max_per_window => Max,
+        sweep_interval_ms => max(WindowSecs * 1_000 div 2, 1_000)
+    }.
+
+semaphore_config() ->
+    #{max => get_int_env(auth_validation_max_concurrent, 5)}.
+
+get_int_env(Key, Default) ->
+    case application:get_env(aws, Key) of
+        {ok, N} when is_integer(N), N > 0 -> N;
+        _ -> Default
+    end.

--- a/test/aws_auth_validate_tests.erl
+++ b/test/aws_auth_validate_tests.erl
@@ -1,0 +1,149 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% Unit tests for the auth-validation subsystem's standalone workers: the
+%% per-IP rate limiter and the concurrency semaphore. Tests for the
+%% registry, LDAP backend, and HTTP pipeline are added alongside those
+%% modules in later changes.
+-module(aws_auth_validate_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(IP1, {10, 0, 0, 1}).
+-define(IP2, {10, 0, 0, 2}).
+
+%%--------------------------------------------------------------------
+%% Rate limiter
+%%--------------------------------------------------------------------
+
+rate_limiter_test_() ->
+    {foreach,
+        fun() ->
+            {ok, Pid} = aws_auth_validate_rate_limiter:start_link(#{
+                window_ms => 60_000,
+                max_per_window => 3,
+                sweep_interval_ms => 60_000
+            }),
+            Pid
+        end,
+        fun stop/1,
+        [
+            {"allows up to max then rejects", fun() ->
+                ?assertEqual(ok, aws_auth_validate_rate_limiter:check(?IP1)),
+                ?assertEqual(ok, aws_auth_validate_rate_limiter:check(?IP1)),
+                ?assertEqual(ok, aws_auth_validate_rate_limiter:check(?IP1)),
+                ?assertEqual(
+                    {error, rate_limited},
+                    aws_auth_validate_rate_limiter:check(?IP1)
+                )
+            end},
+            {"per-IP isolation", fun() ->
+                ok = aws_auth_validate_rate_limiter:check(?IP1),
+                ok = aws_auth_validate_rate_limiter:check(?IP1),
+                ok = aws_auth_validate_rate_limiter:check(?IP1),
+                ?assertEqual(
+                    {error, rate_limited},
+                    aws_auth_validate_rate_limiter:check(?IP1)
+                ),
+                ?assertEqual(ok, aws_auth_validate_rate_limiter:check(?IP2))
+            end},
+            {"reset clears counters", fun() ->
+                ok = aws_auth_validate_rate_limiter:check(?IP1),
+                ok = aws_auth_validate_rate_limiter:check(?IP1),
+                ok = aws_auth_validate_rate_limiter:check(?IP1),
+                ?assertEqual(
+                    {error, rate_limited},
+                    aws_auth_validate_rate_limiter:check(?IP1)
+                ),
+                ok = aws_auth_validate_rate_limiter:reset(),
+                ?assertEqual(ok, aws_auth_validate_rate_limiter:check(?IP1))
+            end}
+        ]}.
+
+rate_limiter_window_expiry_test_() ->
+    {setup,
+        fun() ->
+            {ok, Pid} = aws_auth_validate_rate_limiter:start_link(#{
+                window_ms => 50,
+                max_per_window => 1,
+                sweep_interval_ms => 60_000
+            }),
+            Pid
+        end,
+        fun stop/1,
+        fun(_) ->
+            ok = aws_auth_validate_rate_limiter:check(?IP1),
+            ?assertEqual(
+                {error, rate_limited},
+                aws_auth_validate_rate_limiter:check(?IP1)
+            ),
+            timer:sleep(80),
+            [?_assertEqual(ok, aws_auth_validate_rate_limiter:check(?IP1))]
+        end}.
+
+%%--------------------------------------------------------------------
+%% Semaphore
+%%--------------------------------------------------------------------
+
+semaphore_test_() ->
+    {foreach,
+        fun() ->
+            {ok, Pid} = aws_auth_validate_semaphore:start_link(#{max => 2}),
+            Pid
+        end,
+        fun stop/1,
+        [
+            {"acquire/release sequence", fun() ->
+                {ok, R1} = aws_auth_validate_semaphore:acquire(),
+                {ok, R2} = aws_auth_validate_semaphore:acquire(),
+                ?assertEqual({error, full}, aws_auth_validate_semaphore:acquire()),
+                ok = aws_auth_validate_semaphore:release(R1),
+                {ok, R3} = aws_auth_validate_semaphore:acquire(),
+                ok = aws_auth_validate_semaphore:release(R2),
+                ok = aws_auth_validate_semaphore:release(R3),
+                ?assertEqual(0, aws_auth_validate_semaphore:current())
+            end}
+        ]}.
+
+semaphore_crashed_holder_test_() ->
+    {setup,
+        fun() ->
+            {ok, Pid} = aws_auth_validate_semaphore:start_link(#{max => 1}),
+            Pid
+        end,
+        fun stop/1,
+        fun(_) ->
+            Self = self(),
+            Worker = spawn(fun() ->
+                {ok, _Ref} = aws_auth_validate_semaphore:acquire(),
+                Self ! acquired,
+                receive
+                    die -> exit(boom)
+                end
+            end),
+            receive acquired -> ok after 1_000 -> ?assert(false) end,
+            ?assertEqual({error, full}, aws_auth_validate_semaphore:acquire()),
+            Worker ! die,
+            wait_until_zero(50),
+            [?_assertMatch({ok, _}, aws_auth_validate_semaphore:acquire())]
+        end}.
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+stop(Pid) ->
+    unlink(Pid),
+    exit(Pid, kill),
+    timer:sleep(10),
+    ok.
+
+wait_until_zero(0) ->
+    ?assertEqual(0, aws_auth_validate_semaphore:current());
+wait_until_zero(N) ->
+    case aws_auth_validate_semaphore:current() of
+        0 -> ok;
+        _ -> timer:sleep(10), wait_until_zero(N - 1)
+    end.

--- a/test/aws_auth_validate_tests.erl
+++ b/test/aws_auth_validate_tests.erl
@@ -83,6 +83,47 @@ rate_limiter_window_expiry_test_() ->
             [?_assertEqual(ok, aws_auth_validate_rate_limiter:check(?IP1))]
         end}.
 
+%% The periodic sweep is the rate limiter's memory-safety mechanism: it
+%% evicts counters whose window has fully expired so per-IP state cannot
+%% grow without bound for IPs that are seen once and never again.
+%%
+%% This must be proven by observing the internal counter map shrink, NOT
+%% by re-checking an IP: a fresh check would reset an expired window via
+%% the on-check expiry path in handle_call/3, which would pass whether or
+%% not the sweep ever ran. We register two IPs, then wait (with no further
+%% checks) for their windows to lapse and a sweep to fire, and assert the
+%% counter map is emptied by the sweep alone.
+rate_limiter_sweep_eviction_test_() ->
+    {setup,
+        fun() ->
+            {ok, Pid} = aws_auth_validate_rate_limiter:start_link(#{
+                window_ms => 40,
+                max_per_window => 5,
+                sweep_interval_ms => 30
+            }),
+            Pid
+        end,
+        fun stop/1,
+        fun(Pid) ->
+            ok = aws_auth_validate_rate_limiter:check(?IP1),
+            ok = aws_auth_validate_rate_limiter:check(?IP2),
+            ?assertEqual(2, counter_count(Pid)),
+            %% Wait for both windows to lapse (40ms) and at least one sweep
+            %% (every 30ms) to fire. No checks in between, so only the
+            %% sweep can remove these entries.
+            timer:sleep(120),
+            [?_assertEqual(0, counter_count(Pid))]
+        end}.
+
+%% Number of per-IP counters currently held by the rate limiter. Read from
+%% the gen_server's internal state: the counters field is the sole map in
+%% the #rate_state{} record, so we locate it by type rather than by tuple
+%% position (robust to field reordering).
+counter_count(Pid) ->
+    State = sys:get_state(Pid),
+    [Counters] = [E || E <- tuple_to_list(State), is_map(E)],
+    maps:size(Counters).
+
 %%--------------------------------------------------------------------
 %% Semaphore
 %%--------------------------------------------------------------------
@@ -130,9 +171,107 @@ semaphore_crashed_holder_test_() ->
             [?_assertMatch({ok, _}, aws_auth_validate_semaphore:acquire())]
         end}.
 
+%% Correctness property under real parallelism: with many more contending
+%% processes than slots, the semaphore must never hand out more than `max`
+%% slots at once, and once everyone is done `current` must return to 0.
+%% Each worker acquires, briefly holds (recording the peak concurrency
+%% seen across all holders via a shared counter), then releases.
+semaphore_concurrent_cap_test_() ->
+    {setup,
+        fun() ->
+            {ok, Pid} = aws_auth_validate_semaphore:start_link(#{max => 3}),
+            Pid
+        end,
+        fun stop/1,
+        fun(_) ->
+            Max = 3,
+            Workers = 30,
+            Self = self(),
+            %% Tracks how many slots are held concurrently and the peak.
+            Tracker = spawn_link(fun() -> tracker_loop(0, 0, Self) end),
+            Pids = [
+                spawn(fun() -> contend(Tracker, Self) end)
+             || _ <- lists:seq(1, Workers)
+            ],
+            %% Wait for every worker to finish a full acquire/hold/release.
+            [receive {done, P} -> ok after 5_000 -> ?assert(false) end || P <- Pids],
+            Tracker ! {peak, self()},
+            Peak = receive {peak_value, V} -> V after 1_000 -> -1 end,
+            [
+                ?_assert(Peak =< Max),
+                ?_assert(Peak >= 1),
+                ?_assertEqual(0, settle_to_zero(100))
+            ]
+        end}.
+
+%% One contending worker: try to acquire (retrying on full), hold briefly
+%% while bumping the live-holder count, then release and report back.
+contend(Tracker, Owner) ->
+    case aws_auth_validate_semaphore:acquire() of
+        {ok, Ref} ->
+            Tracker ! inc,
+            timer:sleep(5),
+            Tracker ! dec,
+            ok = aws_auth_validate_semaphore:release(Ref),
+            Owner ! {done, self()};
+        {error, full} ->
+            timer:sleep(2),
+            contend(Tracker, Owner)
+    end.
+
+%% Shared peak-concurrency tracker. Holds the current live count and the
+%% maximum ever observed; replies to {peak, From} with the max.
+tracker_loop(Cur, Peak, Owner) ->
+    receive
+        inc ->
+            Cur1 = Cur + 1,
+            tracker_loop(Cur1, max(Cur1, Peak), Owner);
+        dec ->
+            tracker_loop(Cur - 1, Peak, Owner);
+        {peak, From} ->
+            From ! {peak_value, Peak},
+            tracker_loop(Cur, Peak, Owner)
+    end.
+
+%% Releasing the same ref twice (or after the holder is already gone) must
+%% be idempotent and must never drive `current` below zero or corrupt the
+%% holder set. Implementation treats an unknown ref as a no-op.
+semaphore_idempotent_release_test_() ->
+    {setup,
+        fun() ->
+            {ok, Pid} = aws_auth_validate_semaphore:start_link(#{max => 2}),
+            Pid
+        end,
+        fun stop/1,
+        fun(_) ->
+            {ok, Ref} = aws_auth_validate_semaphore:acquire(),
+            ?assertEqual(1, aws_auth_validate_semaphore:current()),
+            ok = aws_auth_validate_semaphore:release(Ref),
+            ?assertEqual(0, aws_auth_validate_semaphore:current()),
+            %% Double release: must stay at 0, not go negative.
+            ok = aws_auth_validate_semaphore:release(Ref),
+            %% A bogus ref the semaphore never issued is also a no-op.
+            ok = aws_auth_validate_semaphore:release(make_ref()),
+            [
+                ?_assertEqual(0, aws_auth_validate_semaphore:current()),
+                %% Capacity is intact: both slots are still acquirable.
+                ?_assertMatch({ok, _}, aws_auth_validate_semaphore:acquire()),
+                ?_assertMatch({ok, _}, aws_auth_validate_semaphore:acquire())
+            ]
+        end}.
+
 %%--------------------------------------------------------------------
 %% Helpers
 %%--------------------------------------------------------------------
+
+%% Poll until the semaphore's current count reaches 0, returning it.
+settle_to_zero(0) ->
+    aws_auth_validate_semaphore:current();
+settle_to_zero(N) ->
+    case aws_auth_validate_semaphore:current() of
+        0 -> 0;
+        _ -> timer:sleep(10), settle_to_zero(N - 1)
+    end.
 
 stop(Pid) ->
     unlink(Pid),

--- a/test/aws_auth_validate_tests.erl
+++ b/test/aws_auth_validate_tests.erl
@@ -28,8 +28,7 @@ rate_limiter_test_() ->
             }),
             Pid
         end,
-        fun stop/1,
-        [
+        fun stop/1, [
             {"allows up to max then rejects", fun() ->
                 ?assertEqual(ok, aws_auth_validate_rate_limiter:check(?IP1)),
                 ?assertEqual(ok, aws_auth_validate_rate_limiter:check(?IP1)),
@@ -72,8 +71,7 @@ rate_limiter_window_expiry_test_() ->
             }),
             Pid
         end,
-        fun stop/1,
-        fun(_) ->
+        fun stop/1, fun(_) ->
             ok = aws_auth_validate_rate_limiter:check(?IP1),
             ?assertEqual(
                 {error, rate_limited},
@@ -103,8 +101,7 @@ rate_limiter_sweep_eviction_test_() ->
             }),
             Pid
         end,
-        fun stop/1,
-        fun(Pid) ->
+        fun stop/1, fun(Pid) ->
             ok = aws_auth_validate_rate_limiter:check(?IP1),
             ok = aws_auth_validate_rate_limiter:check(?IP2),
             ?assertEqual(2, counter_count(Pid)),
@@ -134,8 +131,7 @@ semaphore_test_() ->
             {ok, Pid} = aws_auth_validate_semaphore:start_link(#{max => 2}),
             Pid
         end,
-        fun stop/1,
-        [
+        fun stop/1, [
             {"acquire/release sequence", fun() ->
                 {ok, R1} = aws_auth_validate_semaphore:acquire(),
                 {ok, R2} = aws_auth_validate_semaphore:acquire(),
@@ -154,8 +150,7 @@ semaphore_crashed_holder_test_() ->
             {ok, Pid} = aws_auth_validate_semaphore:start_link(#{max => 1}),
             Pid
         end,
-        fun stop/1,
-        fun(_) ->
+        fun stop/1, fun(_) ->
             Self = self(),
             Worker = spawn(fun() ->
                 {ok, _Ref} = aws_auth_validate_semaphore:acquire(),
@@ -164,7 +159,10 @@ semaphore_crashed_holder_test_() ->
                     die -> exit(boom)
                 end
             end),
-            receive acquired -> ok after 1_000 -> ?assert(false) end,
+            receive
+                acquired -> ok
+            after 1_000 -> ?assert(false)
+            end,
             ?assertEqual({error, full}, aws_auth_validate_semaphore:acquire()),
             Worker ! die,
             wait_until_zero(50),
@@ -182,8 +180,7 @@ semaphore_concurrent_cap_test_() ->
             {ok, Pid} = aws_auth_validate_semaphore:start_link(#{max => 3}),
             Pid
         end,
-        fun stop/1,
-        fun(_) ->
+        fun stop/1, fun(_) ->
             Max = 3,
             Workers = 30,
             Self = self(),
@@ -194,9 +191,19 @@ semaphore_concurrent_cap_test_() ->
              || _ <- lists:seq(1, Workers)
             ],
             %% Wait for every worker to finish a full acquire/hold/release.
-            [receive {done, P} -> ok after 5_000 -> ?assert(false) end || P <- Pids],
+            [
+                receive
+                    {done, P} -> ok
+                after 5_000 -> ?assert(false)
+                end
+             || P <- Pids
+            ],
             Tracker ! {peak, self()},
-            Peak = receive {peak_value, V} -> V after 1_000 -> -1 end,
+            Peak =
+                receive
+                    {peak_value, V} -> V
+                after 1_000 -> -1
+                end,
             [
                 ?_assert(Peak =< Max),
                 ?_assert(Peak >= 1),
@@ -242,8 +249,7 @@ semaphore_idempotent_release_test_() ->
             {ok, Pid} = aws_auth_validate_semaphore:start_link(#{max => 2}),
             Pid
         end,
-        fun stop/1,
-        fun(_) ->
+        fun stop/1, fun(_) ->
             {ok, Ref} = aws_auth_validate_semaphore:acquire(),
             ?assertEqual(1, aws_auth_validate_semaphore:current()),
             ok = aws_auth_validate_semaphore:release(Ref),
@@ -269,8 +275,11 @@ settle_to_zero(0) ->
     aws_auth_validate_semaphore:current();
 settle_to_zero(N) ->
     case aws_auth_validate_semaphore:current() of
-        0 -> 0;
-        _ -> timer:sleep(10), settle_to_zero(N - 1)
+        0 ->
+            0;
+        _ ->
+            timer:sleep(10),
+            settle_to_zero(N - 1)
     end.
 
 stop(Pid) ->
@@ -283,6 +292,9 @@ wait_until_zero(0) ->
     ?assertEqual(0, aws_auth_validate_semaphore:current());
 wait_until_zero(N) ->
     case aws_auth_validate_semaphore:current() of
-        0 -> ok;
-        _ -> timer:sleep(10), wait_until_zero(N - 1)
+        0 ->
+            ok;
+        _ ->
+            timer:sleep(10),
+            wait_until_zero(N - 1)
     end.

--- a/test/config_schema_SUITE_data/aws.snippets
+++ b/test/config_schema_SUITE_data/aws.snippets
@@ -100,5 +100,45 @@
             ]}
          ]}
         ],
-        [aws_arn_config]}
+        [aws_arn_config]},
+
+    {aws_auth_validation_enabled,
+        "aws.auth_validation.enabled = true",
+        [{aws, [{auth_validation_enabled, true}]}],
+        [aws_auth_validation_enabled]},
+
+    {aws_auth_validation_max_concurrent,
+        "aws.auth_validation.max_concurrent = 8",
+        [{aws, [{auth_validation_max_concurrent, 8}]}],
+        [aws_auth_validation_max_concurrent]},
+
+    {aws_auth_validation_max_body_size,
+        "aws.auth_validation.max_body_size = 32768",
+        [{aws, [{auth_validation_max_body_size, 32768}]}],
+        [aws_auth_validation_max_body_size]},
+
+    {aws_auth_validation_connection_timeout_ms,
+        "aws.auth_validation.connection_timeout_ms = 7000",
+        [{aws, [{auth_validation_connection_timeout_ms, 7000}]}],
+        [aws_auth_validation_connection_timeout_ms]},
+
+    {aws_auth_validation_rate_limit_window_seconds,
+        "aws.auth_validation.rate_limit.window_seconds = 30",
+        [{aws, [{auth_validation_rate_limit_window_seconds, 30}]}],
+        [aws_auth_validation_rate_limit_window_seconds]},
+
+    {aws_auth_validation_rate_limit_max_requests,
+        "aws.auth_validation.rate_limit.max_requests = 25",
+        [{aws, [{auth_validation_rate_limit_max_requests, 25}]}],
+        [aws_auth_validation_rate_limit_max_requests]},
+
+    {aws_auth_validation_required_user_tag,
+        "aws.auth_validation.required_user_tag = monitoring",
+        [{aws, [{auth_validation_required_user_tag, monitoring}]}],
+        [aws_auth_validation_required_user_tag]},
+
+    {aws_auth_validation_enabled_methods,
+        "aws.auth_validation.enabled_methods.ldap = true",
+        [{aws, [{auth_validation_enabled_methods, [{<<"ldap">>, true}]}]}],
+        [aws_auth_validation_enabled_methods]}
 ].


### PR DESCRIPTION
Note: Merging batches in from my existing prototype branch. Auth validation backend/endpoint are not yet merged nor are they included in this PR.

Add per-IP rate limiter and concurrency semaphore for later auth validation
  - aws_auth_validate_rate_limiter: per-source-IP fixed-window limiter (gen_server) with periodic sweep of stale counters
  - aws_auth_validate_semaphore: counting semaphore (gen_server) that bounds concurrent outbound connections; monitors holders so a slot is reclaimed if the caller crashes
  - aws_sup: conditionally starts both workers only when aws.auth_validation.enabled is true; otherwise the supervisor stays empty and the rest of the plugin is undisturbed
  - priv/schema/aws.schema: aws.auth_validation.* configuration knobs (enable toggle, body size, concurrency, timeout, rate limit, user tag) with defaults
  - test/aws_auth_validate_tests.erl: Unit tests for the rate limiter (window enforcement, per-IP isolation, reset, window expiry, and sweep eviction of stale counters) and the semaphore (acquire/release, crashed-holder reclamation, concurrent cap enforcement under real parallelism, and idempotent release), plus config schema snippets for the new settings
