### PR TITLE
Block fc00::/7 and IPv4-mapped IMDS in the SSRF filter

### DIFF
--- a/src/aws_auth_validate_ldap.erl
+++ b/src/aws_auth_validate_ldap.erl
@@ -467,9 +467,27 @@ is_private_ip({169, 254, _, _}) -> true;
 is_private_ip({0, _, _, _}) -> true;
 is_private_ip(_) -> false.
 
+%% Block the IPv6 ranges that correspond to the v4 blocks above, so the filter
+%% cannot be bypassed by handing the endpoint a v6 (or v6-encoded) address.
+%%   ::1            loopback
+%%   ::             unspecified
+%%   fc00::/7       unique local addresses (ULA). Includes the IPv6 IMDS
+%%                  address fd00:ec2::254 -- the whole point of this block.
+%%   fe80::/10      link-local (spans fe80..febf, NOT just fe80)
+%% IPv4-mapped (::ffff:a.b.c.d) and IPv4-compatible (::a.b.c.d) addresses embed
+%% a v4 address in the low 32 bits; re-check those against the v4 ranges so e.g.
+%% ::ffff:169.254.169.254 cannot reach IMDS.
 is_private_ip6({0, 0, 0, 0, 0, 0, 0, 1}) -> true;
-is_private_ip6({16#fe80, _, _, _, _, _, _, _}) -> true;
+is_private_ip6({0, 0, 0, 0, 0, 0, 0, 0}) -> true;
+is_private_ip6({W1, _, _, _, _, _, _, _}) when W1 >= 16#fc00, W1 =< 16#fdff -> true;
+is_private_ip6({W1, _, _, _, _, _, _, _}) when W1 >= 16#fe80, W1 =< 16#febf -> true;
+is_private_ip6({0, 0, 0, 0, 0, 16#ffff, W7, W8}) -> is_private_ip(v6_words_to_v4(W7, W8));
+is_private_ip6({0, 0, 0, 0, 0, 0, W7, W8}) -> is_private_ip(v6_words_to_v4(W7, W8));
 is_private_ip6(_) -> false.
+
+%% Split the low 32 bits of a v4-mapped/compatible v6 address into a v4 tuple.
+v6_words_to_v4(W7, W8) ->
+    {W7 bsr 8, W7 band 16#ff, W8 bsr 8, W8 band 16#ff}.
 
 %%--------------------------------------------------------------------
 %% Config conflict

--- a/test/aws_auth_validate_tests.erl
+++ b/test/aws_auth_validate_tests.erl
@@ -198,6 +198,26 @@ server_blocks_rfc1918_192_test() ->
 server_blocks_zero_network_test() ->
     ?assertEqual(false, aws_auth_validate_ldap:is_allowed_server("0.0.0.0")).
 
+server_blocks_ipv6_loopback_test() ->
+    ?assertEqual(false, aws_auth_validate_ldap:is_allowed_server("::1")).
+
+%% fc00::/7 (ULA). fd00:ec2::254 is the IPv6 IMDS address -- the SSRF filter
+%% must block it just like the v4 169.254.169.254.
+server_blocks_ipv6_imds_test() ->
+    ?assertEqual(false, aws_auth_validate_ldap:is_allowed_server("fd00:ec2::254")).
+
+server_blocks_ipv6_ula_test() ->
+    ?assertEqual(false, aws_auth_validate_ldap:is_allowed_server("fc00::1")).
+
+%% fe80::/10 spans fe80..febf, not just the fe80 word.
+server_blocks_ipv6_link_local_test() ->
+    ?assertEqual(false, aws_auth_validate_ldap:is_allowed_server("fe80::1")),
+    ?assertEqual(false, aws_auth_validate_ldap:is_allowed_server("febf::1")).
+
+%% An IPv4-mapped v6 address embedding IMDS must not bypass the v4 ranges.
+server_blocks_ipv4_mapped_imds_test() ->
+    ?assertEqual(false, aws_auth_validate_ldap:is_allowed_server("::ffff:169.254.169.254")).
+
 server_rejects_unresolvable_test() ->
     ?assertEqual(
         false, aws_auth_validate_ldap:is_allowed_server("this.host.does.not.exist.invalid")


### PR DESCRIPTION
  Addresses @the-mikedavis's PR #55 review: the IPv6 side of the SSRF
  filter was too narrow and let the IPv6 IMDS address through.

  is_private_ip6/1 only matched ::1 and an EXACT fe80 word, so:
  - fc00::/7 (unique local addresses) was not blocked at all -- including the IPv6 IMDS address fd00:ec2::254, the metadata endpoint this filter exists to protect.
  - link-local was under-blocked: fe80::/10 spans fe80..febf, but only the literal fe80 word matched (febf::1 slipped through).
  - IPv4-mapped (::ffff:a.b.c.d) and IPv4-compatible (::a.b.c.d) addresses bypassed the filter entirely, so ::ffff:169.254.169.254 could reach v4 IMDS despite the v4 block.

  Block ::1, ::, fc00::/7, and fe80::/10 by range, and decode the low 32
  bits of v4-mapped/compatible addresses back through the v4 ranges.

  Tests: add coverage for ::1, fd00:ec2::254, fc00::1, fe80::1/febf::1, and
  ::ffff:169.254.169.254.