### PR TITLE
Feature: LDAP Validation Endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ define PROJECT_ENV
 []
 endef
 
-DEPS = rabbit_common rabbitmq_aws rabbit
-TEST_DEPS = meck rabbitmq_ct_helpers rabbitmq_ct_client_helpers
-LOCAL_DEPS = crypto inets ssl xmerl public_key
+DEPS = rabbit_common rabbitmq_aws rabbit rabbitmq_management
+TEST_DEPS = meck rabbitmq_ct_helpers rabbitmq_ct_client_helpers rabbitmq_auth_backend_ldap
+LOCAL_DEPS = crypto inets ssl xmerl public_key eldap
 
 PLT_APPS = rabbit
 

--- a/priv/schema/aws.schema
+++ b/priv/schema/aws.schema
@@ -96,6 +96,66 @@
     [{datatype, string}]}.
 
 %%--------------------------------------------------------------------------------------------------
+%% auth validation endpoint (PUT /api/aws/auth/validate/:method)
+%%
+
+%% @doc Master toggle. When unset (the effective default) the validation
+%% subsystem starts no workers and the endpoint returns 404. The default
+%% lives in code (aws_sup reads this with a `false' fallback); it is
+%% intentionally NOT declared here so the key is only emitted into the
+%% generated config when an operator sets it.
+{mapping, "aws.auth_validation.enabled", "aws.auth_validation_enabled",
+    [{datatype, {enum, [true, false]}}]}.
+
+%% @doc Per-method enable flag. Methods are enabled by default; set
+%% explicit false to disable a specific method even when the master
+%% toggle is on. Example:
+%%   aws.auth_validation.enabled_methods.ldap = false
+{mapping, "aws.auth_validation.enabled_methods.$name", "aws.auth_validation_enabled_methods",
+    [{datatype, {enum, [true, false]}}]}.
+
+{translation, "aws.auth_validation_enabled_methods",
+ fun(Conf) ->
+     Settings = cuttlefish_variable:filter_by_prefix("aws.auth_validation.enabled_methods", Conf),
+     [{list_to_binary(lists:last(Key)), Value} || {Key, Value} <- Settings]
+ end}.
+
+%% Note: none of the settings below declare a schema {default, ...}. A
+%% defaulted mapping is emitted into every generated config, which breaks
+%% config_schema_SUITE's exact-match snippets. Effective defaults are
+%% applied by the consuming code when the key is unset, so the key reaches
+%% the app env only when an operator sets it explicitly.
+
+%% @doc Maximum HTTP request body size in bytes (effective default 65536).
+{mapping, "aws.auth_validation.max_body_size", "aws.auth_validation_max_body_size",
+    [{datatype, integer}]}.
+
+%% @doc Maximum concurrent outbound auth-validation connections (effective
+%% default 5; applied by aws_sup).
+{mapping, "aws.auth_validation.max_concurrent", "aws.auth_validation_max_concurrent",
+    [{datatype, integer}]}.
+
+%% @doc Per-connection timeout in milliseconds for outbound calls
+%% (effective default 5000).
+{mapping, "aws.auth_validation.connection_timeout_ms", "aws.auth_validation_connection_timeout_ms",
+    [{datatype, integer}]}.
+
+%% @doc Rate limiter window in seconds, per source IP (effective default
+%% 60; applied by aws_sup).
+{mapping, "aws.auth_validation.rate_limit.window_seconds", "aws.auth_validation_rate_limit_window_seconds",
+    [{datatype, integer}]}.
+
+%% @doc Rate limiter max successful requests per window per source IP
+%% (effective default 10; applied by aws_sup).
+{mapping, "aws.auth_validation.rate_limit.max_requests", "aws.auth_validation_rate_limit_max_requests",
+    [{datatype, integer}]}.
+
+%% @doc Required management user tag to access the endpoint (effective
+%% default administrator).
+{mapping, "aws.auth_validation.required_user_tag", "aws.auth_validation_required_user_tag",
+    [{datatype, atom}]}.
+
+%%--------------------------------------------------------------------------------------------------
 %% misc
 %%
 %% @doc Custom headers for AWS STS calls. Header name should be the exact case-sensitive headername

--- a/src/aws_auth_validate_arn_lock.erl
+++ b/src/aws_auth_validate_arn_lock.erl
@@ -1,0 +1,100 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% Serializes ARN resolution for the auth-validation endpoint.
+%%
+%% ARN resolution goes through the shared `rabbitmq_aws' singleton, and
+%% `aws_sms'/`aws_acm_pca' call `rabbitmq_aws:set_region/1' (a global write)
+%% derived from the request's ARN before issuing the HTTP call. The
+%% concurrency semaphore admits up to `max_concurrent' validations at once,
+%% so without serialization two concurrent requests for ARNs in different
+%% regions can interleave: request A sets region R1, request B then sets R2,
+%% and A signs/sends to the wrong region. This lock makes the
+%% set_region-then-resolve section mutually exclusive across validation
+%% requests so the region cannot be clobbered mid-resolution.
+%%
+%% Scope note: the broker's own boot-time ARN resolution (aws_arn_config) is
+%% a rabbit_boot_step that runs before networking, hence before the endpoint
+%% is reachable, so it never races validation traffic. Only
+%% validation-vs-validation needs guarding, which is what this lock does.
+%%
+%% The closure runs INSIDE this gen_server, so resolutions are inherently
+%% serialized. A crashing closure is caught here (the lock server survives)
+%% and its exception is re-raised in the caller, preserving the existing
+%% try/catch behaviour in aws_auth_validate_ldap:validate/1.
+-module(aws_auth_validate_arn_lock).
+
+-behaviour(gen_server).
+
+-export([start_link/0, start_link/1, with_lock/1]).
+
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
+
+%% Upper bound on a single serialized resolution. Must exceed the AWS
+%% client's own retry/timeout budget so a slow-but-progressing resolve is
+%% not aborted, while still bounding how long one stuck resolve can block
+%% the queue. rabbitmq_aws does linear-backoff retries with finite per-call
+%% timeouts, so 60s is comfortably above a normal worst case.
+-define(DEFAULT_CALL_TIMEOUT_MS, 60_000).
+
+-record(state, {}).
+
+-spec start_link() -> {ok, pid()} | {error, term()}.
+start_link() ->
+    start_link(#{}).
+
+-spec start_link(map()) -> {ok, pid()} | {error, term()}.
+start_link(Config) when is_map(Config) ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, Config, []).
+
+%% Run Fun under the lock, serialized against all other with_lock/1 callers.
+%% Returns Fun's value, or re-raises in the caller whatever exception Fun
+%% raised (so callers see the same error class/reason as an unlocked call).
+-spec with_lock(fun(() -> Result)) -> Result.
+with_lock(Fun) when is_function(Fun, 0) ->
+    case gen_server:call(?MODULE, {run, Fun}, ?DEFAULT_CALL_TIMEOUT_MS) of
+        {ok, Result} -> Result;
+        {raised, Class, Reason, Stacktrace} -> erlang:raise(Class, Reason, Stacktrace)
+    end.
+
+%%--------------------------------------------------------------------
+%% gen_server callbacks
+%%--------------------------------------------------------------------
+
+init(_Config) ->
+    {ok, #state{}}.
+
+handle_call({run, Fun}, _From, State) ->
+    %% Run the closure here so it is serialized with every other request.
+    %% Catch any exception so a failed resolution never crashes the lock
+    %% server; re-raise it in the caller to preserve unlocked semantics.
+    Reply =
+        try Fun() of
+            Result -> {ok, Result}
+        catch
+            Class:Reason:Stacktrace -> {raised, Class, Reason, Stacktrace}
+        end,
+    {reply, Reply, State};
+handle_call(_Request, _From, State) ->
+    {reply, {error, unknown_request}, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.

--- a/src/aws_auth_validate_backend.erl
+++ b/src/aws_auth_validate_backend.erl
@@ -1,0 +1,25 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% Behaviour every auth validation backend must implement. The registry
+%% dispatches a request to a module that exports these three callbacks.
+-module(aws_auth_validate_backend).
+
+-export_type([error_category/0, result/0]).
+
+-type error_category() ::
+    input_invalid
+    | connection_failed
+    | tls_failed
+    | auth_failed
+    | config_conflict
+    | query_invalid
+    | authz_unverified.
+
+-type result() :: ok | {error, error_category(), Reason :: binary()}.
+
+-callback method_name() -> binary().
+-callback validate(Body :: map()) -> result().
+-callback allowed_fields() -> [binary()].

--- a/src/aws_auth_validate_ldap.erl
+++ b/src/aws_auth_validate_ldap.erl
@@ -1,0 +1,466 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% LDAP simple-bind validation backend.
+%%
+%% Opens an ephemeral connection per request, optionally performs
+%% start_tls, attempts a simple bind, then unconditionally closes the
+%% handle. All outcomes collapse to a fixed set of error categories so
+%% the HTTP response cannot be used to extract LDAP-server or
+%% network-topology details. Credentials never appear in returned
+%% reasons.
+%%
+%% Beyond authentication, the backend optionally validates two further
+%% layers of an LDAP configuration, reusing the same bound connection:
+%%
+%%   * DN lookup -- when `dn_lookup_base' is supplied, confirms the base
+%%     DN exists and is readable by the bound user. `dn_lookup_attribute'
+%%     is checked for syntactic validity only.
+%%
+%%   * Authorization queries -- `queries.{tags,vhost_access,
+%%     resource_access,topic_access}' are parsed with the same grammar
+%%     the broker uses (aws_auth_validate_ldap_query), and any group/DN
+%%     referenced with a fully literal DN (no ${...} runtime placeholder)
+%%     is checked for existence and readability. Query terms that need a
+%%     runtime principal (e.g. ${username}) are parsed but not evaluated,
+%%     because the endpoint has no live login to evaluate them against and
+%%     must not leak directory contents.
+%%
+%% Parse failures map to `query_invalid' (400); a referenced object that
+%% cannot be verified maps to `authz_unverified' (422). Both carry fixed
+%% constant messages -- no DN, group name, or raw LDAP detail is echoed.
+-module(aws_auth_validate_ldap).
+
+-behaviour(aws_auth_validate_backend).
+
+-export([method_name/0, validate/1, allowed_fields/0]).
+
+-include_lib("eldap/include/eldap.hrl").
+
+-define(DEFAULT_TIMEOUT_MS, 5_000).
+
+%% Accepted query names within the `queries' object. Mirrors the broker's
+%% auth_ldap.queries.* config keys.
+-define(QUERY_NAMES, [
+    <<"tags">>,
+    <<"vhost_access">>,
+    <<"resource_access">>,
+    <<"topic_access">>
+]).
+
+-define(REASON_BAD_SERVERS, <<"servers must be a non-empty list of non-empty strings">>).
+-define(REASON_BAD_PORT, <<"port must be an integer in 1..65535">>).
+-define(REASON_BAD_USER_DN, <<"user_dn must be a non-empty string">>).
+-define(REASON_BAD_PASSWORD_ARN, <<"password_arn must be a non-empty string">>).
+-define(REASON_BAD_SSL_FLAG, <<"use_ssl must be a boolean">>).
+-define(REASON_BAD_STARTTLS_FLAG, <<"use_starttls must be a boolean">>).
+-define(REASON_BAD_SSL_OPTIONS, <<"ssl_options must be an object">>).
+-define(REASON_TLS_BOTH, <<"use_ssl and use_starttls are mutually exclusive">>).
+-define(REASON_CONNECTION, <<"could not connect to LDAP server">>).
+-define(REASON_TLS_HANDSHAKE, <<"TLS handshake failed">>).
+-define(REASON_AUTH, <<"LDAP simple bind rejected the supplied credentials">>).
+-define(REASON_ARN_RESOLVE, <<"failed to resolve ARN">>).
+-define(REASON_BAD_DN_LOOKUP_BASE, <<"dn_lookup_base must be a non-empty string">>).
+-define(REASON_BAD_DN_LOOKUP_ATTR, <<"dn_lookup_attribute must be a non-empty string">>).
+-define(REASON_BAD_QUERIES, <<"queries must be an object of query strings">>).
+-define(REASON_BAD_QUERY_VALUE, <<"each query must be a non-empty string">>).
+-define(REASON_QUERY_PARSE, <<"one or more authorization queries are not valid">>).
+-define(REASON_DN_LOOKUP_BASE_UNVERIFIED,
+    <<"dn_lookup_base does not exist or is not readable by the bind user">>
+).
+-define(REASON_AUTHZ_UNVERIFIED,
+    <<"a DN referenced by an authorization query could not be verified">>
+).
+
+method_name() ->
+    <<"ldap">>.
+
+allowed_fields() ->
+    [
+        <<"servers">>,
+        <<"port">>,
+        <<"user_dn">>,
+        <<"password_arn">>,
+        <<"use_ssl">>,
+        <<"use_starttls">>,
+        <<"ssl_options">>,
+        <<"dn_lookup_base">>,
+        <<"dn_lookup_attribute">>,
+        <<"queries">>
+    ].
+
+-spec validate(map()) -> aws_auth_validate_backend:result().
+validate(Body) when is_map(Body) ->
+    %% Order matters for security: every purely-local check (type/shape
+    %% validation, query grammar, config conflicts) runs before we resolve
+    %% the password ARN. Malformed input is rejected without fetching the
+    %% customer's secret, and the secret is resolved only once we are about
+    %% to actually connect.
+    case parse_input(Body) of
+        {error, _, _} = Err ->
+            Err;
+        {ok, Params} ->
+            case check_config_conflicts(Params) of
+                {error, _, _} = Err ->
+                    Err;
+                ok ->
+                    case resolve_password(Body, Params) of
+                        {error, _, _} = Err -> Err;
+                        {ok, Params1} -> do_ldap_validate(Params1)
+                    end
+            end
+    end.
+
+%%--------------------------------------------------------------------
+%% Input parsing
+%%--------------------------------------------------------------------
+
+%% Pure, network-free validation steps. Password ARN resolution is handled
+%% separately (resolve_password/2) after these all pass.
+parse_input(Body) ->
+    Steps = [
+        fun parse_servers/2,
+        fun parse_port/2,
+        fun parse_user_dn/2,
+        fun parse_use_ssl/2,
+        fun parse_use_starttls/2,
+        fun parse_ssl_options/2,
+        fun parse_dn_lookup_base/2,
+        fun parse_dn_lookup_attribute/2,
+        fun parse_queries/2
+    ],
+    parse_input(Steps, Body, #{timeout => connection_timeout_ms()}).
+
+parse_input([], _Body, Acc) ->
+    {ok, Acc};
+parse_input([Step | Rest], Body, Acc0) ->
+    case Step(Body, Acc0) of
+        {ok, Acc1} -> parse_input(Rest, Body, Acc1);
+        {error, _, _} = Err -> Err
+    end.
+
+parse_servers(Body, Acc) ->
+    case maps:get(<<"servers">>, Body, undefined) of
+        Servers when is_list(Servers), Servers =/= [] ->
+            case lists:all(fun is_nonempty_binary/1, Servers) of
+                true -> {ok, Acc#{servers => [binary_to_list(S) || S <- Servers]}};
+                false -> {error, input_invalid, ?REASON_BAD_SERVERS}
+            end;
+        _ ->
+            {error, input_invalid, ?REASON_BAD_SERVERS}
+    end.
+
+parse_port(Body, Acc) ->
+    case maps:get(<<"port">>, Body, undefined) of
+        Port when is_integer(Port), Port >= 1, Port =< 65535 ->
+            {ok, Acc#{port => Port}};
+        _ ->
+            {error, input_invalid, ?REASON_BAD_PORT}
+    end.
+
+parse_user_dn(Body, Acc) ->
+    case maps:get(<<"user_dn">>, Body, undefined) of
+        UserDn when is_binary(UserDn), byte_size(UserDn) > 0 ->
+            {ok, Acc#{user_dn => binary_to_list(UserDn)}};
+        _ ->
+            {error, input_invalid, ?REASON_BAD_USER_DN}
+    end.
+
+%% Resolve the bind password from its ARN. Runs only after all pure input
+%% validation has passed, so a malformed request never triggers a secret
+%% fetch. The resolved password is added to the params map and never logged
+%% or returned. Validated for shape here (rather than in parse_input) so the
+%% network call stays out of the pure pipeline.
+resolve_password(Body, Params) ->
+    case maps:get(<<"password_arn">>, Body, undefined) of
+        Arn when is_binary(Arn), byte_size(Arn) > 0 ->
+            case resolve_arn(Arn) of
+                {ok, Password} -> {ok, Params#{password => Password}};
+                {error, _} -> {error, input_invalid, ?REASON_ARN_RESOLVE}
+            end;
+        _ ->
+            {error, input_invalid, ?REASON_BAD_PASSWORD_ARN}
+    end.
+
+parse_use_ssl(Body, Acc) ->
+    parse_boolean(<<"use_ssl">>, Body, Acc, use_ssl, ?REASON_BAD_SSL_FLAG).
+
+parse_use_starttls(Body, Acc) ->
+    parse_boolean(<<"use_starttls">>, Body, Acc, use_starttls, ?REASON_BAD_STARTTLS_FLAG).
+
+parse_boolean(Key, Body, Acc, AccKey, Reason) ->
+    case maps:get(Key, Body, undefined) of
+        undefined -> {ok, Acc#{AccKey => false}};
+        Bool when is_boolean(Bool) -> {ok, Acc#{AccKey => Bool}};
+        _ -> {error, input_invalid, Reason}
+    end.
+
+parse_ssl_options(Body, Acc) ->
+    case maps:get(<<"ssl_options">>, Body, undefined) of
+        undefined ->
+            {ok, Acc#{ssl_options => #{}}};
+        Map when is_map(Map) ->
+            {ok, Acc#{ssl_options => Map}};
+        _ ->
+            {error, input_invalid, ?REASON_BAD_SSL_OPTIONS}
+    end.
+
+%% DN lookup fields are optional. When `dn_lookup_base' is absent we store
+%% `none' and skip the readability check entirely. `dn_lookup_attribute' is
+%% likewise optional and validated for shape only.
+parse_dn_lookup_base(Body, Acc) ->
+    case maps:get(<<"dn_lookup_base">>, Body, undefined) of
+        undefined ->
+            {ok, Acc#{dn_lookup_base => none}};
+        Base when is_binary(Base), byte_size(Base) > 0 ->
+            {ok, Acc#{dn_lookup_base => binary_to_list(Base)}};
+        _ ->
+            {error, input_invalid, ?REASON_BAD_DN_LOOKUP_BASE}
+    end.
+
+parse_dn_lookup_attribute(Body, Acc) ->
+    case maps:get(<<"dn_lookup_attribute">>, Body, undefined) of
+        undefined ->
+            {ok, Acc#{dn_lookup_attribute => none}};
+        Attr when is_binary(Attr), byte_size(Attr) > 0 ->
+            {ok, Acc#{dn_lookup_attribute => binary_to_list(Attr)}};
+        _ ->
+            {error, input_invalid, ?REASON_BAD_DN_LOOKUP_ATTR}
+    end.
+
+%% `queries' is an optional object mapping query names (tags, vhost_access,
+%% resource_access, topic_access) to query-DSL strings. Each value is parsed
+%% with the broker-compatible grammar; unknown query names are ignored (the
+%% registry-level field filter governs the top-level surface, not nested
+%% keys). A parse failure short-circuits to query_invalid.
+parse_queries(Body, Acc) ->
+    case maps:get(<<"queries">>, Body, undefined) of
+        undefined ->
+            {ok, Acc#{queries => []}};
+        Map when is_map(Map) ->
+            parse_query_map(maps:to_list(Map), Acc, []);
+        _ ->
+            {error, input_invalid, ?REASON_BAD_QUERIES}
+    end.
+
+parse_query_map([], Acc, Parsed) ->
+    {ok, Acc#{queries => lists:reverse(Parsed)}};
+parse_query_map([{Name, Value} | Rest], Acc, Parsed) ->
+    case lists:member(Name, ?QUERY_NAMES) of
+        false ->
+            %% Ignore query names we don't recognise rather than failing the
+            %% whole request; keeps the accepted surface aligned with the
+            %% broker's four query types without leaking which were ignored.
+            parse_query_map(Rest, Acc, Parsed);
+        true ->
+            case Value of
+                V when is_binary(V), byte_size(V) > 0 ->
+                    case aws_auth_validate_ldap_query:parse(V) of
+                        {ok, Query} ->
+                            parse_query_map(Rest, Acc, [{Name, Query} | Parsed]);
+                        {error, _} ->
+                            {error, query_invalid, ?REASON_QUERY_PARSE}
+                    end;
+                _ ->
+                    {error, input_invalid, ?REASON_BAD_QUERY_VALUE}
+            end
+    end.
+
+is_nonempty_binary(B) -> is_binary(B) andalso byte_size(B) > 0.
+
+%%--------------------------------------------------------------------
+%% Config conflict
+%%--------------------------------------------------------------------
+
+check_config_conflicts(#{use_ssl := true, use_starttls := true}) ->
+    {error, config_conflict, ?REASON_TLS_BOTH};
+check_config_conflicts(_) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% LDAP execution
+%%--------------------------------------------------------------------
+
+do_ldap_validate(
+    #{
+        servers := Servers,
+        port := Port,
+        user_dn := UserDn,
+        password := Password,
+        use_ssl := UseSsl,
+        use_starttls := UseStartTls,
+        ssl_options := SslOpts,
+        timeout := Timeout
+    } = Params
+) ->
+    OpenOpts = [{port, Port}, {timeout, Timeout}] ++ ssl_open_opts(UseSsl, SslOpts),
+    case eldap:open(Servers, OpenOpts) of
+        {error, _Reason} ->
+            {error, connection_failed, ?REASON_CONNECTION};
+        {ok, Handle} ->
+            try
+                case maybe_start_tls(Handle, UseStartTls, SslOpts, Timeout) of
+                    {error, _Reason} ->
+                        {error, tls_failed, ?REASON_TLS_HANDSHAKE};
+                    ok ->
+                        case eldap:simple_bind(Handle, UserDn, Password) of
+                            ok -> post_bind_checks(Handle, Params);
+                            {error, _Reason} -> {error, auth_failed, ?REASON_AUTH}
+                        end
+                end
+            after
+                catch eldap:close(Handle)
+            end
+    end.
+
+%% After a successful bind, run the optional DN-lookup and authorization
+%% checks in sequence on the same bound handle. The first failure wins; if
+%% none are configured (or all pass) the request succeeds with `ok'.
+post_bind_checks(Handle, Params) ->
+    case check_dn_lookup(Handle, Params) of
+        ok -> check_authz_queries(Handle, Params);
+        {error, _, _} = Err -> Err
+    end.
+
+%%--------------------------------------------------------------------
+%% DN lookup validation
+%%--------------------------------------------------------------------
+
+%% When a dn_lookup_base is supplied, confirm it exists and is readable by
+%% the bound user. We never run an actual username->DN search here (there is
+%% no principal to look up and doing so could leak directory contents);
+%% confirming the base is reachable is the side-effect-free signal a
+%% customer needs to know their dn_lookup_base is correct.
+check_dn_lookup(_Handle, #{dn_lookup_base := none}) ->
+    ok;
+check_dn_lookup(Handle, #{dn_lookup_base := Base}) ->
+    case object_exists(Handle, Base) of
+        true -> ok;
+        _ -> {error, authz_unverified, ?REASON_DN_LOOKUP_BASE_UNVERIFIED}
+    end.
+
+%%--------------------------------------------------------------------
+%% Authorization query validation
+%%--------------------------------------------------------------------
+
+%% For each parsed query, extract the fully-literal DNs (those with no
+%% ${...} runtime placeholder) and confirm each exists and is readable by
+%% the bound user. Queries that reference only runtime-filled DNs contribute
+%% no checks -- they were already validated for grammar at parse time.
+check_authz_queries(Handle, #{queries := Queries}) ->
+    LiteralDns = lists:usort(
+        lists:flatmap(
+            fun({_Name, Query}) -> aws_auth_validate_ldap_query:literal_dns(Query) end,
+            Queries
+        )
+    ),
+    check_dns(Handle, LiteralDns).
+
+check_dns(_Handle, []) ->
+    ok;
+check_dns(Handle, [DN | Rest]) ->
+    case object_exists(Handle, DN) of
+        true -> check_dns(Handle, Rest);
+        _ -> {error, authz_unverified, ?REASON_AUTHZ_UNVERIFIED}
+    end.
+
+%% Base-scoped existence probe. Mirrors rabbit_auth_backend_ldap:object_exists/3
+%% (base object, present(objectClass) filter) so a DN this returns true for is
+%% one the broker's queries could also resolve. Any error -- not found,
+%% referral, permission denied -- collapses to `false'; the caller maps that
+%% to the single fixed authz_unverified category, leaking no LDAP detail.
+object_exists(Handle, DN) ->
+    case
+        eldap:search(Handle, [
+            {base, DN},
+            {filter, eldap:present("objectClass")},
+            {attributes, ["objectClass"]},
+            {scope, eldap:baseObject()}
+        ])
+    of
+        {ok, #eldap_search_result{entries = Entries}} ->
+            length(Entries) > 0;
+        _ ->
+            false
+    end.
+
+ssl_open_opts(true, SslOpts) ->
+    [{ssl, true}, {sslopts, build_ssl_opts(SslOpts)}];
+ssl_open_opts(false, _SslOpts) ->
+    [{ssl, false}].
+
+maybe_start_tls(_Handle, false, _SslOpts, _Timeout) ->
+    ok;
+maybe_start_tls(Handle, true, SslOpts, Timeout) ->
+    eldap:start_tls(Handle, build_ssl_opts(SslOpts), Timeout).
+
+%% Translate the JSON ssl_options map into an Erlang ssl options
+%% proplist suitable for eldap. Unknown keys are ignored to keep the
+%% allowed surface narrow.
+build_ssl_opts(Map) when is_map(Map) ->
+    Pairs = [
+        {cacerts, <<"cacertfile_arn">>, fun resolve_and_decode_pem_cacerts/1},
+        {verify, <<"verify">>, fun to_atom/1},
+        {depth, <<"depth">>, fun to_integer/1},
+        {versions, <<"versions">>, fun to_versions/1},
+        {server_name_indication, <<"server_name_indication">>, fun to_list/1}
+    ],
+    lists:foldl(
+        fun({SslKey, JsonKey, Fun}, Acc) ->
+            case maps:get(JsonKey, Map, undefined) of
+                undefined ->
+                    Acc;
+                Value ->
+                    case (catch Fun(Value)) of
+                        {'EXIT', _} -> Acc;
+                        skip -> Acc;
+                        Translated -> [{SslKey, Translated} | Acc]
+                    end
+            end
+        end,
+        [],
+        Pairs
+    ).
+
+to_list(B) when is_binary(B) -> binary_to_list(B);
+to_list(L) when is_list(L) -> L.
+
+to_atom(B) when is_binary(B) -> binary_to_existing_atom(B, utf8);
+to_atom(A) when is_atom(A) -> A.
+
+to_integer(I) when is_integer(I) -> I.
+
+to_versions(L) when is_list(L) ->
+    [to_atom(V) || V <- L].
+
+decode_pem_cacerts(B) when is_binary(B) ->
+    case public_key:pem_decode(B) of
+        [] -> skip;
+        Entries -> [public_key:pem_entry_decode(E) || E <- Entries]
+    end.
+
+resolve_and_decode_pem_cacerts(Arn) when is_binary(Arn) ->
+    case resolve_arn(Arn) of
+        {ok, PemData} -> decode_pem_cacerts(PemData);
+        {error, _} -> skip
+    end.
+
+%%--------------------------------------------------------------------
+
+%% ARN resolution mutates the shared rabbitmq_aws region/credential
+%% singleton (aws_sms/aws_acm_pca call rabbitmq_aws:set_region/1), so
+%% serialize it across concurrent validation requests to prevent region
+%% clobbering between a set_region and its HTTP call. See
+%% aws_auth_validate_arn_lock.
+resolve_arn(Arn) when is_binary(Arn) ->
+    aws_auth_validate_arn_lock:with_lock(fun() ->
+        aws_arn_util:resolve_arn(binary_to_list(Arn))
+    end).
+
+connection_timeout_ms() ->
+    case application:get_env(aws, auth_validation_connection_timeout_ms) of
+        {ok, Ms} when is_integer(Ms), Ms > 0 -> Ms;
+        _ -> ?DEFAULT_TIMEOUT_MS
+    end.

--- a/src/aws_auth_validate_ldap_query.erl
+++ b/src/aws_auth_validate_ldap_query.erl
@@ -1,0 +1,187 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% Self-contained parser for the rabbitmq_auth_backend_ldap authorization
+%% query DSL.
+%%
+%% This intentionally mirrors the grammar accepted by
+%% rabbit_auth_backend_ldap_util:parse_query/1 (erl_scan + erl_parse:parse_term
+%% over the same accepted-term allowlist) so that a query the broker would
+%% accept is accepted here and vice-versa (design requirement R12: the
+%% validation endpoint must not diverge from rabbit_auth_backend_ldap). A
+%% parity test (aws_auth_validate_query_parity_tests) guards against drift.
+%%
+%% Two deliberate differences from the upstream helper:
+%%   1. It returns {ok, Query} | {error, Reason} instead of throwing via
+%%      cuttlefish:invalid/2 -- this runs in the request path, not at
+%%      config-load time.
+%%   2. It adds literal_dns/1, which walks a parsed query and returns the
+%%      DNs that are fully literal (contain no ${...} runtime placeholder).
+%%      Those are the only DNs the endpoint can check for existence without
+%%      a runtime principal, and they drive the static reachability check.
+-module(aws_auth_validate_ldap_query).
+
+-export([parse/1, literal_dns/1, is_literal/1]).
+
+-export_type([query/0]).
+
+-type query() :: tuple() | list().
+
+%%--------------------------------------------------------------------
+%% Parsing
+%%--------------------------------------------------------------------
+
+%% Parse one query expression. Accepts the same top-level term shapes as the
+%% broker's parse_query/1. Returns the parsed Erlang term on success.
+-spec parse(binary() | string()) -> {ok, query()} | {error, binary()}.
+parse(Query) when is_binary(Query) ->
+    parse(unicode:characters_to_list(Query, utf8));
+parse(Query0) when is_list(Query0) ->
+    case scan(fixup(Query0)) of
+        {ok, Tokens} ->
+            case erl_parse:parse_term(Tokens) of
+                {ok, Term} -> accept(Term);
+                {error, _} -> {error, <<"query is not a valid expression">>}
+            end;
+        {error, _} ->
+            {error, <<"query could not be tokenized">>}
+    end;
+parse(_) ->
+    {error, <<"query must be a string">>}.
+
+%% erl_parse:parse_term/1 needs a trailing dot.
+fixup(Query0) ->
+    Query1 = string:trim(Query0, both),
+    case Query1 of
+        "" ->
+            ".";
+        _ ->
+            case lists:last(Query1) of
+                $. -> Query1;
+                _ -> Query1 ++ "."
+            end
+    end.
+
+scan(Str) ->
+    case erl_scan:string(Str) of
+        {ok, Tokens, _EndLine} -> {ok, Tokens};
+        {error, _Info, _Loc} -> {error, scan_failed}
+    end.
+
+%% Top-level allowlist -- mirrors rabbit_auth_backend_ldap_util:parse_query/1.
+%% Anything not matched here is rejected rather than passed to the backend.
+accept({constant, B} = T) when is_boolean(B) -> {ok, T};
+accept({in_group, _} = T) -> {ok, T};
+accept({in_group_nested, _, _} = T) -> {ok, T};
+accept({for, Q} = T) when is_list(Q) -> {ok, T};
+accept({'not', _} = T) -> {ok, T};
+accept({'and', Q} = T) when is_list(Q) -> {ok, T};
+accept({'or', Q} = T) when is_list(Q) -> {ok, T};
+accept({equals, _, _} = T) -> {ok, T};
+accept({match, _, _} = T) -> {ok, T};
+%% tag_queries are expressed as a list of {Tag, SubQuery} pairs.
+accept(T) when is_list(T) -> {ok, T};
+accept(_) -> {error, <<"unrecognised query expression">>}.
+
+%%--------------------------------------------------------------------
+%% Literal DN extraction
+%%--------------------------------------------------------------------
+
+%% Walk a parsed query and collect the DNs that can be checked for existence
+%% without a runtime principal: DN-bearing terms (exists, in_group,
+%% in_group_nested, attribute) whose DN pattern contains no ${...}
+%% placeholder. Returns a deduplicated list of DN strings.
+-spec literal_dns(query()) -> [string()].
+literal_dns(Query) ->
+    lists:usort(collect(Query, [])).
+
+collect({constant, _}, Acc) ->
+    Acc;
+collect({exists, DN}, Acc) ->
+    maybe_dn(DN, Acc);
+collect({in_group, DN}, Acc) ->
+    maybe_dn(DN, Acc);
+collect({in_group, DN, _Desc}, Acc) ->
+    maybe_dn(DN, Acc);
+collect({in_group_nested, DN}, Acc) ->
+    maybe_dn(DN, Acc);
+collect({in_group_nested, DN, _Desc}, Acc) ->
+    maybe_dn(DN, Acc);
+collect({in_group_nested, DN, _Desc, _Scope}, Acc) ->
+    maybe_dn(DN, Acc);
+collect({attribute, DN, _AttrName}, Acc) ->
+    maybe_dn(DN, Acc);
+collect({'not', SubQuery}, Acc) ->
+    collect(SubQuery, Acc);
+collect({'and', Queries}, Acc) when is_list(Queries) ->
+    lists:foldl(fun collect/2, Acc, Queries);
+collect({'or', Queries}, Acc) when is_list(Queries) ->
+    lists:foldl(fun collect/2, Acc, Queries);
+collect({for, Clauses}, Acc) when is_list(Clauses) ->
+    lists:foldl(
+        fun
+            ({_Type, _Value, SubQuery}, A) -> collect(SubQuery, A);
+            (_Other, A) -> A
+        end,
+        Acc,
+        Clauses
+    );
+collect({equals, A1, A2}, Acc) ->
+    collect(A2, collect(A1, Acc));
+collect({match, A1, A2}, Acc) ->
+    collect(A2, collect(A1, Acc));
+%% tag_queries: a list of {Tag, SubQuery} pairs.
+collect(List, Acc) when is_list(List) ->
+    case is_dn_string(List) of
+        true ->
+            %% A bare DN string used directly (rare, but harmless to check).
+            maybe_dn(List, Acc);
+        false ->
+            lists:foldl(
+                fun
+                    ({_Tag, SubQuery}, A) -> collect(SubQuery, A);
+                    (_Other, A) -> A
+                end,
+                Acc,
+                List
+            )
+    end;
+collect(_Other, Acc) ->
+    Acc.
+
+maybe_dn(DN, Acc) ->
+    case is_literal(DN) of
+        true -> [dn_to_list(DN) | Acc];
+        false -> Acc
+    end.
+
+%% A DN pattern is "literal" when it is a concrete string with no ${...}
+%% runtime placeholder. {string, Pattern} wrappers are unwrapped first.
+-spec is_literal(term()) -> boolean().
+is_literal({string, Pattern}) ->
+    is_literal(Pattern);
+is_literal(DN) when is_binary(DN) ->
+    is_dn_string(binary_to_list(DN)) andalso not has_placeholder(binary_to_list(DN));
+is_literal(DN) when is_list(DN) ->
+    is_dn_string(DN) andalso not has_placeholder(DN);
+is_literal(_) ->
+    false.
+
+dn_to_list({string, Pattern}) -> dn_to_list(Pattern);
+dn_to_list(DN) when is_binary(DN) -> binary_to_list(DN);
+dn_to_list(DN) when is_list(DN) -> DN.
+
+%% True when the string contains a ${...} fill placeholder consumed at
+%% runtime by the broker's fill/2 (e.g. ${username}, ${vhost}).
+has_placeholder(Str) ->
+    string:find(Str, "${") =/= nomatch.
+
+%% A printable flat string (proper list of integers in a sane char range).
+is_dn_string([]) ->
+    false;
+is_dn_string(L) when is_list(L) ->
+    lists:all(fun(C) -> is_integer(C) andalso C >= 0 andalso C =< 16#10FFFF end, L);
+is_dn_string(_) ->
+    false.

--- a/src/aws_auth_validate_mgmt.erl
+++ b/src/aws_auth_validate_mgmt.erl
@@ -1,0 +1,251 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% Cowboy REST handler that exposes
+%%   PUT /api/aws/auth/validate/:method
+%% Implements the rabbit_mgmt_extension behaviour so the route is
+%% mounted automatically by the management plugin. Each request flows
+%% through a fixed pipeline: feature toggle -> management auth -> user
+%% tag gate -> per-IP rate limit -> body size cap -> JSON decode ->
+%% concurrency semaphore -> registry dispatch -> audit log -> response.
+-module(aws_auth_validate_mgmt).
+
+-behaviour(rabbit_mgmt_extension).
+
+-export([dispatcher/0, web_ui/0]).
+
+-export([
+    init/2,
+    content_types_accepted/2,
+    allowed_methods/2,
+    resource_exists/2,
+    is_authorized/2,
+    accept_content/2
+]).
+
+-include_lib("rabbitmq_web_dispatch/include/rabbitmq_web_dispatch_records.hrl").
+-include_lib("rabbit_common/include/rabbit.hrl").
+-include("aws.hrl").
+
+-define(DEFAULT_MAX_BODY_SIZE, 65_536).
+-define(DEFAULT_REQUIRED_USER_TAG, administrator).
+
+dispatcher() -> [{"/aws/auth/validate/:method", ?MODULE, []}].
+
+web_ui() -> [].
+
+%%--------------------------------------------------------------------
+%% cowboy_rest callbacks
+%%--------------------------------------------------------------------
+
+init(Req, _Opts) ->
+    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+
+content_types_accepted(ReqData, Context) ->
+    {[{'*', accept_content}], ReqData, Context}.
+
+allowed_methods(ReqData, Context) ->
+    {[<<"PUT">>, <<"OPTIONS">>], ReqData, Context}.
+
+resource_exists(ReqData, Context) ->
+    {feature_enabled(), ReqData, Context}.
+
+is_authorized(ReqData, Context) ->
+    case required_user_tag() of
+        administrator ->
+            rabbit_mgmt_util:is_authorized_admin(ReqData, Context);
+        Tag ->
+            case rabbit_mgmt_util:is_authorized(ReqData, Context) of
+                {true, ReqData1, Context1} ->
+                    authorize_tag(Tag, ReqData1, Context1);
+                Other ->
+                    Other
+            end
+    end.
+
+%%--------------------------------------------------------------------
+%% Request pipeline
+%%--------------------------------------------------------------------
+
+accept_content(Req0, Context) ->
+    %% Enforce the feature toggle here, before touching any worker. For a PUT,
+    %% cowboy_rest routes resource_exists/2 -> false into the create path
+    %% (accept_content), NOT a 404 -- so resource_exists alone does not gate
+    %% the endpoint. When the feature is disabled, aws_sup starts no
+    %% rate_limiter/semaphore workers, so reaching the pipeline below would
+    %% gen_server:call a non-existent process and crash (HTTP 500). Short-
+    %% circuit to 404 instead, matching the documented toggle behaviour.
+    case feature_enabled() of
+        false ->
+            reply_error(404, method_disabled, <<"Validation method disabled">>, Req0, Context);
+        true ->
+            T0 = erlang:monotonic_time(millisecond),
+            SourceIP = peer_ip(Req0),
+            Method = cowboy_req:binding(method, Req0),
+            case aws_auth_validate_rate_limiter:check(SourceIP) of
+                {error, rate_limited} ->
+                    audit(Method, SourceIP, rate_limited, T0),
+                    reply_error(429, rate_limited, <<"Rate limit exceeded">>, Req0, Context);
+                ok ->
+                    with_body(T0, SourceIP, Method, Req0, Context)
+            end
+    end.
+
+with_body(T0, SourceIP, Method, Req0, Context) ->
+    MaxBytes = max_body_size(),
+    case read_body(Req0, MaxBytes) of
+        {error, body_too_large, Req1} ->
+            audit(Method, SourceIP, input_invalid, T0),
+            reply_error(400, body_too_large, <<"Request body too large">>, Req1, Context);
+        {ok, RawBody, Req1} ->
+            case decode_json(RawBody) of
+                {error, _} ->
+                    audit(Method, SourceIP, input_invalid, T0),
+                    reply_error(400, input_invalid, <<"Invalid JSON body">>, Req1, Context);
+                {ok, BodyMap} when is_map(BodyMap) ->
+                    with_semaphore(T0, SourceIP, Method, BodyMap, Req1, Context);
+                {ok, _NotMap} ->
+                    audit(Method, SourceIP, input_invalid, T0),
+                    reply_error(
+                        400, input_invalid, <<"JSON body must be an object">>, Req1, Context
+                    )
+            end
+    end.
+
+with_semaphore(T0, SourceIP, Method, BodyMap, Req, Context) ->
+    case aws_auth_validate_semaphore:acquire() of
+        {error, full} ->
+            audit(Method, SourceIP, capacity_exhausted, T0),
+            reply_error(503, capacity_exhausted, <<"Service at capacity">>, Req, Context);
+        {ok, Ref} ->
+            try
+                Result = aws_auth_validate_registry:dispatch(Method, BodyMap),
+                audit(Method, SourceIP, result_category(Result), T0),
+                respond(Result, Req, Context)
+            after
+                aws_auth_validate_semaphore:release(Ref)
+            end
+    end.
+
+%%--------------------------------------------------------------------
+%% Response mapping
+%%--------------------------------------------------------------------
+
+respond(ok, Req, Context) ->
+    Req1 = cowboy_req:reply(204, #{}, <<>>, Req),
+    {stop, Req1, Context};
+respond({error, unknown_method}, Req, Context) ->
+    reply_error(404, unknown_method, <<"Unknown validation method">>, Req, Context);
+respond({error, method_disabled}, Req, Context) ->
+    reply_error(404, method_disabled, <<"Validation method disabled">>, Req, Context);
+respond({error, Category, Reason}, Req, Context) when is_atom(Category), is_binary(Reason) ->
+    Status = status_for_category(Category),
+    reply_error(Status, Category, Reason, Req, Context).
+
+status_for_category(input_invalid) -> 400;
+status_for_category(connection_failed) -> 400;
+status_for_category(tls_failed) -> 400;
+status_for_category(query_invalid) -> 400;
+status_for_category(auth_failed) -> 422;
+status_for_category(config_conflict) -> 422;
+status_for_category(authz_unverified) -> 422.
+
+reply_error(Status, Category, Message, Req, Context) ->
+    Body = rabbit_json:encode(#{
+        error => atom_to_binary(Category, utf8),
+        message => Message
+    }),
+    Headers = #{<<"content-type">> => <<"application/json">>},
+    Req1 = cowboy_req:reply(Status, Headers, Body, Req),
+    {stop, Req1, Context}.
+
+result_category(ok) -> success;
+result_category({error, unknown_method}) -> unknown_method;
+result_category({error, method_disabled}) -> method_disabled;
+result_category({error, Category, _Reason}) -> Category.
+
+%%--------------------------------------------------------------------
+%% Authorization helpers
+%%--------------------------------------------------------------------
+
+%% Operator-configured non-administrator tag gating. The default
+%% (administrator) is handled in is_authorized/2 via the management
+%% plugin's helper, which already handles oauth tokens etc.
+authorize_tag(Tag, ReqData, #context{user = #user{tags = Tags}} = Context) ->
+    case lists:member(Tag, Tags) of
+        true -> {true, ReqData, Context};
+        false -> not_authorised(ReqData, Context)
+    end;
+authorize_tag(_Tag, ReqData, Context) ->
+    not_authorised(ReqData, Context).
+
+not_authorised(ReqData, Context) ->
+    Body = rabbit_json:encode(#{
+        error => <<"insufficient_user_tag">>,
+        message => <<"User does not have required tag">>
+    }),
+    Headers = #{<<"content-type">> => <<"application/json">>},
+    Req1 = cowboy_req:reply(401, Headers, Body, ReqData),
+    {stop, Req1, Context}.
+
+%%--------------------------------------------------------------------
+%% Request helpers
+%%--------------------------------------------------------------------
+
+peer_ip(Req) ->
+    case cowboy_req:peer(Req) of
+        {IP, _Port} -> IP;
+        _ -> {0, 0, 0, 0}
+    end.
+
+read_body(Req0, MaxBytes) ->
+    Opts = #{length => MaxBytes + 1, period => 5_000},
+    case cowboy_req:read_body(Req0, Opts) of
+        {ok, Body, Req1} when byte_size(Body) =< MaxBytes ->
+            {ok, Body, Req1};
+        {ok, _Body, Req1} ->
+            {error, body_too_large, Req1};
+        {more, _Body, Req1} ->
+            {error, body_too_large, Req1}
+    end.
+
+decode_json(<<>>) ->
+    {ok, #{}};
+decode_json(Raw) ->
+    rabbit_json:try_decode(Raw).
+
+audit(Method, SourceIP, ResultCategory, T0) ->
+    Duration = erlang:monotonic_time(millisecond) - T0,
+    ?AWS_LOG_INFO(
+        "auth_validate: method=~ts source_ip=~ts result=~ts duration_ms=~B",
+        [Method, format_ip(SourceIP), ResultCategory, Duration]
+    ).
+
+format_ip(IP) when is_tuple(IP) ->
+    case inet:ntoa(IP) of
+        {error, _} -> <<"unknown">>;
+        Str -> list_to_binary(Str)
+    end;
+format_ip(_) ->
+    <<"unknown">>.
+
+%%--------------------------------------------------------------------
+%% Configuration accessors
+%%--------------------------------------------------------------------
+
+feature_enabled() ->
+    application:get_env(aws, auth_validation_enabled, false) =:= true.
+
+max_body_size() ->
+    case application:get_env(aws, auth_validation_max_body_size) of
+        {ok, N} when is_integer(N), N > 0 -> N;
+        _ -> ?DEFAULT_MAX_BODY_SIZE
+    end.
+
+required_user_tag() ->
+    case application:get_env(aws, auth_validation_required_user_tag) of
+        {ok, Tag} when is_atom(Tag) -> Tag;
+        _ -> ?DEFAULT_REQUIRED_USER_TAG
+    end.

--- a/src/aws_auth_validate_rate_limiter.erl
+++ b/src/aws_auth_validate_rate_limiter.erl
@@ -1,0 +1,121 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% Per-source-IP fixed-window rate limiter. A periodic sweep evicts
+%% stale entries whose window has fully expired, bounding state size.
+-module(aws_auth_validate_rate_limiter).
+
+-behaviour(gen_server).
+
+-export([start_link/1, check/1, reset/0]).
+
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
+
+-record(rate_state, {
+    counters = #{} :: #{inet:ip_address() => {non_neg_integer(), integer()}},
+    window_ms :: pos_integer(),
+    max_per_window :: pos_integer(),
+    sweep_interval_ms :: pos_integer()
+}).
+
+-type config() :: #{
+    window_ms => pos_integer(),
+    max_per_window => pos_integer(),
+    sweep_interval_ms => pos_integer()
+}.
+
+-define(DEFAULT_WINDOW_MS, 60_000).
+-define(DEFAULT_MAX_PER_WINDOW, 10).
+-define(DEFAULT_SWEEP_INTERVAL_MS, 30_000).
+
+-spec start_link(config()) -> {ok, pid()} | {error, term()}.
+start_link(Config) ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, Config, []).
+
+-spec check(inet:ip_address()) -> ok | {error, rate_limited}.
+check(IP) ->
+    gen_server:call(?MODULE, {check, IP}).
+
+-spec reset() -> ok.
+reset() ->
+    gen_server:call(?MODULE, reset).
+
+%%--------------------------------------------------------------------
+%% gen_server callbacks
+%%--------------------------------------------------------------------
+
+init(Config) when is_map(Config) ->
+    State = #rate_state{
+        window_ms = maps:get(window_ms, Config, ?DEFAULT_WINDOW_MS),
+        max_per_window = maps:get(max_per_window, Config, ?DEFAULT_MAX_PER_WINDOW),
+        sweep_interval_ms = maps:get(sweep_interval_ms, Config, ?DEFAULT_SWEEP_INTERVAL_MS)
+    },
+    schedule_sweep(State#rate_state.sweep_interval_ms),
+    {ok, State}.
+
+handle_call(
+    {check, IP},
+    _From,
+    #rate_state{
+        counters = Counters0,
+        window_ms = WindowMs,
+        max_per_window = Max
+    } = State
+) ->
+    Now = erlang:monotonic_time(millisecond),
+    case maps:get(IP, Counters0, undefined) of
+        undefined ->
+            {reply, ok, State#rate_state{counters = maps:put(IP, {1, Now}, Counters0)}};
+        {_Count, WindowStart} when (Now - WindowStart) >= WindowMs ->
+            {reply, ok, State#rate_state{counters = maps:put(IP, {1, Now}, Counters0)}};
+        {Count, _WindowStart} when Count >= Max ->
+            {reply, {error, rate_limited}, State};
+        {Count, WindowStart} ->
+            Counters1 = maps:put(IP, {Count + 1, WindowStart}, Counters0),
+            {reply, ok, State#rate_state{counters = Counters1}}
+    end;
+handle_call(reset, _From, State) ->
+    {reply, ok, State#rate_state{counters = #{}}};
+handle_call(_Request, _From, State) ->
+    {reply, {error, unknown_request}, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(
+    sweep,
+    #rate_state{
+        counters = Counters0,
+        window_ms = WindowMs,
+        sweep_interval_ms = SweepMs
+    } = State
+) ->
+    Now = erlang:monotonic_time(millisecond),
+    Counters1 = maps:filter(
+        fun(_IP, {_Count, WindowStart}) -> (Now - WindowStart) < WindowMs end,
+        Counters0
+    ),
+    schedule_sweep(SweepMs),
+    {noreply, State#rate_state{counters = Counters1}};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%--------------------------------------------------------------------
+
+schedule_sweep(SweepMs) ->
+    erlang:send_after(SweepMs, self(), sweep).

--- a/src/aws_auth_validate_registry.erl
+++ b/src/aws_auth_validate_registry.erl
@@ -1,0 +1,62 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% Maps a method path segment to a backend module, gates dispatch on
+%% per-method enable flags, and filters the request body to the
+%% intersection of the backend's allowed_fields/0 and any operator
+%% override list.
+-module(aws_auth_validate_registry).
+
+-export([dispatch/2, lookup_backend/1, effective_allowed_fields/2]).
+
+-spec dispatch(binary(), map()) ->
+    aws_auth_validate_backend:result()
+    | {error, unknown_method | method_disabled}.
+dispatch(Method, Body) when is_binary(Method), is_map(Body) ->
+    case lookup_backend(Method) of
+        {error, _} = Err ->
+            Err;
+        {ok, Module} ->
+            case is_method_enabled(Method) of
+                false ->
+                    {error, method_disabled};
+                true ->
+                    AllowedFields = effective_allowed_fields(Module, Method),
+                    FilteredBody = maps:with(AllowedFields, Body),
+                    Module:validate(FilteredBody)
+            end
+    end.
+
+-spec lookup_backend(binary()) -> {ok, module()} | {error, unknown_method}.
+lookup_backend(<<"ldap">>) ->
+    {ok, aws_auth_validate_ldap};
+lookup_backend(_) ->
+    {error, unknown_method}.
+
+-spec effective_allowed_fields(module(), binary()) -> [binary()].
+effective_allowed_fields(Module, Method) ->
+    BaseFields = Module:allowed_fields(),
+    case application:get_env(aws, {auth_validation_allowed_fields_override, Method}) of
+        {ok, Override} when is_list(Override) ->
+            [F || F <- Override, lists:member(F, BaseFields)];
+        _ ->
+            BaseFields
+    end.
+
+%%--------------------------------------------------------------------
+
+%% Per-method enable check. Defaults to enabled when no per-method
+%% setting is provided so the operator only has to opt out, not in.
+-spec is_method_enabled(binary()) -> boolean().
+is_method_enabled(Method) ->
+    case application:get_env(aws, auth_validation_enabled_methods) of
+        {ok, Methods} when is_list(Methods) ->
+            case lists:keyfind(Method, 1, Methods) of
+                {_, Bool} when is_boolean(Bool) -> Bool;
+                false -> true
+            end;
+        _ ->
+            true
+    end.

--- a/src/aws_auth_validate_semaphore.erl
+++ b/src/aws_auth_validate_semaphore.erl
@@ -1,0 +1,125 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% Counting semaphore that bounds concurrent outbound auth-validation
+%% requests. Holders are monitored so a crashed handler frees its slot
+%% automatically.
+-module(aws_auth_validate_semaphore).
+
+-behaviour(gen_server).
+
+-export([start_link/1, acquire/0, release/1, current/0]).
+
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
+
+-record(sem_state, {
+    max :: pos_integer(),
+    current = 0 :: non_neg_integer(),
+    holders = #{} :: #{reference() => pid()}
+}).
+
+-type config() :: #{max => pos_integer()}.
+
+-define(DEFAULT_MAX, 5).
+
+-spec start_link(config()) -> {ok, pid()} | {error, term()}.
+start_link(Config) ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, Config, []).
+
+-spec acquire() -> {ok, reference()} | {error, full}.
+acquire() ->
+    gen_server:call(?MODULE, acquire).
+
+-spec release(reference()) -> ok.
+release(Ref) ->
+    gen_server:call(?MODULE, {release, Ref}).
+
+-spec current() -> non_neg_integer().
+current() ->
+    gen_server:call(?MODULE, get_current).
+
+%%--------------------------------------------------------------------
+%% gen_server callbacks
+%%--------------------------------------------------------------------
+
+init(Config) when is_map(Config) ->
+    {ok, #sem_state{max = maps:get(max, Config, ?DEFAULT_MAX)}}.
+
+handle_call(acquire, _From, #sem_state{max = Max, current = Current} = State) when
+    Current >= Max
+->
+    {reply, {error, full}, State};
+handle_call(
+    acquire,
+    {Pid, _Tag},
+    #sem_state{
+        current = Current,
+        holders = Holders0
+    } = State
+) ->
+    Ref = erlang:monitor(process, Pid),
+    Holders1 = maps:put(Ref, Pid, Holders0),
+    {reply, {ok, Ref}, State#sem_state{
+        current = Current + 1,
+        holders = Holders1
+    }};
+handle_call(
+    {release, Ref},
+    _From,
+    #sem_state{
+        current = Current,
+        holders = Holders0
+    } = State
+) ->
+    case maps:take(Ref, Holders0) of
+        {_Pid, Holders1} ->
+            erlang:demonitor(Ref, [flush]),
+            {reply, ok, State#sem_state{
+                current = Current - 1,
+                holders = Holders1
+            }};
+        error ->
+            %% Already released (e.g. via DOWN). Treat idempotently.
+            {reply, ok, State}
+    end;
+handle_call(get_current, _From, #sem_state{current = Current} = State) ->
+    {reply, Current, State};
+handle_call(_Request, _From, State) ->
+    {reply, {error, unknown_request}, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(
+    {'DOWN', Ref, process, _Pid, _Reason},
+    #sem_state{
+        current = Current,
+        holders = Holders0
+    } = State
+) ->
+    case maps:take(Ref, Holders0) of
+        {_Holder, Holders1} ->
+            {noreply, State#sem_state{
+                current = Current - 1,
+                holders = Holders1
+            }};
+        error ->
+            {noreply, State}
+    end;
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.

--- a/src/aws_sup.erl
+++ b/src/aws_sup.erl
@@ -16,10 +16,80 @@ start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 init([]) ->
+    %% Tolerate a few transient worker crashes before giving up: a single
+    %% restart within 5s (intensity => 1) would tear down the whole
+    %% supervisor -- and with it ARN resolution -- on a second crash. The
+    %% validation workers are independent gen_servers, so allow several
+    %% restarts in a slightly wider window before escalating.
     SupFlags = #{
         strategy => one_for_one,
-        intensity => 1,
-        period => 5
+        intensity => 5,
+        period => 10
     },
-    ChildSpecs = [],
+    ChildSpecs = auth_validation_children(),
     {ok, {SupFlags, ChildSpecs}}.
+
+%%--------------------------------------------------------------------
+%% Auth validation feature: workers are started only when the feature
+%% toggle is on. With the toggle off, the supervisor remains empty and
+%% the validation route returns 404, leaving the rest of the plugin
+%% (ARN resolution) entirely undisturbed.
+%%--------------------------------------------------------------------
+
+auth_validation_children() ->
+    case application:get_env(aws, auth_validation_enabled, false) of
+        true -> [rate_limiter_spec(), semaphore_spec(), arn_lock_spec()];
+        _ -> []
+    end.
+
+rate_limiter_spec() ->
+    Config = rate_limiter_config(),
+    #{
+        id => aws_auth_validate_rate_limiter,
+        start => {aws_auth_validate_rate_limiter, start_link, [Config]},
+        restart => permanent,
+        shutdown => 5_000,
+        type => worker,
+        modules => [aws_auth_validate_rate_limiter]
+    }.
+
+semaphore_spec() ->
+    Config = semaphore_config(),
+    #{
+        id => aws_auth_validate_semaphore,
+        start => {aws_auth_validate_semaphore, start_link, [Config]},
+        restart => permanent,
+        shutdown => 5_000,
+        type => worker,
+        modules => [aws_auth_validate_semaphore]
+    }.
+
+%% Serializes ARN resolution so concurrent validations cannot clobber the
+%% shared rabbitmq_aws region/credential singleton mid-resolve.
+arn_lock_spec() ->
+    #{
+        id => aws_auth_validate_arn_lock,
+        start => {aws_auth_validate_arn_lock, start_link, []},
+        restart => permanent,
+        shutdown => 5_000,
+        type => worker,
+        modules => [aws_auth_validate_arn_lock]
+    }.
+
+rate_limiter_config() ->
+    WindowSecs = get_int_env(auth_validation_rate_limit_window_seconds, 60),
+    Max = get_int_env(auth_validation_rate_limit_max_requests, 10),
+    #{
+        window_ms => WindowSecs * 1_000,
+        max_per_window => Max,
+        sweep_interval_ms => max(WindowSecs * 1_000 div 2, 1_000)
+    }.
+
+semaphore_config() ->
+    #{max => get_int_env(auth_validation_max_concurrent, 5)}.
+
+get_int_env(Key, Default) ->
+    case application:get_env(aws, Key) of
+        {ok, N} when is_integer(N), N > 0 -> N;
+        _ -> Default
+    end.

--- a/test/aws_auth_validate_ldap_query_tests.erl
+++ b/test/aws_auth_validate_ldap_query_tests.erl
@@ -1,0 +1,181 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% Unit tests for the self-contained LDAP authorization-query parser
+%% (aws_auth_validate_ldap_query), plus a parity test asserting it agrees
+%% with the broker's rabbit_auth_backend_ldap_util:parse_query/1 on
+%% accept/reject for a representative corpus (design requirement R12).
+-module(aws_auth_validate_ldap_query_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%%--------------------------------------------------------------------
+%% Accept / reject
+%%--------------------------------------------------------------------
+
+%% Queries the broker accepts. Kept in sync with the parity test below.
+accepted_queries() ->
+    [
+        <<"{constant, true}">>,
+        <<"{constant, false}">>,
+        <<"{in_group, \"cn=admins,ou=groups,dc=example,dc=com\"}">>,
+        <<"{in_group_nested, \"cn=g,dc=example,dc=com\", \"member\"}">>,
+        <<"{'not', {constant, true}}">>,
+        <<"{'and', [{constant, true}, {constant, false}]}">>,
+        <<"{'or', [{constant, true}, {constant, false}]}">>,
+        <<"{equals, \"${username}\", \"admin\"}">>,
+        <<"{match, \"${username}\", \"^a.*\"}">>,
+        <<"{for, [{permission, configure, {constant, true}}]}">>,
+        %% tag_queries form: a list of {Tag, SubQuery} pairs.
+        <<"[{administrator, {in_group, \"cn=admins,dc=example,dc=com\"}}]">>,
+        %% trailing dot already present
+        <<"{constant, true}.">>,
+        %% A bare quoted string parses to an Erlang list, so it hits the
+        %% is_list/1 (tag_queries) clause in BOTH parsers. Included here to
+        %% pin that parity quirk rather than to endorse it as a useful query.
+        <<"\"just a string\"">>
+    ].
+
+rejected_queries() ->
+    [
+        <<"{garbage,">>,
+        <<"not even erlang">>,
+        <<"{bogus_term, 1, 2}">>,
+        <<"42">>,
+        <<>>,
+        %% Forms the runtime evaluator handles but parse_query/1 (the config
+        %% gate we mirror) rejects, so the endpoint rejects them too.
+        <<"{in_group, \"cn=g,dc=example,dc=com\", \"member\"}">>,
+        <<"{exists, \"ou=users,dc=example,dc=com\"}">>,
+        <<"{attribute, \"cn=g,dc=example,dc=com\", \"member\"}">>
+    ].
+
+parse_accepts_test_() ->
+    [
+        ?_assertMatch({ok, _}, aws_auth_validate_ldap_query:parse(Q))
+     || Q <- accepted_queries()
+    ].
+
+parse_rejects_test_() ->
+    [
+        ?_assertMatch({error, _}, aws_auth_validate_ldap_query:parse(Q))
+     || Q <- rejected_queries()
+    ].
+
+parse_accepts_string_input_test() ->
+    ?assertMatch({ok, _}, aws_auth_validate_ldap_query:parse("{constant, true}")).
+
+%%--------------------------------------------------------------------
+%% Literal DN extraction
+%%--------------------------------------------------------------------
+
+literal_dns_in_group_test() ->
+    {ok, Q} = aws_auth_validate_ldap_query:parse(
+        <<"{in_group, \"cn=admins,ou=groups,dc=example,dc=com\"}">>
+    ),
+    ?assertEqual(
+        ["cn=admins,ou=groups,dc=example,dc=com"],
+        aws_auth_validate_ldap_query:literal_dns(Q)
+    ).
+
+literal_dns_skips_placeholder_test() ->
+    %% A DN with a ${...} placeholder is runtime-filled, not literal, so it
+    %% contributes no static reachability check.
+    {ok, Q} = aws_auth_validate_ldap_query:parse(
+        <<"{in_group, \"cn=${username},ou=groups,dc=example,dc=com\"}">>
+    ),
+    ?assertEqual([], aws_auth_validate_ldap_query:literal_dns(Q)).
+
+literal_dns_constant_test() ->
+    {ok, Q} = aws_auth_validate_ldap_query:parse(<<"{constant, true}">>),
+    ?assertEqual([], aws_auth_validate_ldap_query:literal_dns(Q)).
+
+literal_dns_nested_and_or_test() ->
+    {ok, Q} = aws_auth_validate_ldap_query:parse(
+        <<"{'or', [{in_group, \"cn=a,dc=x\"}, {'and', [{in_group, \"cn=b,dc=x\"}]}]}">>
+    ),
+    ?assertEqual(
+        ["cn=a,dc=x", "cn=b,dc=x"],
+        aws_auth_validate_ldap_query:literal_dns(Q)
+    ).
+
+literal_dns_tag_queries_test() ->
+    {ok, Q} = aws_auth_validate_ldap_query:parse(
+        <<"[{administrator, {in_group, \"cn=admins,dc=x\"}}, {management, {constant, true}}]">>
+    ),
+    ?assertEqual(["cn=admins,dc=x"], aws_auth_validate_ldap_query:literal_dns(Q)).
+
+literal_dns_exists_test() ->
+    %% parse/1 rejects {exists,_} (parse_query/1 does not allow it), but
+    %% literal_dns/1 still walks the term defensively, so test it on a
+    %% directly-constructed term rather than via parse/1.
+    ?assertEqual(
+        ["ou=users,dc=x"],
+        aws_auth_validate_ldap_query:literal_dns({exists, "ou=users,dc=x"})
+    ).
+
+literal_dns_for_test() ->
+    {ok, Q} = aws_auth_validate_ldap_query:parse(
+        <<"{for, [{permission, configure, {in_group, \"cn=cfg,dc=x\"}}]}">>
+    ),
+    ?assertEqual(["cn=cfg,dc=x"], aws_auth_validate_ldap_query:literal_dns(Q)).
+
+%%--------------------------------------------------------------------
+%% Parity with rabbit_auth_backend_ldap_util:parse_query/1 (R12)
+%%--------------------------------------------------------------------
+
+%% The broker's parser throws via cuttlefish:invalid/2 on rejection; ours
+%% returns {error, _}. This asserts both classify each corpus entry the same
+%% way (both accept, or both reject).
+%%
+%% Runs only when upstream parse_query/1 is actually usable in this node.
+%% It is not enough that the module loads: parse_query/1 calls
+%% rabbit_data_coercion (and cuttlefish:invalid on rejection), and across
+%% the RMQ-version CI matrix those deps are not always loaded in the bare
+%% eunit node. If they are missing, every parse_query/1 call throws undef
+%% and upstream_accepts/1 would report "rejected" for EVERYTHING, making the
+%% test fail spuriously. So we probe upstream with a known-good and a
+%% known-bad query first and skip the whole parity check unless upstream
+%% classifies both correctly.
+parity_test_() ->
+    case upstream_parser_usable() of
+        true ->
+            [
+                {
+                    binary_to_list(Q),
+                    ?_assertEqual(
+                        upstream_accepts(Q),
+                        ours_accepts(Q)
+                    )
+                }
+             || Q <- accepted_queries() ++ rejected_queries()
+            ];
+        false ->
+            %% Upstream not usable in this build; nothing to compare.
+            []
+    end.
+
+%% True only if rabbit_auth_backend_ldap_util:parse_query/1 is loaded AND its
+%% transitive deps are available, verified by a positive+negative probe.
+upstream_parser_usable() ->
+    code:ensure_loaded(rabbit_auth_backend_ldap_util) =/= {error, nofile} andalso
+        erlang:function_exported(rabbit_auth_backend_ldap_util, parse_query, 1) andalso
+        upstream_accepts(<<"{constant, true}">>) andalso
+        not upstream_accepts(<<"{bogus_term, 1, 2}">>).
+
+ours_accepts(Q) ->
+    case aws_auth_validate_ldap_query:parse(Q) of
+        {ok, _} -> true;
+        {error, _} -> false
+    end.
+
+upstream_accepts(Q) ->
+    try rabbit_auth_backend_ldap_util:parse_query(Q) of
+        _ -> true
+    catch
+        %% cuttlefish:invalid/2 throws a {invalid, _} tuple; any throw/exit
+        %% from the parser means it rejected the query.
+        _:_ -> false
+    end.

--- a/test/aws_auth_validate_mgmt_SUITE.erl
+++ b/test/aws_auth_validate_mgmt_SUITE.erl
@@ -1,0 +1,313 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% HTTP-level tests for the auth validation endpoint
+%%   PUT /api/aws/auth/validate/:method
+%% These exercise the request pipeline (auth, body parsing, dispatch,
+%% feature toggle) without requiring a real LDAP server. The actual
+%% bind/connect/TLS paths are covered in aws_auth_validate_ldap_SUITE.
+-module(aws_auth_validate_mgmt_SUITE).
+
+-export([
+    all/0,
+    groups/0,
+    init_per_suite/1,
+    end_per_suite/1,
+    init_per_group/2,
+    end_per_group/2,
+    init_per_testcase/2,
+    end_per_testcase/2
+]).
+
+-export([
+    feature_disabled_returns_404/1,
+    unknown_method_returns_404/1,
+    bad_json_returns_400/1,
+    body_too_large_returns_400/1,
+    config_conflict_returns_422/1,
+    missing_servers_returns_400/1,
+    rate_limit_returns_429/1,
+    capacity_exhausted_returns_503/1,
+    method_disabled_returns_404/1,
+    options_returns_allowed_methods/1,
+    get_returns_405/1,
+    password_not_in_response/1
+]).
+
+%% Invoked on the broker node via rpc to hold a semaphore slot.
+-export([hold_slot/1]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("rabbitmq_ct_helpers/include/rabbit_mgmt_test.hrl").
+-include("aws.hrl").
+
+-define(API, "/aws/auth/validate/ldap").
+
+all() ->
+    [
+        {group, feature_disabled},
+        {group, feature_enabled}
+    ].
+
+groups() ->
+    [
+        {feature_disabled, [], [
+            feature_disabled_returns_404
+        ]},
+        {feature_enabled, [], [
+            unknown_method_returns_404,
+            bad_json_returns_400,
+            body_too_large_returns_400,
+            config_conflict_returns_422,
+            missing_servers_returns_400,
+            rate_limit_returns_429,
+            capacity_exhausted_returns_503,
+            method_disabled_returns_404,
+            options_returns_allowed_methods,
+            get_returns_405,
+            password_not_in_response
+        ]}
+    ].
+
+init_per_suite(Config) ->
+    ok = inets:start(),
+    rabbit_ct_helpers:log_environment(),
+    Config.
+
+end_per_suite(Config) ->
+    inets:stop(),
+    Config.
+
+init_per_group(feature_disabled, Config) ->
+    setup_broker(Config, [{auth_validation_enabled, false}]);
+init_per_group(feature_enabled, Config) ->
+    setup_broker(Config, [
+        {auth_validation_enabled, true},
+        {auth_validation_max_concurrent, 1},
+        {auth_validation_max_body_size, 1024},
+        {auth_validation_rate_limit_window_seconds, 60},
+        {auth_validation_rate_limit_max_requests, 3}
+    ]).
+
+end_per_group(_Group, Config) ->
+    rabbit_ct_helpers:run_teardown_steps(
+        Config,
+        rabbit_ct_broker_helpers:teardown_steps()
+    ).
+
+init_per_testcase(method_disabled_returns_404 = TC, Config) ->
+    reset_rate_limiter(Config),
+    rabbit_ct_broker_helpers:rpc(
+        Config,
+        0,
+        application,
+        set_env,
+        [aws, auth_validation_enabled_methods, [{<<"ldap">>, false}]]
+    ),
+    rabbit_ct_helpers:testcase_started(Config, TC);
+init_per_testcase(TC, Config) ->
+    %% Reset the per-IP rate limiter before every case so no case inherits
+    %% another's token consumption (the feature_enabled group allows only 3
+    %% requests/window, and all CT traffic shares source IP 127.0.0.1).
+    %% rate_limit_returns_429 deliberately exhausts its own fresh budget.
+    reset_rate_limiter(Config),
+    rabbit_ct_helpers:testcase_started(Config, TC).
+
+end_per_testcase(method_disabled_returns_404 = TC, Config) ->
+    rabbit_ct_broker_helpers:rpc(
+        Config, 0, application, unset_env, [aws, auth_validation_enabled_methods]
+    ),
+    rabbit_ct_helpers:testcase_finished(Config, TC);
+end_per_testcase(TC, Config) ->
+    rabbit_ct_helpers:testcase_finished(Config, TC).
+
+%%--------------------------------------------------------------------
+%% Feature-disabled group
+%%--------------------------------------------------------------------
+
+feature_disabled_returns_404(Config) ->
+    %% with feature disabled, resource_exists/2 -> false -> 404.
+    Body = base_body(),
+    {ok, {{_, Code, _}, _Headers, _ResBody}} = put_request(Config, ?API, Body),
+    ?assertEqual(404, Code).
+
+%%--------------------------------------------------------------------
+%% Feature-enabled group
+%%--------------------------------------------------------------------
+
+unknown_method_returns_404(Config) ->
+    Body = base_body(),
+    Path = "/aws/auth/validate/no-such-method",
+    {ok, {{_, Code, _}, _, _}} = put_request(Config, Path, Body),
+    ?assertEqual(404, Code).
+
+bad_json_returns_400(Config) ->
+    rabbit_mgmt_test_util:http_put_raw(Config, ?API, "{not valid json", 400).
+
+body_too_large_returns_400(Config) ->
+    Big = binary:copy(<<"x">>, 4096),
+    Body = (base_body())#{<<"user_dn">> => Big},
+    {ok, {{_, Code, _}, _, _}} = put_request(Config, ?API, Body),
+    ?assertEqual(400, Code).
+
+config_conflict_returns_422(Config) ->
+    Body = (base_body())#{<<"use_ssl">> => true, <<"use_starttls">> => true},
+    {ok, {{_, Code, _}, _, ResBody}} = put_request(Config, ?API, Body),
+    ?assertEqual(422, Code),
+    ?assertMatch(#{<<"error">> := <<"config_conflict">>}, decode(ResBody)).
+
+missing_servers_returns_400(Config) ->
+    Body = maps:remove(<<"servers">>, base_body()),
+    {ok, {{_, Code, _}, _, ResBody}} = put_request(Config, ?API, Body),
+    ?assertEqual(400, Code),
+    ?assertMatch(#{<<"error">> := <<"input_invalid">>}, decode(ResBody)).
+
+rate_limit_returns_429(Config) ->
+    %% rate limit window=60s, max=3 (configured in init_per_group)
+
+    %% guaranteed-fail port
+    Body = (base_body())#{<<"servers">> => [<<"127.0.0.1">>], <<"port">> => 1},
+    %% three requests should all proceed past rate limit; fourth gets 429
+    [_ = put_request(Config, ?API, Body) || _ <- lists:seq(1, 3)],
+    {ok, {{_, Code, _}, _, _}} = put_request(Config, ?API, Body),
+    ?assertEqual(429, Code).
+
+capacity_exhausted_returns_503(Config) ->
+    %% Hold the only semaphore slot for the duration of the HTTP request.
+    %%
+    %% A plain rpc(..., aws_auth_validate_semaphore, acquire, []) does NOT
+    %% work: erpc runs acquire/0 in a transient worker process that exits as
+    %% soon as the call returns, and the semaphore monitors its holder and
+    %% auto-releases the slot on that worker's DOWN -- so the slot would be
+    %% free again before our request arrives. Instead spawn a long-lived
+    %% holder process ON THE BROKER NODE (via ?MODULE:hold_slot/1, which puts
+    %% this suite on the broker's code path) that acquires and then blocks
+    %% until told to release.
+    Holder = rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, hold_slot, [self()]),
+    ok = wait_for_current(Config, 1, 50),
+    try
+        Body = base_body(),
+        {ok, {{_, Code, _}, _, _}} = put_request(Config, ?API, Body),
+        ?assertEqual(503, Code)
+    after
+        Holder ! release,
+        _ = wait_for_current(Config, 0, 50)
+    end.
+
+method_disabled_returns_404(Config) ->
+    Body = base_body(),
+    {ok, {{_, Code, _}, _, _}} = put_request(Config, ?API, Body),
+    ?assertEqual(404, Code).
+
+options_returns_allowed_methods(Config) ->
+    {ok, {{_, Code, _}, Headers, _}} = rabbit_mgmt_test_util:req(
+        Config,
+        0,
+        options,
+        ?API,
+        [rabbit_mgmt_test_util:auth_header("guest", "guest")]
+    ),
+    ?assertEqual(200, Code),
+    Allow = string:to_upper(proplists:get_value("allow", Headers, "")),
+    ?assert(string:str(Allow, "PUT") > 0),
+    ?assert(string:str(Allow, "OPTIONS") > 0).
+
+get_returns_405(Config) ->
+    {ok, {{_, Code, _}, _, _}} = rabbit_mgmt_test_util:req(
+        Config,
+        0,
+        get,
+        ?API,
+        [rabbit_mgmt_test_util:auth_header("guest", "guest")]
+    ),
+    ?assertEqual(405, Code).
+
+password_not_in_response(Config) ->
+    %% Property 6: response body must never contain the submitted password.
+    Password = <<"super-secret-pAssw0rd!">>,
+    Body = (base_body())#{
+        <<"password">> => Password,
+        <<"servers">> => [<<"127.0.0.1">>],
+        <<"port">> => 1
+    },
+    {ok, {{_, _Code, _}, _, ResBody}} = put_request(Config, ?API, Body),
+    ?assertEqual(nomatch, binary:match(iolist_to_binary(ResBody), Password)).
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+setup_broker(Config0, ExtraEnv) ->
+    Config1 = rabbit_ct_helpers:set_config(Config0, [
+        {rmq_nodename_suffix, ?MODULE}
+    ]),
+    Config2 = rabbit_ct_helpers:merge_app_env(Config1, {aws, ExtraEnv}),
+    rabbit_ct_helpers:run_setup_steps(
+        Config2,
+        rabbit_ct_broker_helpers:setup_steps()
+    ).
+
+%% Reset the per-IP rate limiter. Wrapped in catch because the
+%% feature_disabled group starts no limiter process (nothing to reset).
+reset_rate_limiter(Config) ->
+    catch rabbit_ct_broker_helpers:rpc(
+        Config, 0, aws_auth_validate_rate_limiter, reset, []
+    ),
+    ok.
+
+%% Runs ON THE BROKER NODE (invoked via rpc with Module=?MODULE). Spawns a
+%% persistent process that acquires the only semaphore slot and blocks until
+%% told to release, so the slot stays held across an HTTP request issued from
+%% the CT node. Returns the holder pid (on the broker node).
+hold_slot(Parent) ->
+    spawn(fun() ->
+        {ok, _Ref} = aws_auth_validate_semaphore:acquire(),
+        Parent ! slot_held,
+        receive
+            release -> ok
+        after 30_000 -> ok
+        end
+    end).
+
+%% Poll the semaphore's current holder count until it reaches Target.
+wait_for_current(_Config, Target, 0) ->
+    {error, {timeout_waiting_for_current, Target}};
+wait_for_current(Config, Target, N) ->
+    case rabbit_ct_broker_helpers:rpc(Config, 0, aws_auth_validate_semaphore, current, []) of
+        Target ->
+            ok;
+        _ ->
+            timer:sleep(20),
+            wait_for_current(Config, Target, N - 1)
+    end.
+
+base_body() ->
+    #{
+        <<"servers">> => [<<"127.0.0.1">>],
+        <<"port">> => 389,
+        <<"user_dn">> => <<"cn=test,dc=example,dc=com">>,
+        <<"password">> => <<"unused">>
+    }.
+
+put_request(Config, Path, BodyMap) ->
+    Body = binary_to_list(rabbit_json:encode(BodyMap)),
+    rabbit_mgmt_test_util:req(
+        Config,
+        0,
+        put,
+        Path,
+        [
+            rabbit_mgmt_test_util:auth_header("guest", "guest"),
+            {"content-type", "application/json"}
+        ],
+        Body
+    ).
+
+decode(ResBody) ->
+    case rabbit_json:try_decode(iolist_to_binary(ResBody)) of
+        {ok, Map} -> Map;
+        _ -> #{}
+    end.

--- a/test/aws_auth_validate_tests.erl
+++ b/test/aws_auth_validate_tests.erl
@@ -1,0 +1,551 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% Unit tests for the auth-validation subsystem's pure modules: rate
+%% limiter, semaphore, registry, the LDAP backend's input parsing, and the
+%% LDAP query DSL parser (incl. upstream parity). The live bind/connect/TLS
+%% path lives in aws_auth_validate_ldap_SUITE; the HTTP pipeline (when added)
+%% lives in aws_auth_validate_mgmt_SUITE.
+-module(aws_auth_validate_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(IP1, {10, 0, 0, 1}).
+-define(IP2, {10, 0, 0, 2}).
+
+%%--------------------------------------------------------------------
+%% Rate limiter
+%%--------------------------------------------------------------------
+
+rate_limiter_test_() ->
+    {foreach,
+        fun() ->
+            {ok, Pid} = aws_auth_validate_rate_limiter:start_link(#{
+                window_ms => 60_000,
+                max_per_window => 3,
+                sweep_interval_ms => 60_000
+            }),
+            Pid
+        end,
+        fun stop/1, [
+            {"allows up to max then rejects", fun() ->
+                ?assertEqual(ok, aws_auth_validate_rate_limiter:check(?IP1)),
+                ?assertEqual(ok, aws_auth_validate_rate_limiter:check(?IP1)),
+                ?assertEqual(ok, aws_auth_validate_rate_limiter:check(?IP1)),
+                ?assertEqual(
+                    {error, rate_limited},
+                    aws_auth_validate_rate_limiter:check(?IP1)
+                )
+            end},
+            {"per-IP isolation", fun() ->
+                ok = aws_auth_validate_rate_limiter:check(?IP1),
+                ok = aws_auth_validate_rate_limiter:check(?IP1),
+                ok = aws_auth_validate_rate_limiter:check(?IP1),
+                ?assertEqual(
+                    {error, rate_limited},
+                    aws_auth_validate_rate_limiter:check(?IP1)
+                ),
+                ?assertEqual(ok, aws_auth_validate_rate_limiter:check(?IP2))
+            end},
+            {"reset clears counters", fun() ->
+                ok = aws_auth_validate_rate_limiter:check(?IP1),
+                ok = aws_auth_validate_rate_limiter:check(?IP1),
+                ok = aws_auth_validate_rate_limiter:check(?IP1),
+                ?assertEqual(
+                    {error, rate_limited},
+                    aws_auth_validate_rate_limiter:check(?IP1)
+                ),
+                ok = aws_auth_validate_rate_limiter:reset(),
+                ?assertEqual(ok, aws_auth_validate_rate_limiter:check(?IP1))
+            end}
+        ]}.
+
+rate_limiter_window_expiry_test_() ->
+    {setup,
+        fun() ->
+            {ok, Pid} = aws_auth_validate_rate_limiter:start_link(#{
+                window_ms => 50,
+                max_per_window => 1,
+                sweep_interval_ms => 60_000
+            }),
+            Pid
+        end,
+        fun stop/1, fun(_) ->
+            ok = aws_auth_validate_rate_limiter:check(?IP1),
+            ?assertEqual(
+                {error, rate_limited},
+                aws_auth_validate_rate_limiter:check(?IP1)
+            ),
+            timer:sleep(80),
+            [?_assertEqual(ok, aws_auth_validate_rate_limiter:check(?IP1))]
+        end}.
+
+%%--------------------------------------------------------------------
+%% Semaphore
+%%--------------------------------------------------------------------
+
+semaphore_test_() ->
+    {foreach,
+        fun() ->
+            {ok, Pid} = aws_auth_validate_semaphore:start_link(#{max => 2}),
+            Pid
+        end,
+        fun stop/1, [
+            {"acquire/release sequence", fun() ->
+                {ok, R1} = aws_auth_validate_semaphore:acquire(),
+                {ok, R2} = aws_auth_validate_semaphore:acquire(),
+                ?assertEqual({error, full}, aws_auth_validate_semaphore:acquire()),
+                ok = aws_auth_validate_semaphore:release(R1),
+                {ok, R3} = aws_auth_validate_semaphore:acquire(),
+                ok = aws_auth_validate_semaphore:release(R2),
+                ok = aws_auth_validate_semaphore:release(R3),
+                ?assertEqual(0, aws_auth_validate_semaphore:current())
+            end}
+        ]}.
+
+semaphore_crashed_holder_test_() ->
+    {setup,
+        fun() ->
+            {ok, Pid} = aws_auth_validate_semaphore:start_link(#{max => 1}),
+            Pid
+        end,
+        fun stop/1, fun(_) ->
+            Self = self(),
+            Worker = spawn(fun() ->
+                {ok, _Ref} = aws_auth_validate_semaphore:acquire(),
+                Self ! acquired,
+                receive
+                    die -> exit(boom)
+                end
+            end),
+            receive
+                acquired -> ok
+            after 1_000 -> ?assert(false)
+            end,
+            ?assertEqual({error, full}, aws_auth_validate_semaphore:acquire()),
+            Worker ! die,
+            wait_until_zero(50),
+            [?_assertMatch({ok, _}, aws_auth_validate_semaphore:acquire())]
+        end}.
+
+%%--------------------------------------------------------------------
+%% ARN resolution lock
+%%--------------------------------------------------------------------
+
+arn_lock_test_() ->
+    {foreach,
+        fun() ->
+            {ok, Pid} = aws_auth_validate_arn_lock:start_link(),
+            Pid
+        end,
+        fun stop/1, [
+            {"returns the closure's value", fun() ->
+                ?assertEqual(42, aws_auth_validate_arn_lock:with_lock(fun() -> 42 end))
+            end},
+            {"serializes concurrent callers (no interleaving)", fun() ->
+                %% Each closure marks the lock busy on entry and clears it on
+                %% exit; if two ran concurrently one would observe busy=true.
+                %% A shared ets table records whether overlap was ever seen.
+                T = ets:new(arn_lock_probe, [public, set]),
+                ets:insert(T, {busy, false}),
+                ets:insert(T, {overlap, false}),
+                Self = self(),
+                Run = fun() ->
+                    aws_auth_validate_arn_lock:with_lock(fun() ->
+                        case ets:lookup(T, busy) of
+                            [{busy, true}] -> ets:insert(T, {overlap, true});
+                            _ -> ok
+                        end,
+                        ets:insert(T, {busy, true}),
+                        timer:sleep(15),
+                        ets:insert(T, {busy, false}),
+                        ok
+                    end),
+                    Self ! done
+                end,
+                Pids = [spawn(Run) || _ <- lists:seq(1, 5)],
+                [
+                    receive
+                        done -> ok
+                    after 5_000 -> ?assert(false)
+                    end
+                 || _ <- Pids
+                ],
+                ?assertEqual([{overlap, false}], ets:lookup(T, overlap)),
+                ets:delete(T)
+            end},
+            {"re-raises the closure's exception in the caller", fun() ->
+                ?assertError(
+                    boom,
+                    aws_auth_validate_arn_lock:with_lock(fun() -> erlang:error(boom) end)
+                )
+            end},
+            {"survives a crashing closure (next call still works)", fun() ->
+                catch aws_auth_validate_arn_lock:with_lock(fun() -> erlang:error(boom) end),
+                ?assertEqual(ok, aws_auth_validate_arn_lock:with_lock(fun() -> ok end))
+            end}
+        ]}.
+
+%%--------------------------------------------------------------------
+%% Registry
+%%--------------------------------------------------------------------
+
+registry_unknown_method_test() ->
+    ?assertEqual(
+        {error, unknown_method},
+        aws_auth_validate_registry:dispatch(<<"nope">>, #{})
+    ).
+
+registry_method_disabled_test_() ->
+    {setup,
+        fun() ->
+            application:set_env(
+                aws,
+                auth_validation_enabled_methods,
+                [{<<"ldap">>, false}]
+            )
+        end,
+        fun(_) ->
+            application:unset_env(aws, auth_validation_enabled_methods)
+        end,
+        [
+            ?_assertEqual(
+                {error, method_disabled},
+                aws_auth_validate_registry:dispatch(<<"ldap">>, #{})
+            )
+        ]}.
+
+registry_field_filter_override_test_() ->
+    {setup,
+        fun() ->
+            application:set_env(
+                aws,
+                {auth_validation_allowed_fields_override, <<"ldap">>},
+                [<<"servers">>, <<"port">>, <<"unknown">>]
+            )
+        end,
+        fun(_) ->
+            application:unset_env(
+                aws,
+                {auth_validation_allowed_fields_override, <<"ldap">>}
+            )
+        end,
+        [
+            fun() ->
+                Effective = aws_auth_validate_registry:effective_allowed_fields(
+                    aws_auth_validate_ldap, <<"ldap">>
+                ),
+                ?assert(lists:member(<<"servers">>, Effective)),
+                ?assert(lists:member(<<"port">>, Effective)),
+                ?assertNot(lists:member(<<"unknown">>, Effective))
+            end
+        ]}.
+
+%%--------------------------------------------------------------------
+%% LDAP backend (input parsing only - the real bind path needs slapd)
+%%--------------------------------------------------------------------
+
+ldap_method_name_test() ->
+    ?assertEqual(<<"ldap">>, aws_auth_validate_ldap:method_name()).
+
+ldap_allowed_fields_test() ->
+    Fields = aws_auth_validate_ldap:allowed_fields(),
+    [
+        ?assert(lists:member(F, Fields))
+     || F <- [
+            <<"servers">>,
+            <<"port">>,
+            <<"user_dn">>,
+            <<"password_arn">>,
+            <<"use_ssl">>,
+            <<"use_starttls">>,
+            <<"ssl_options">>,
+            <<"dn_lookup_base">>,
+            <<"dn_lookup_attribute">>,
+            <<"queries">>
+        ]
+    ].
+
+%% These all fail in the pure (network-free) validation pipeline, before any
+%% password ARN resolution or outbound connection is attempted.
+ldap_input_validation_test_() ->
+    [
+        ?_assertMatch(
+            {error, input_invalid, _},
+            aws_auth_validate_ldap:validate(
+                #{<<"port">> => 389, <<"user_dn">> => <<"u">>}
+            )
+        ),
+        ?_assertMatch(
+            {error, input_invalid, _},
+            aws_auth_validate_ldap:validate(base_body(#{<<"servers">> => []}))
+        ),
+        ?_assertMatch(
+            {error, input_invalid, _},
+            aws_auth_validate_ldap:validate(base_body(#{<<"port">> => 0}))
+        ),
+        ?_assertMatch(
+            {error, input_invalid, _},
+            aws_auth_validate_ldap:validate(base_body(#{<<"port">> => 65536}))
+        ),
+        ?_assertMatch(
+            {error, input_invalid, _},
+            aws_auth_validate_ldap:validate(base_body(#{<<"user_dn">> => <<>>}))
+        ),
+        ?_assertMatch(
+            {error, input_invalid, _},
+            aws_auth_validate_ldap:validate(base_body(#{<<"ssl_options">> => <<"x">>}))
+        )
+    ].
+
+ldap_config_conflict_test() ->
+    Body = base_body(#{<<"use_ssl">> => true, <<"use_starttls">> => true}),
+    ?assertMatch({error, config_conflict, _}, aws_auth_validate_ldap:validate(Body)).
+
+%%--------------------------------------------------------------------
+%% DN lookup + authorization query input validation (pure pipeline)
+%%--------------------------------------------------------------------
+
+ldap_dn_lookup_input_test_() ->
+    [
+        %% Wrong types for the optional DN-lookup fields are rejected.
+        ?_assertMatch(
+            {error, input_invalid, _},
+            aws_auth_validate_ldap:validate(base_body(#{<<"dn_lookup_base">> => 123}))
+        ),
+        ?_assertMatch(
+            {error, input_invalid, _},
+            aws_auth_validate_ldap:validate(base_body(#{<<"dn_lookup_base">> => <<>>}))
+        ),
+        ?_assertMatch(
+            {error, input_invalid, _},
+            aws_auth_validate_ldap:validate(base_body(#{<<"dn_lookup_attribute">> => 1}))
+        )
+    ].
+
+ldap_queries_input_test_() ->
+    [
+        %% queries must be an object.
+        ?_assertMatch(
+            {error, input_invalid, _},
+            aws_auth_validate_ldap:validate(base_body(#{<<"queries">> => <<"nope">>}))
+        ),
+        %% A non-string query value is a shape error.
+        ?_assertMatch(
+            {error, input_invalid, _},
+            aws_auth_validate_ldap:validate(
+                base_body(#{<<"queries">> => #{<<"tags">> => 123}})
+            )
+        ),
+        %% A syntactically invalid query string is query_invalid (400).
+        ?_assertMatch(
+            {error, query_invalid, _},
+            aws_auth_validate_ldap:validate(
+                base_body(#{<<"queries">> => #{<<"vhost_access">> => <<"{garbage,">>}})
+            )
+        ),
+        %% A grammatically-valid query that references a disallowed top-level
+        %% term is also query_invalid.
+        ?_assertMatch(
+            {error, query_invalid, _},
+            aws_auth_validate_ldap:validate(
+                base_body(#{<<"queries">> => #{<<"tags">> => <<"{bogus_term, 1, 2}">>}})
+            )
+        )
+    ].
+
+%%--------------------------------------------------------------------
+%% LDAP query DSL parser (aws_auth_validate_ldap_query)
+%%--------------------------------------------------------------------
+
+parse_accepts_test_() ->
+    [
+        ?_assertMatch({ok, _}, aws_auth_validate_ldap_query:parse(Q))
+     || Q <- accepted_queries()
+    ].
+
+parse_rejects_test_() ->
+    [
+        ?_assertMatch({error, _}, aws_auth_validate_ldap_query:parse(Q))
+     || Q <- rejected_queries()
+    ].
+
+parse_accepts_string_input_test() ->
+    ?assertMatch({ok, _}, aws_auth_validate_ldap_query:parse("{constant, true}")).
+
+%% Literal DN extraction (the placeholder-free DNs used for static reachability)
+
+literal_dns_in_group_test() ->
+    {ok, Q} = aws_auth_validate_ldap_query:parse(
+        <<"{in_group, \"cn=admins,ou=groups,dc=example,dc=com\"}">>
+    ),
+    ?assertEqual(
+        ["cn=admins,ou=groups,dc=example,dc=com"],
+        aws_auth_validate_ldap_query:literal_dns(Q)
+    ).
+
+literal_dns_skips_placeholder_test() ->
+    %% A DN with a ${...} placeholder is runtime-filled, not literal, so it
+    %% contributes no static reachability check.
+    {ok, Q} = aws_auth_validate_ldap_query:parse(
+        <<"{in_group, \"cn=${username},ou=groups,dc=example,dc=com\"}">>
+    ),
+    ?assertEqual([], aws_auth_validate_ldap_query:literal_dns(Q)).
+
+literal_dns_constant_test() ->
+    {ok, Q} = aws_auth_validate_ldap_query:parse(<<"{constant, true}">>),
+    ?assertEqual([], aws_auth_validate_ldap_query:literal_dns(Q)).
+
+literal_dns_nested_and_or_test() ->
+    {ok, Q} = aws_auth_validate_ldap_query:parse(
+        <<"{'or', [{in_group, \"cn=a,dc=x\"}, {'and', [{in_group, \"cn=b,dc=x\"}]}]}">>
+    ),
+    ?assertEqual(
+        ["cn=a,dc=x", "cn=b,dc=x"],
+        aws_auth_validate_ldap_query:literal_dns(Q)
+    ).
+
+literal_dns_tag_queries_test() ->
+    {ok, Q} = aws_auth_validate_ldap_query:parse(
+        <<"[{administrator, {in_group, \"cn=admins,dc=x\"}}, {management, {constant, true}}]">>
+    ),
+    ?assertEqual(["cn=admins,dc=x"], aws_auth_validate_ldap_query:literal_dns(Q)).
+
+literal_dns_exists_test() ->
+    %% parse/1 rejects {exists,_} (parse_query/1 does not allow it), but
+    %% literal_dns/1 still walks the term defensively, so test it on a
+    %% directly-constructed term rather than via parse/1.
+    ?assertEqual(
+        ["ou=users,dc=x"],
+        aws_auth_validate_ldap_query:literal_dns({exists, "ou=users,dc=x"})
+    ).
+
+literal_dns_for_test() ->
+    {ok, Q} = aws_auth_validate_ldap_query:parse(
+        <<"{for, [{permission, configure, {in_group, \"cn=cfg,dc=x\"}}]}">>
+    ),
+    ?assertEqual(["cn=cfg,dc=x"], aws_auth_validate_ldap_query:literal_dns(Q)).
+
+%% Parity with rabbit_auth_backend_ldap_util:parse_query/1 (design req R12).
+%% The broker's parser throws via cuttlefish:invalid/2 on rejection; ours
+%% returns {error, _}. Assert both classify each corpus entry the same way.
+%%
+%% Runs only when upstream parse_query/1 is actually usable in this node.
+%% It is not enough that the module loads: parse_query/1 calls
+%% rabbit_data_coercion (and cuttlefish:invalid on rejection), and across
+%% the RMQ-version CI matrix those deps are not always loaded in the bare
+%% eunit node. If they are missing, every parse_query/1 call throws undef
+%% and upstream_accepts/1 would report "rejected" for EVERYTHING, making the
+%% test fail spuriously. So we probe upstream with a known-good and a
+%% known-bad query first and skip the whole parity check unless upstream
+%% classifies both correctly.
+parity_test_() ->
+    case upstream_parser_usable() of
+        true ->
+            [
+                {
+                    binary_to_list(Q),
+                    ?_assertEqual(upstream_accepts(Q), ours_accepts(Q))
+                }
+             || Q <- accepted_queries() ++ rejected_queries()
+            ];
+        false ->
+            []
+    end.
+
+%% True only if rabbit_auth_backend_ldap_util:parse_query/1 is loaded AND its
+%% transitive deps are available, verified by a positive+negative probe.
+upstream_parser_usable() ->
+    code:ensure_loaded(rabbit_auth_backend_ldap_util) =/= {error, nofile} andalso
+        erlang:function_exported(rabbit_auth_backend_ldap_util, parse_query, 1) andalso
+        upstream_accepts(<<"{constant, true}">>) andalso
+        not upstream_accepts(<<"{bogus_term, 1, 2}">>).
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+stop(Pid) ->
+    unlink(Pid),
+    exit(Pid, kill),
+    timer:sleep(10),
+    ok.
+
+wait_until_zero(0) ->
+    ?assertEqual(0, aws_auth_validate_semaphore:current());
+wait_until_zero(N) ->
+    case aws_auth_validate_semaphore:current() of
+        0 ->
+            ok;
+        _ ->
+            timer:sleep(10),
+            wait_until_zero(N - 1)
+    end.
+
+%% A minimally-valid body for the pure validation pipeline. Note: the tests
+%% that use this assert failures triggered *before* password_arn resolution,
+%% so the ARN here is never resolved (no AWS call is made).
+base_body(Overrides) when is_map(Overrides) ->
+    Base = #{
+        <<"servers">> => [<<"127.0.0.1">>],
+        <<"port">> => 389,
+        <<"user_dn">> => <<"cn=u">>,
+        <<"password_arn">> => <<"arn:aws:secretsmanager:us-east-1:111111111111:secret:x">>
+    },
+    maps:merge(Base, Overrides).
+
+%% Query corpus shared by the parser accept/reject tests and the parity test.
+
+%% Queries the broker accepts. Kept in sync with the parity test.
+accepted_queries() ->
+    [
+        <<"{constant, true}">>,
+        <<"{constant, false}">>,
+        <<"{in_group, \"cn=admins,ou=groups,dc=example,dc=com\"}">>,
+        <<"{in_group_nested, \"cn=g,dc=example,dc=com\", \"member\"}">>,
+        <<"{'not', {constant, true}}">>,
+        <<"{'and', [{constant, true}, {constant, false}]}">>,
+        <<"{'or', [{constant, true}, {constant, false}]}">>,
+        <<"{equals, \"${username}\", \"admin\"}">>,
+        <<"{match, \"${username}\", \"^a.*\"}">>,
+        <<"{for, [{permission, configure, {constant, true}}]}">>,
+        %% tag_queries form: a list of {Tag, SubQuery} pairs.
+        <<"[{administrator, {in_group, \"cn=admins,dc=example,dc=com\"}}]">>,
+        %% trailing dot already present
+        <<"{constant, true}.">>,
+        %% A bare quoted string parses to an Erlang list, so it hits the
+        %% is_list/1 (tag_queries) clause in BOTH parsers. Included here to
+        %% pin that parity quirk rather than to endorse it as a useful query.
+        <<"\"just a string\"">>
+    ].
+
+rejected_queries() ->
+    [
+        <<"{garbage,">>,
+        <<"not even erlang">>,
+        <<"{bogus_term, 1, 2}">>,
+        <<"42">>,
+        <<>>,
+        %% Forms the runtime evaluator handles but parse_query/1 (the config
+        %% gate we mirror) rejects, so the endpoint rejects them too.
+        <<"{in_group, \"cn=g,dc=example,dc=com\", \"member\"}">>,
+        <<"{exists, \"ou=users,dc=example,dc=com\"}">>,
+        <<"{attribute, \"cn=g,dc=example,dc=com\", \"member\"}">>
+    ].
+
+ours_accepts(Q) ->
+    case aws_auth_validate_ldap_query:parse(Q) of
+        {ok, _} -> true;
+        {error, _} -> false
+    end.
+
+upstream_accepts(Q) ->
+    try rabbit_auth_backend_ldap_util:parse_query(Q) of
+        %% cuttlefish:invalid/2 throws on rejection; any throw/exit means the
+        %% upstream parser rejected the query.
+        _ -> true
+    catch
+        _:_ -> false
+    end.

--- a/test/config_schema_SUITE_data/aws.snippets
+++ b/test/config_schema_SUITE_data/aws.snippets
@@ -100,5 +100,45 @@
             ]}
          ]}
         ],
-        [aws_arn_config]}
+        [aws_arn_config]},
+
+    {aws_auth_validation_enabled,
+        "aws.auth_validation.enabled = true",
+        [{aws, [{auth_validation_enabled, true}]}],
+        [aws_auth_validation_enabled]},
+
+    {aws_auth_validation_max_concurrent,
+        "aws.auth_validation.max_concurrent = 8",
+        [{aws, [{auth_validation_max_concurrent, 8}]}],
+        [aws_auth_validation_max_concurrent]},
+
+    {aws_auth_validation_max_body_size,
+        "aws.auth_validation.max_body_size = 32768",
+        [{aws, [{auth_validation_max_body_size, 32768}]}],
+        [aws_auth_validation_max_body_size]},
+
+    {aws_auth_validation_connection_timeout_ms,
+        "aws.auth_validation.connection_timeout_ms = 7000",
+        [{aws, [{auth_validation_connection_timeout_ms, 7000}]}],
+        [aws_auth_validation_connection_timeout_ms]},
+
+    {aws_auth_validation_rate_limit_window_seconds,
+        "aws.auth_validation.rate_limit.window_seconds = 30",
+        [{aws, [{auth_validation_rate_limit_window_seconds, 30}]}],
+        [aws_auth_validation_rate_limit_window_seconds]},
+
+    {aws_auth_validation_rate_limit_max_requests,
+        "aws.auth_validation.rate_limit.max_requests = 25",
+        [{aws, [{auth_validation_rate_limit_max_requests, 25}]}],
+        [aws_auth_validation_rate_limit_max_requests]},
+
+    {aws_auth_validation_required_user_tag,
+        "aws.auth_validation.required_user_tag = monitoring",
+        [{aws, [{auth_validation_required_user_tag, monitoring}]}],
+        [aws_auth_validation_required_user_tag]},
+
+    {aws_auth_validation_enabled_methods,
+        "aws.auth_validation.enabled_methods.ldap = true",
+        [{aws, [{auth_validation_enabled_methods, [{<<"ldap">>, true}]}]}],
+        [aws_auth_validation_enabled_methods]}
 ].


### PR DESCRIPTION
*Issue #43*

*Revision of PR #46 (cleaner commit history)*

Allow customers to conveniently validate their LDAP broker configs via /api/aws/auth/validate/ldap with more descriptive (but safe) error messages instead of blindly guessing error causes, changing the config, and restarting the broker (~30 min per restart)

This endpoint is extensible for other forms of auth (HTTP/OAuth), however this PR focuses on solely implementing LDAP.

### Core subsystem (src/aws_auth_validate_*)
  - aws_auth_validate_mgmt -- Cowboy REST handler for PUT /api/aws/auth/validate/:method; pipeline: feature toggle → admin auth → per-IP rate limit → body-size cap → JSON decode → concurrency semaphore → registry dispatch → audit log → response.
  - aws_auth_validate_registry -- method → backend dispatch with per-method enable flags and request-field filtering.
  - aws_auth_validate_backend -- behaviour (method_name/0, validate/1, allowed_fields/0).
  - aws_auth_validate_ldap -- LDAP backend: ephemeral eldap connect → optional StartTLS → simple bind → optional post-bind DN-lookup + authorization-query checks. All outcomes collapse to fixed response categories (no credential/LDAP detail leakage).
  - aws_auth_validate_ldap_query -- self-contained parser for the authz query DSL, mirroring rabbit_auth_backend_ldap_util:parse_query/1 exactly (R12 parity).
  - aws_auth_validate_rate_limiter / aws_auth_validate_semaphore -- supervised gen_servers, started by aws_sup only when the feature is enabled.
  - aws_auth_validate_arn_lock -- supervised gen_server mutex that serializes ARN resolution. Meant to prevent region-clobbering with the global AWS credential state when resolving password/cacertfile ARNs via the validation endpoint.

### Config (priv/schema/aws.schema, aws_sup)
  - aws.auth_validation.* cuttlefish settings (toggle, body size, concurrency, rate limit, timeout, user tag); workers conditionally supervised.
  - Defaults are applied in code, not declared as schema defaults, so they aren't emitted into every generated config (keeps config_schema_SUITE snippets exact).
  
### Tests
  - aws_auth_validate_tests (eunit): rate limiter, semaphore, ARN lock (value pass-through, serialization under concurrent callers, exception re-raise, survival of a crashing closure), registry, LDAP input validation, and query-parser + upstream-parity tests.
  - aws_auth_validate_mgmt_SUITE (CT): the HTTP pipeline (auth, rate limit, body cap, semaphore, dispatch, response mapping) without a live LDAP server.
  - aws.snippets: config-schema coverage for the new settings.

### Response contract
  All failures return a fixed {"error": "<category>", "message": "<constant>"} -- never raw LDAP errors, hostnames, DNs, or the resolved password.
  Categories: input_invalid / connection_failed / tls_failed / query_invalid (400), auth_failed / config_conflict / authz_unverified (422), plus pipeline-level insufficient_user_tag (401), unknown_method / method_disabled (404), rate_limited (429), capacity_exhausted (503).

### Security notes
  - Endpoint disabled by default; admin-tag gated.
  - Ephemeral connections only -- no broker/auth-backend state mutation.
  - password_arn is resolved (via the plugin's existing ARN machinery) only after all pure input validation passes, so malformed requests never trigger a secret fetch. Resolution is serialized by aws_auth_validate_arn_lock so concurrent validations cannot clobber the shared client's region mid-resolution.
  - assume_role is deliberately not accepted (it would let a request swap the broker's global AWS credentials -- confused-deputy).

### Excluded from this PR
- Integration tests to prevent divergence from the real LDAP auth backend
