### PR TITLE
Block RFC 6598 CGNAT (100.64.0.0/10) in the SSRF filter

### DIFF
--- a/src/aws_auth_validate_ldap.erl
+++ b/src/aws_auth_validate_ldap.erl
@@ -458,12 +458,16 @@ check_server_ip(Server) ->
             end
     end.
 
-%% Block RFC 1918, loopback, link-local, and cloud metadata ranges.
+%% Block RFC 1918, loopback, link-local, CGNAT, and cloud metadata ranges.
+%%   100.64.0.0/10 (RFC 6598) is carrier-grade NAT shared address space (second
+%%   octet 64..127); it can route to provider/internal infrastructure, so it is
+%%   denied alongside the RFC 1918 ranges.
 is_private_ip({127, _, _, _}) -> true;
 is_private_ip({10, _, _, _}) -> true;
 is_private_ip({172, B, _, _}) when B >= 16, B =< 31 -> true;
 is_private_ip({192, 168, _, _}) -> true;
 is_private_ip({169, 254, _, _}) -> true;
+is_private_ip({100, B, _, _}) when B >= 64, B =< 127 -> true;
 is_private_ip({0, _, _, _}) -> true;
 is_private_ip(_) -> false.
 

--- a/test/aws_auth_validate_tests.erl
+++ b/test/aws_auth_validate_tests.erl
@@ -198,6 +198,18 @@ server_blocks_rfc1918_192_test() ->
 server_blocks_zero_network_test() ->
     ?assertEqual(false, aws_auth_validate_ldap:is_allowed_server("0.0.0.0")).
 
+%% 100.64.0.0/10 (RFC 6598) carrier-grade NAT shared address space.
+server_blocks_cgnat_test() ->
+    ?assertEqual(false, aws_auth_validate_ldap:is_allowed_server("100.64.0.1")),
+    ?assertEqual(false, aws_auth_validate_ldap:is_allowed_server("100.100.50.1")),
+    ?assertEqual(false, aws_auth_validate_ldap:is_allowed_server("100.127.255.255")).
+
+%% Boundary: 100.63.x and 100.128.x are public space and must stay allowed, so
+%% the /10 mask (second octet 64..127) is not widened to the whole 100/8.
+server_allows_cgnat_boundaries_test() ->
+    ?assertEqual(true, aws_auth_validate_ldap:is_allowed_server("100.63.255.255")),
+    ?assertEqual(true, aws_auth_validate_ldap:is_allowed_server("100.128.0.0")).
+
 server_blocks_ipv6_loopback_test() ->
     ?assertEqual(false, aws_auth_validate_ldap:is_allowed_server("::1")).
 
@@ -241,6 +253,10 @@ peer_allowed_rebound_to_imds_blocked_test() ->
 
 peer_allowed_private_v4_blocked_test() ->
     ?assertEqual(blocked, aws_auth_validate_ldap:peer_allowed({ok, {{10, 0, 0, 5}, 389}})).
+
+%% A peer that rebound into CGNAT (RFC 6598) must be caught on the live socket.
+peer_allowed_rebound_to_cgnat_blocked_test() ->
+    ?assertEqual(blocked, aws_auth_validate_ldap:peer_allowed({ok, {{100, 64, 0, 1}, 389}})).
 
 peer_allowed_public_v6_ok_test() ->
     ?assertEqual(


### PR DESCRIPTION
  - add is_private_ip/1 clause for 100.64.0.0/10 (second octet 64..127), the carrier-grade NAT shared address space, which can route to provider/internal infrastructure and so belongs in the denylist alongside the RFC 1918 ranges
  - the v6 IPv4-mapped/compatible clauses re-dispatch through is_private_ip/1, so ::ffff:100.64.x.x and the post-connect peer_allowed/1 re-check inherit the block for free
  - cover with is_allowed_server tests (in-range + boundary cases pinning the mask to /10: 100.63.x and 100.128.x stay allowed) and a peer_allowed/1 rebound case
