### PR TITLE
Close the SSRF DNS-rebinding TOCTOU with a post-connect peer check

### DIFF
--- a/src/aws_auth_validate_ldap.erl
+++ b/src/aws_auth_validate_ldap.erl
@@ -46,8 +46,9 @@
 
 -ifdef(TEST).
 %% Exposed for unit tests: build_ssl_opts/1 translates validated ssl_options
-%% to the eldap proplist and is otherwise internal.
--export([build_ssl_opts/1, is_allowed_server/1]).
+%% to the eldap proplist; peer_allowed/1 is the post-connect SSRF re-check on a
+%% peername result. Both are otherwise internal.
+-export([build_ssl_opts/1, is_allowed_server/1, peer_allowed/1]).
 -endif.
 
 -include_lib("eldap/include/eldap.hrl").
@@ -429,17 +430,16 @@ is_nonempty_binary(B) -> is_binary(B) andalso byte_size(B) > 0.
 %% Bypassed when auth_validation_allow_private_networks is true (for testing
 %% against local slapd instances).
 %%
-%% KNOWN LIMITATION (DNS-rebinding TOCTOU): this check resolves Server and
-%% inspects the resulting IP, but eldap:open/2 is later handed the original
-%% hostname STRING and re-resolves it independently. An attacker who controls
-%% DNS for the hostname could answer with a public IP here and a blocked
-%% (private/metadata) IP at connect time, bypassing the filter. The window is
-%% small and exploitation requires control of the hostname's DNS. Closing it
-%% fully would mean resolving once and passing the vetted IP literal to
-%% eldap:open (which weakens TLS hostname verification / SNI) or pinning DNS
-%% across both calls; both are larger changes deferred as a follow-up. The
-%% admin-only gating and disabled-by-default posture keep the residual risk
-%% low. See gap_analysis.md.
+%% This is the FIRST of two SSRF checks (defence in depth). It resolves Server
+%% and rejects a blocked IP before any connection is attempted, so a malformed
+%% or obviously-internal target never opens a socket. On its own it is subject
+%% to a DNS-rebinding TOCTOU -- eldap:open/2 re-resolves the hostname, so the
+%% peer it connects to could differ from the IP vetted here. That window is
+%% closed by the SECOND check, verify_connected_peer/1, which re-validates the
+%% actual connected socket's peer (see do_ldap_bind/1). We keep this pre-connect
+%% check too: it rejects bad input cheaply (no socket, clearer input_invalid
+%% category) and avoids dialing out for the common case. Both checks are
+%% bypassed under auth_validation_allow_private_networks for local-slapd tests.
 is_allowed_server(Server) ->
     case application:get_env(aws, auth_validation_allow_private_networks, false) of
         true -> true;
@@ -543,19 +543,65 @@ do_ldap_bind(
             {error, connection_failed, ?REASON_CONNECTION};
         {ok, Handle} ->
             try
-                case maybe_start_tls(Handle, UseStartTls, SslOpts, Timeout) of
-                    {error, _Reason} ->
-                        {error, tls_failed, ?REASON_TLS_HANDSHAKE};
+                %% SSRF (R4): close the DNS-rebinding window. parse_servers/2's
+                %% is_allowed_server/1 vetted a resolved IP, but eldap re-resolved
+                %% the hostname for this connection, so the peer we are actually
+                %% attached to may differ (DNS rebinding). Re-check the *real*
+                %% connected peer -- the exact socket every later operation
+                %% (start_tls, bind, search) runs over -- before sending anything.
+                %% A blocked peer collapses to connection_failed (indistinguishable
+                %% from an unreachable host, so it leaks no recon signal).
+                case verify_connected_peer(Handle) of
+                    blocked ->
+                        {error, connection_failed, ?REASON_CONNECTION};
                     ok ->
-                        case eldap:simple_bind(Handle, UserDn, Password) of
-                            ok -> post_bind_checks(Handle, Params);
-                            {error, _Reason} -> {error, auth_failed, ?REASON_AUTH}
+                        case maybe_start_tls(Handle, UseStartTls, SslOpts, Timeout) of
+                            {error, _Reason} ->
+                                {error, tls_failed, ?REASON_TLS_HANDSHAKE};
+                            ok ->
+                                case eldap:simple_bind(Handle, UserDn, Password) of
+                                    ok -> post_bind_checks(Handle, Params);
+                                    {error, _Reason} -> {error, auth_failed, ?REASON_AUTH}
+                                end
                         end
                 end
             after
                 catch eldap:close(Handle)
             end
     end.
+
+%% Re-validate the IP eldap actually connected to, closing the DNS-rebinding
+%% TOCTOU between is_allowed_server/1 (pre-connect, on a resolved IP) and this
+%% live socket. Reads the peer from the open handle rather than re-resolving the
+%% hostname, so what we check is exactly what we will talk to. Bypassed under
+%% auth_validation_allow_private_networks (local-slapd testing), matching
+%% is_allowed_server/1. Fails closed: if the peer cannot be determined, treat it
+%% as blocked.
+verify_connected_peer(Handle) ->
+    case application:get_env(aws, auth_validation_allow_private_networks, false) of
+        true -> ok;
+        _ -> check_peer_ip(Handle)
+    end.
+
+check_peer_ip(Handle) ->
+    case eldap:info(Handle) of
+        #{socket := Sock, socket_type := ssl} -> peer_allowed(ssl:peername(Sock));
+        #{socket := Sock, socket_type := tcp} -> peer_allowed(inet:peername(Sock));
+        _ -> blocked
+    end.
+
+peer_allowed({ok, {IP, _Port}}) when tuple_size(IP) =:= 4 ->
+    case is_private_ip(IP) of
+        true -> blocked;
+        false -> ok
+    end;
+peer_allowed({ok, {IP, _Port}}) when tuple_size(IP) =:= 8 ->
+    case is_private_ip6(IP) of
+        true -> blocked;
+        false -> ok
+    end;
+peer_allowed(_) ->
+    blocked.
 
 %% After a successful bind, run the optional DN-lookup and authorization
 %% checks in sequence on the same bound handle. The first failure wins; if

--- a/test/aws_auth_validate_tests.erl
+++ b/test/aws_auth_validate_tests.erl
@@ -223,6 +223,41 @@ server_rejects_unresolvable_test() ->
         false, aws_auth_validate_ldap:is_allowed_server("this.host.does.not.exist.invalid")
     ).
 
+%%--------------------------------------------------------------------
+%% Post-connect peer re-check (DNS-rebinding TOCTOU defence)
+%%--------------------------------------------------------------------
+
+%% peer_allowed/1 takes a peername/1 result ({ok, {IP, Port}}) and is the
+%% second SSRF gate: it runs on the live socket's peer, so even if the
+%% pre-connect is_allowed_server/1 was passed a public IP, a peer that rebound
+%% to a blocked range is caught here.
+peer_allowed_public_v4_ok_test() ->
+    ?assertEqual(ok, aws_auth_validate_ldap:peer_allowed({ok, {{8, 8, 8, 8}, 636}})).
+
+peer_allowed_rebound_to_imds_blocked_test() ->
+    ?assertEqual(
+        blocked, aws_auth_validate_ldap:peer_allowed({ok, {{169, 254, 169, 254}, 80}})
+    ).
+
+peer_allowed_private_v4_blocked_test() ->
+    ?assertEqual(blocked, aws_auth_validate_ldap:peer_allowed({ok, {{10, 0, 0, 5}, 389}})).
+
+peer_allowed_public_v6_ok_test() ->
+    ?assertEqual(
+        ok, aws_auth_validate_ldap:peer_allowed({ok, {{16#2606, 16#4700, 0, 0, 0, 0, 0, 1}, 636}})
+    ).
+
+%% fd00:ec2::254 (IPv6 IMDS) reached as the live peer must be blocked.
+peer_allowed_rebound_to_v6_imds_blocked_test() ->
+    ?assertEqual(
+        blocked,
+        aws_auth_validate_ldap:peer_allowed({ok, {{16#fd00, 16#0ec2, 0, 0, 0, 0, 0, 16#254}, 636}})
+    ).
+
+%% Fail closed: an undeterminable peer (peername error) is treated as blocked.
+peer_allowed_error_blocked_test() ->
+    ?assertEqual(blocked, aws_auth_validate_ldap:peer_allowed({error, einval})).
+
 ldap_validate_rejects_private_server_test() ->
     Body = base_body(#{<<"servers">> => [<<"169.254.169.254">>]}),
     ?assertMatch({error, input_invalid, _}, aws_auth_validate_ldap:validate(Body)).


### PR DESCRIPTION
  is_allowed_server/1 resolves the hostname and vets the IP before
  connecting, but eldap:open/2 re-resolves the hostname independently, so
  an attacker controlling the hostname's DNS could answer with a public IP
  at check time and a blocked (private/metadata) IP at connect time --
  reaching IMDS or internal services through the endpoint. The pre-connect
  filter cannot see the address eldap actually dials.

  Add a second check, verify_connected_peer/1, run immediately after
  eldap:open succeeds and before any data is sent (start_tls, bind,
  search). It reads the real connected peer from the handle via
  eldap:info/1 + ssl:peername/1 | inet:peername/1 and re-runs the same
  is_private_ip/is_private_ip6 range checks on it. Because it inspects the
  live socket rather than re-resolving, the peer it validates is exactly
  the one every later operation uses, so the rebinding window is closed.

  A blocked peer collapses to connection_failed -- indistinguishable from
  an unreachable host, leaking no reconnaissance signal. Fails closed: an
  undeterminable peer is treated as blocked. Bypassed under
  auth_validation_allow_private_networks, matching the pre-connect filter,
  so local-slapd tests are unaffected.

  The pre-connect filter is kept as cheap defence in depth: it rejects bad
  input as input_invalid without opening a socket and avoids dialing out
  for obviously-internal targets.

  Chose this over pinning the vetted IP into eldap:open: eldap shares one
  TLS option set across all hosts and OTP would switch the cert reference
  ID to {ip, _}, breaking hostname verification / SNI. Checking the live
  peer closes the window without touching TLS identity checking.

  Tests: peer_allowed/1 unit cases for public v4/v6 (ok), private v4,
  rebound-to-IMDS v4 (169.254.169.254) and v6 (fd00:ec2::254), and a
  peername error (fail-closed -> blocked).
