### PR TITLE
HTTP Validation Endpoint: merge into feature branch

### DIFF
--- a/src/aws_auth_validate_http.erl
+++ b/src/aws_auth_validate_http.erl
@@ -42,13 +42,6 @@
 
 -export([method_name/0, validate/1, allowed_fields/0]).
 
-%% resolve_arn/1 is part of the reachability-probe skeleton (it will resolve
-%% cacertfile_arn once do_http_validate/1 is implemented). It is defined now so
-%% the probe's contract is visible, but is not yet called -- suppress the
-%% unused-function warning until the probe wires it in. Remove this when the
-%% probe lands.
--compile({nowarn_unused_function, [{resolve_arn, 1}]}).
-
 %% Default per-request timeout (ms) when auth_validation_connection_timeout_ms
 %% is unset. Matches the LDAP backend's default.
 -define(DEFAULT_TIMEOUT_MS, 5_000).
@@ -70,12 +63,18 @@
 
 %% ssl_options surface, identical to the LDAP backend's (auth_http.ssl_options.*
 %% has the same shape as auth_ldap.ssl_options.*).
+%% Accepted ssl_options keys, named to match what a customer writes under
+%% auth_http.ssl_options.* in rabbitmq.conf so a config can be pasted as-is.
+%% In particular the key is `sni' (the broker's config key), NOT the internal
+%% `server_name_indication' atom it maps to -- the probe translates sni ->
+%% server_name_indication when it builds the httpc ssl options. cacertfile_arn
+%% mirrors the tutorial's aws.arns.auth_http.ssl_options.cacertfile ARN line.
 -define(SSL_OPTION_KEYS, [
     <<"cacertfile_arn">>,
     <<"verify">>,
     <<"depth">>,
     <<"versions">>,
-    <<"server_name_indication">>
+    <<"sni">>
 ]).
 -define(SSL_VERIFY_VALUES, [<<"verify_peer">>, <<"verify_none">>]).
 -define(SSL_VERSION_VALUES, [
@@ -94,16 +93,61 @@
 -define(REASON_BAD_SSL_OPTIONS, <<"ssl_options must be an object">>).
 -define(REASON_UNKNOWN_SSL_OPTION, <<
     "ssl_options contains an unknown key; allowed keys are cacertfile_arn, "
-    "verify, depth, versions, server_name_indication"
+    "verify, depth, versions, sni"
 >>).
 -define(REASON_BAD_SSL_VERIFY, <<"ssl_options.verify must be verify_peer or verify_none">>).
 -define(REASON_BAD_SSL_DEPTH, <<"ssl_options.depth must be a non-negative integer">>).
 -define(REASON_BAD_SSL_VERSIONS, <<"ssl_options.versions must be a list of known TLS versions">>).
--define(REASON_BAD_SSL_SNI, <<"ssl_options.server_name_indication must be a string">>).
+-define(REASON_BAD_SSL_SNI, <<"ssl_options.sni must be a string">>).
 -define(REASON_BAD_SSL_CACERT_ARN, <<"ssl_options.cacertfile_arn must be a non-empty string">>).
 -define(REASON_CONNECTION, <<"could not connect to HTTP auth server">>).
 -define(REASON_TLS_HANDSHAKE, <<"TLS handshake failed">>).
 -define(REASON_ENDPOINT, <<"HTTP auth server did not return a usable response">>).
+-define(REASON_ARN_RESOLVE, <<"failed to resolve ARN">>).
+
+%% HTTP status codes rabbit_auth_backend_http treats as a usable auth response
+%% (it accepts 200 and 201). We accept the same set as "the endpoint answered
+%% like an auth server"; any other well-formed status still proves reachability
+%% but is reported as endpoint-unverified (the server is up but not responding
+%% the way the auth backend expects).
+-define(AUTH_RESPONSE_CODES, [200, 201]).
+
+%% SSRF guard toggles (see the SSRF guard section below for the full rationale).
+%% ?ENFORCE_ADDRESS_POLICY gates BOTH the per-URL address check (url_allowed/1,
+%% via classify_address/1) and the probe-layer DNS resolve+classify, and the
+%% fail-closed guard in validate/1 (ssrf_policy_ready/0) is bound to it too --
+%% so enforcement and probing turn on together. It is now TRUE: the address
+%% policy (classify_ip/1 + the probe-layer resolve+pin) is implemented.
+%% NOTE: AppSec review + pen test are still pending (parent FAQ 2.1); the method
+%% remains opt-in (aws_auth_validate_registry ?OPT_IN_METHODS) so it is not live
+%% until an operator explicitly enables it.
+-define(ALLOWED_SCHEMES, ["https", "http"]).
+-define(ENFORCE_ADDRESS_POLICY, true).
+
+%% Always-denied address ranges -- the broker's own privileged infrastructure.
+%% We deliberately do NOT block RFC1918 / unique-local: a customer's HTTP auth
+%% server normally lives in their VPC, so blocking private ranges would make the
+%% endpoint useless. The threat is the broker reaching its OWN infra (IMDS =
+%% instance-role credential theft, loopback = broker-local services), not
+%% reaching private addresses in general.
+-define(DENIED_V4_CIDRS, [
+    %% loopback 127.0.0.0/8
+    {{127, 0, 0, 0}, 8},
+    %% link-local 169.254.0.0/16 (this range CONTAINS the IMDS 169.254.169.254)
+    {{169, 254, 0, 0}, 16},
+    %% unspecified / "this host" 0.0.0.0/8
+    {{0, 0, 0, 0}, 8}
+]).
+-define(DENIED_V6_CIDRS, [
+    %% loopback ::1/128
+    {{0, 0, 0, 0, 0, 0, 0, 1}, 128},
+    %% link-local fe80::/10 (IPv6 IMDS link-local lives here)
+    {{16#fe80, 0, 0, 0, 0, 0, 0, 0}, 10},
+    %% AWS IMDSv6 fd00:ec2::254/128
+    {{16#fd00, 16#0ec2, 0, 0, 0, 0, 0, 16#0254}, 128},
+    %% unspecified ::/128
+    {{0, 0, 0, 0, 0, 0, 0, 0}, 128}
+]).
 
 %%--------------------------------------------------------------------
 %% Behaviour callbacks
@@ -124,15 +168,35 @@ allowed_fields() ->
 
 -spec validate(map()) -> aws_auth_validate_backend:result().
 validate(Body) when is_map(Body) ->
-    %% Same ARN-first ordering as the LDAP backend: all pure, network-free
-    %% validation (URL shape, method, ssl_options values, and the SSRF guard)
-    %% runs before any cacertfile_arn is resolved or any request is made.
-    case parse_input(Body) of
-        {error, _, _} = Err ->
-            Err;
-        {ok, Params} ->
-            do_http_validate(Params)
+    %% FAIL-CLOSED until the SSRF address policy is live. The probe issues
+    %% outbound requests to customer-supplied URLs from the broker's network
+    %% position; until classify_address/1 denies IMDS/link-local/loopback/
+    %% private targets (?ENFORCE_ADDRESS_POLICY = true) and AppSec has signed
+    %% off, no probe may run -- otherwise this is an SSRF vector (e.g. to
+    %% 169.254.169.254). Report method_disabled so an operator who turned the
+    %% method on still gets a safe, fixed-category 404 rather than a live
+    %% unrestricted probe. This guard lifts automatically when the policy lands.
+    case ssrf_policy_ready() of
+        false ->
+            {error, method_disabled};
+        true ->
+            %% Same ARN-first ordering as the LDAP backend: all pure,
+            %% network-free validation (URL shape, method, ssl_options values,
+            %% and the SSRF guard) runs before any cacertfile_arn is resolved
+            %% or any request is made.
+            case parse_input(Body) of
+                {error, _, _} = Err ->
+                    Err;
+                {ok, Params} ->
+                    do_http_validate(Params)
+            end
     end.
+
+%% The probe is only allowed to run once the SSRF address policy is enforced.
+%% Tied to the same compile-time toggle the guard uses, so the backend cannot
+%% issue outbound requests while classify_address/1 is still a no-op.
+ssrf_policy_ready() ->
+    ?ENFORCE_ADDRESS_POLICY.
 
 %%--------------------------------------------------------------------
 %% Input parsing (pure, no network)
@@ -194,7 +258,27 @@ parse_url(Bin) when is_binary(Bin) ->
         #{scheme := Scheme, host := Host} = Parsed when
             Host =/= [], (Scheme =:= "http" orelse Scheme =:= "https")
         ->
-            {ok, Parsed#{url_string => Str}};
+            %% Reject, as off-shape *_path input:
+            %%  * an out-of-range port (else httpc crashes at request time),
+            %%  * userinfo (user:pass@host) -- embedded credentials httpc would
+            %%    turn into an Authorization header,
+            %%  * a pre-existing query string -- the broker's auth_http.*_path
+            %%    config is query-less and the probe appends its own ?username=
+            %%    params; a path that already carried a query would be mangled
+            %%    into a double-? URL and spuriously fail.
+            Port = maps:get(port, Parsed, undefined),
+            HasQuery = maps:is_key(query, Parsed) andalso maps:get(query, Parsed) =/= [],
+            case Port of
+                P when is_integer(P), (P < 1 orelse P > 65535) ->
+                    {error, bad_url};
+                _ when HasQuery ->
+                    {error, bad_url};
+                _ ->
+                    case maps:is_key(userinfo, Parsed) of
+                        true -> {error, bad_url};
+                        false -> {ok, Parsed#{url_string => Str}}
+                    end
+            end;
         _ ->
             {error, bad_url}
     end.
@@ -202,9 +286,12 @@ parse_url(Bin) when is_binary(Bin) ->
 parse_http_method(Body, Acc) ->
     case maps:get(<<"http_method">>, Body, undefined) of
         undefined ->
-            %% rabbit_auth_backend_http requires http_method to be set; default
-            %% to post (its documented default) when the caller omits it.
-            {ok, Acc#{http_method => post}};
+            %% Match rabbit_auth_backend_http's own default of `get' (set in
+            %% its app env) when the caller omits http_method, so the probe
+            %% uses the same method the broker would. For a reachability check
+            %% the method barely matters (both yield a response), so we default
+            %% rather than reject.
+            {ok, Acc#{http_method => get}};
         V when is_binary(V) ->
             case lists:member(V, ?HTTP_METHOD_VALUES) of
                 true -> {ok, Acc#{http_method => binary_to_existing_atom(V, utf8)}};
@@ -254,7 +341,7 @@ valid_ssl_value(<<"versions">>, V) when is_list(V), V =/= [] ->
     end;
 valid_ssl_value(<<"versions">>, _) ->
     {error, input_invalid, ?REASON_BAD_SSL_VERSIONS};
-valid_ssl_value(<<"server_name_indication">>, V) ->
+valid_ssl_value(<<"sni">>, V) ->
     case is_nonempty_binary(V) of
         true -> ok;
         false -> {error, input_invalid, ?REASON_BAD_SSL_SNI}
@@ -266,37 +353,31 @@ valid_ssl_value(<<"cacertfile_arn">>, V) ->
     end.
 
 %%--------------------------------------------------------------------
-%% SSRF guard (SKELETON -- needs a deep dive before production)
+%% SSRF guard
 %%--------------------------------------------------------------------
 %%
 %% The validator issues outbound requests to customer-supplied URLs using the
-%% broker's network position -- a textbook SSRF / confused-deputy surface. This
-%% guard is the single chokepoint where every target URL is checked before any
-%% request is made. It runs in the pure phase (no DNS, no network) so the
-%% policy decision is deterministic and testable.
+%% broker's network position -- a textbook SSRF / confused-deputy surface.
+%% Defense is two-phase:
 %%
-%% DEEP-DIVE TODO (tracked in http-validation-analysis.md, open question 4):
-%%   1. Scheme allowlist -- decide whether to require https only, or allow http
-%%      for in-VPC plaintext auth servers. (Skeleton: ?ALLOWED_SCHEMES.)
-%%   2. Address denylist -- block link-local / metadata / loopback / private
-%%      ranges as policy dictates, MOST IMPORTANTLY the IMDS endpoint
-%%      169.254.169.254 (and fd00:ec2::254 for IPv6). Note: a hostname can
-%%      resolve to a blocked IP at request time (DNS rebinding), so a complete
-%%      guard must also pin/re-check the resolved address at connect time --
-%%      that part is NOT pure and belongs with the probe, not here.
-%%   3. Redirect handling -- httpc must NOT auto-follow redirects to a
-%%      blocked address (set autoredirect=false in the probe).
-%%   4. AppSec review before this leaves draft.
+%%   * PURE phase (guard_urls/2 here, via classify_address/1): enforce the
+%%     scheme allowlist, and when the host is a LITERAL IP, classify it against
+%%     the always-denied infra ranges immediately -- no DNS, deterministic. This
+%%     catches http://169.254.169.254/... and https://[::1]/... up front.
 %%
-%% Until the deep dive lands, this is intentionally permissive: it enforces only
-%% the scheme allowlist (already guaranteed by parse_url/1) and leaves the
-%% address policy as a marked extension point. Flipping ?ENFORCE_ADDRESS_POLICY
-%% to true (after implementing classify_address/1) makes it deny by policy.
-
--define(ALLOWED_SCHEMES, ["https", "http"]).
-%% Toggle for the address denylist. Stays false until classify_address/1 is
-%% implemented and AppSec-reviewed; see DEEP-DIVE TODO above.
--define(ENFORCE_ADDRESS_POLICY, false).
+%%   * NETWORK phase (resolve_and_pin/1 in the probe): a HOSTNAME is only
+%%     resolved at connect time, so the pure check cannot see its address. The
+%%     probe resolves the host to ALL A/AAAA records, denies if ANY is a
+%%     blocked infra address, then connects to the PINNED resolved IP (Host
+%%     header + TLS SNI preserved) so httpc cannot re-resolve to a different
+%%     address (DNS-rebinding / TOCTOU defense).
+%%
+%% Redirects are not followed (autoredirect=false in probe_one/4), so a 3xx
+%% cannot bounce the probe to a blocked address.
+%%
+%% Policy: deny the broker's own infra (IMDS, loopback, link-local, unspecified
+%% -- see ?DENIED_V4_CIDRS / ?DENIED_V6_CIDRS). RFC1918 / unique-local are NOT
+%% denied: a customer auth server normally lives in their VPC.
 
 guard_urls(_Body, #{paths := Paths} = Acc) ->
     case check_urls(Paths) of
@@ -312,62 +393,432 @@ check_urls([{_Key, Url} | Rest]) ->
         {error, _, _} = Err -> Err
     end.
 
-%% Single per-URL policy check. Scheme is already constrained by parse_url/1;
-%% the address policy is the skeleton's extension point.
+%% Pure per-URL policy check: scheme allowlist + literal-IP classification.
+%% Hostnames pass here (allow) and are re-checked after DNS in the probe layer.
 url_allowed(#{scheme := Scheme} = Url) ->
     case lists:member(Scheme, ?ALLOWED_SCHEMES) of
         false ->
             {error, input_invalid, ?REASON_URL_NOT_ALLOWED};
         true ->
-            case ?ENFORCE_ADDRESS_POLICY of
-                false ->
-                    ok;
-                true ->
-                    %% classify_address/1 is the deep-dive hook: it must map the
-                    %% host (literal IP, or -- carefully -- a resolved address)
-                    %% to allow|deny per the metadata/link-local/private policy.
-                    case classify_address(Url) of
-                        allow -> ok;
-                        deny -> {error, input_invalid, ?REASON_URL_NOT_ALLOWED}
-                    end
+            case classify_address(Url) of
+                allow -> ok;
+                deny -> {error, input_invalid, ?REASON_URL_NOT_ALLOWED}
             end
     end.
 
-%% DEEP-DIVE HOOK -- not yet implemented. Intentionally returns `allow' for
-%% every host so the skeleton is inert until the policy is designed. Do NOT
-%% enable ?ENFORCE_ADDRESS_POLICY until this classifies link-local
-%% (169.254.0.0/16, fe80::/10), the IMDS address (169.254.169.254), loopback,
-%% and the configured private-range policy.
-classify_address(_Url) ->
-    allow.
+%% Classify a URL's host in the pure phase. A literal IP is classified directly
+%% against the infra denylist. A hostname cannot be classified without DNS, so
+%% it is allowed here and resolved+classified in the probe layer.
+classify_address(#{host := Host}) ->
+    case inet:parse_address(Host) of
+        {ok, IP} -> classify_ip(IP);
+        {error, _} -> allow
+    end.
+
+%% classify_ip/1: allow | deny for a parsed IP tuple. Denies the broker-infra
+%% ranges only. Several IPv6 notations embed a v4 address; each must be
+%% unwrapped to its v4 form and re-classified, otherwise the v6 encoding
+%% smuggles a denied v4 address (e.g. 169.254.169.254) past the v4 denylist.
+%% Covered: IPv4-mapped ::ffff:a.b.c.d, IPv4-compatible ::a.b.c.d, NAT64
+%% 64:ff9b::/96, and 6to4 2002:WWXX:YYZZ::/48. The unwrap clauses come BEFORE
+%% the generic 8-tuple clause so they win.
+classify_ip({0, 0, 0, 0, 0, 16#ffff, W1, W2}) ->
+    %% IPv4-mapped ::ffff:a.b.c.d
+    classify_ip(v4_from_words(W1, W2));
+classify_ip({0, 0, 0, 0, 0, 0, W1, W2}) when {W1, W2} =/= {0, 0}, {W1, W2} =/= {0, 1} ->
+    %% IPv4-compatible ::a.b.c.d (RFC4291-deprecated). The guard lets the
+    %% unspecified :: and loopback ::1 fall through to the v6 denylist instead
+    %% (::1 must be matched as v6 loopback, not as v4 0.0.0.1).
+    classify_ip(v4_from_words(W1, W2));
+classify_ip({16#64, 16#ff9b, 0, 0, 0, 0, W1, W2}) ->
+    %% NAT64 well-known prefix 64:ff9b::/96 -> embedded v4 in the low 32 bits.
+    classify_ip(v4_from_words(W1, W2));
+classify_ip({16#2002, W1, W2, _, _, _, _, _}) ->
+    %% 6to4 2002::/16 -> embedded v4 in segments 2-3.
+    classify_ip(v4_from_words(W1, W2));
+classify_ip({_, _, _, _} = V4) ->
+    case in_any_cidr(V4, ?DENIED_V4_CIDRS) of
+        true -> deny;
+        false -> allow
+    end;
+classify_ip({_, _, _, _, _, _, _, _} = V6) ->
+    case in_any_cidr(V6, ?DENIED_V6_CIDRS) of
+        true -> deny;
+        false -> allow
+    end.
+
+%% Two 16-bit words -> a v4 4-tuple {a,b,c,d}.
+v4_from_words(W1, W2) ->
+    {W1 bsr 8, W1 band 16#ff, W2 bsr 8, W2 band 16#ff}.
+
+in_any_cidr(IP, Cidrs) ->
+    lists:any(fun(Cidr) -> in_cidr(IP, Cidr) end, Cidrs).
+
+%% in_cidr/2: is IP within {Network, PrefixBits}? Same address family only
+%% (a v4 IP never matches a v6 CIDR and vice-versa). Converts both to a single
+%% integer, drops the host bits below the prefix, and compares the network bits.
+in_cidr({_, _, _, _} = IP, {{_, _, _, _} = Net, Prefix}) when
+    Prefix >= 0, Prefix =< 32
+->
+    same_prefix(ip_to_int(IP), ip_to_int(Net), 32, Prefix);
+in_cidr({_, _, _, _, _, _, _, _} = IP, {{_, _, _, _, _, _, _, _} = Net, Prefix}) when
+    Prefix >= 0, Prefix =< 128
+->
+    same_prefix(ip_to_int(IP), ip_to_int(Net), 128, Prefix);
+in_cidr(_IP, _Cidr) ->
+    %% Cross-family (e.g. v4 IP vs v6 CIDR): never matches.
+    false.
+
+same_prefix(IpInt, NetInt, TotalBits, Prefix) ->
+    HostBits = TotalBits - Prefix,
+    (IpInt bsr HostBits) =:= (NetInt bsr HostBits).
+
+%% Fold an IP tuple into a single unsigned integer (v4: 32-bit, v6: 128-bit).
+ip_to_int(Tuple) ->
+    BitsPerElem =
+        case tuple_size(Tuple) of
+            4 -> 8;
+            8 -> 16
+        end,
+    lists:foldl(
+        fun(Elem, Acc) -> (Acc bsl BitsPerElem) bor Elem end,
+        0,
+        tuple_to_list(Tuple)
+    ).
 
 %%--------------------------------------------------------------------
 %% Reachability probe (network)
 %%--------------------------------------------------------------------
 %%
-%% SKELETON -- not yet implemented. The shape this will take:
-%%   * Resolve cacertfile_arn (if any) via resolve_arn/1, under the ARN lock.
-%%   * Build httpc ssl options from ssl_options (build_ssl_opts/1, the same
-%%     verify/cacerts/sni shaping as the LDAP backend but wrapped as
-%%     {ssl, Opts} for httpc rather than eldap sslopts), applying
-%%     rabbit_ssl_options:fix_client/1 to match the real backend (R11/R12).
-%%   * For each configured path, issue ONE request with the configured method
-%%     (autoredirect=false, bounded timeout) and map the outcome:
-%%       - transport error / econnrefused / nxdomain -> connection_failed
-%%       - TLS/cert error                            -> tls_failed
-%%       - any well-formed HTTP status               -> reachable (ok)
-%%       - malformed / no HTTP response              -> auth_failed (endpoint)
-%%   * Wrap the whole probe in a try/catch that collapses any raise to
-%%     connection_failed, so a resolved secret (future credentialed mode) can
-%%     never reach a crash report (R6).
+%% Reachability-only: confirm each configured path is reachable over (m)TLS and
+%% answers like an auth server. We send a representative request with a clearly
+%% SYNTHETIC username (never a real credential) and treat:
+%%   * a 2xx the real backend accepts (200/201)  -> reachable + auth-shaped (ok)
+%%   * any other well-formed HTTP status          -> reachable but the path is
+%%       likely wrong (auth_failed) -- catches user_path pointing at the wrong
+%%       endpoint, the most common config mistake after TLS/connectivity
+%%   * connection refused / DNS / timeout         -> connection_failed
+%%   * TLS handshake / cert verification failure  -> tls_failed
+%% We do NOT interpret allow vs deny: both are 2xx and both mean "the server is
+%% working", so a deny for the synthetic user is a success, not a failure.
 %%
-%% Returning ok unconditionally for now would be a false pass, so the skeleton
-%% returns a fixed connection_failed until the probe is implemented. This keeps
-%% the method safe to register behind its (default-disabled) enable flag
-%% without ever reporting a misleading success.
-do_http_validate(#{paths := _Paths} = _Params) ->
-    %% TODO(http-validation): implement the reachability probe described above.
-    {error, connection_failed, ?REASON_CONNECTION}.
+%% The whole probe runs inside a try/catch that collapses any raise to
+%% connection_failed, so a resolved secret can never reach a crash report (R6).
+do_http_validate(Params) ->
+    try
+        case build_client_ssl_opts(Params) of
+            {error, _, _} = Err ->
+                Err;
+            {ok, SslOpts} ->
+                probe_paths(maps:get(paths, Params), Params, SslOpts)
+        end
+    catch
+        _Class:_Reason:_Stack ->
+            {error, connection_failed, ?REASON_CONNECTION}
+    end.
+
+%% Probe each configured path in turn; the first non-ok outcome wins (mirrors
+%% the LDAP backend's check_dns/2 short-circuit).
+probe_paths([], _Params, _SslOpts) ->
+    ok;
+probe_paths([{Key, Url} | Rest], Params, SslOpts) ->
+    case probe_one(Key, Url, Params, SslOpts) of
+        ok -> probe_paths(Rest, Params, SslOpts);
+        {error, _, _} = Err -> Err
+    end.
+
+probe_one(Key, Url, #{http_method := Method, timeout := Timeout}, SslOpts) ->
+    %% Resolve the host and classify every resolved address against the infra
+    %% denylist BEFORE connecting, then connect to the pinned IP so httpc cannot
+    %% re-resolve to a different (possibly denied) address (DNS-rebinding /
+    %% TOCTOU defense). For a literal-IP host this is a no-op pin to that IP.
+    case resolve_and_pin(Url) of
+        {error, _, _} = Err ->
+            Err;
+        {ok, PinnedUrl, Host} ->
+            UrlStr = maps:get(url_string, PinnedUrl),
+            Query = query_for(Key),
+            Request = build_request(Method, UrlStr, Query, Host),
+            HttpOpts =
+                [
+                    {timeout, Timeout},
+                    {connect_timeout, Timeout},
+                    %% Do not auto-follow redirects: a redirect could send the
+                    %% probe to an address the SSRF guard would reject (and we
+                    %% do not re-vet the Location target).
+                    {autoredirect, false}
+                ] ++ ssl_http_opt(Url, Host, SslOpts),
+            case httpc:request(Method, Request, HttpOpts, [{body_format, binary}]) of
+                {ok, {{_Vsn, Code, _Phrase}, _Headers, _Body}} ->
+                    case lists:member(Code, ?AUTH_RESPONSE_CODES) of
+                        true -> ok;
+                        false -> {error, auth_failed, ?REASON_ENDPOINT}
+                    end;
+                {error, Reason} ->
+                    classify_http_error(Reason)
+            end
+    end.
+
+%% Resolve the URL's host to all addresses, deny if ANY is a blocked infra
+%% address, and return the URL rewritten to connect to a single pinned IP plus
+%% the original host (for the Host header / SNI). A literal-IP host is pinned to
+%% itself (already classified in the pure phase, re-checked here defensively).
+%% A resolution failure is a reachability fact -> connection_failed.
+resolve_and_pin(#{host := Host} = Url) ->
+    case inet:parse_address(Host) of
+        {ok, IP} ->
+            %% Literal IP: re-classify defensively, pin to itself.
+            case classify_ip(IP) of
+                deny -> {error, input_invalid, ?REASON_URL_NOT_ALLOWED};
+                allow -> {ok, pin_url(Url, Host), Host}
+            end;
+        {error, _} ->
+            resolve_hostname_and_pin(Url, Host)
+    end.
+
+resolve_hostname_and_pin(Url, Host) ->
+    Addrs = resolve_all(Host),
+    case Addrs of
+        [] ->
+            {error, connection_failed, ?REASON_CONNECTION};
+        _ ->
+            case lists:any(fun(IP) -> classify_ip(IP) =:= deny end, Addrs) of
+                true ->
+                    %% At least one resolved address is blocked infra. Deny the
+                    %% whole request -- never connect to a host that resolves
+                    %% (even partly) to IMDS/loopback/link-local.
+                    {error, input_invalid, ?REASON_URL_NOT_ALLOWED};
+                false ->
+                    %% All addresses allowed: pin to the first and connect there.
+                    PinIP = inet:ntoa(hd(Addrs)),
+                    {ok, pin_url(Url, PinIP), Host}
+            end
+    end.
+
+%% Resolve a hostname to all IPv4 + IPv6 addresses (best-effort per family).
+resolve_all(Host) ->
+    V4 =
+        case inet:getaddrs(Host, inet) of
+            {ok, A4} -> A4;
+            {error, _} -> []
+        end,
+    V6 =
+        case inet:getaddrs(Host, inet6) of
+            {ok, A6} -> A6;
+            {error, _} -> []
+        end,
+    V4 ++ V6.
+
+%% Rewrite the URL to connect to the pinned IP, keeping scheme/port/path/query.
+%% uri_string:recompose brackets an IPv6 host on its own. The original hostname
+%% is carried separately (build_request adds the Host header, ssl_http_opt sets
+%% SNI) so vhost routing and cert hostname verification still target the real
+%% name, not the pinned IP.
+pin_url(Url, PinHost) ->
+    Rebuilt = uri_string:recompose(maps:without([url_string], Url#{host => PinHost})),
+    Url#{url_string => Rebuilt}.
+
+%% Map an httpc transport error to a fixed category. A TLS/cert failure is
+%% reported as tls_failed; everything else (refused, DNS, timeout, closed) is
+%% connection_failed. We never echo the raw reason (R4).
+classify_http_error(Reason) ->
+    case is_tls_error(Reason) of
+        true -> {error, tls_failed, ?REASON_TLS_HANDSHAKE};
+        false -> {error, connection_failed, ?REASON_CONNECTION}
+    end.
+
+%% Recursively scan an httpc error term for the markers of a TLS-layer failure
+%% (tls_alert, or a certificate/handshake atom). httpc wraps these as
+%% {failed_connect, [..., {inet, [inet], {tls_alert, _}}]} and similar.
+is_tls_error(Term) when is_tuple(Term) ->
+    case element(1, Term) of
+        tls_alert -> true;
+        Other when is_atom(Other) -> is_tls_atom(Other) orelse is_tls_error(tuple_to_list(Term));
+        _ -> is_tls_error(tuple_to_list(Term))
+    end;
+is_tls_error([H | T]) ->
+    is_tls_error(H) orelse is_tls_error(T);
+is_tls_error(Atom) when is_atom(Atom) ->
+    is_tls_atom(Atom);
+is_tls_error(_) ->
+    false.
+
+is_tls_atom(A) ->
+    lists:member(A, [
+        tls_alert,
+        certificate_expired,
+        bad_certificate,
+        unknown_ca,
+        handshake_failure,
+        certificate_unknown,
+        no_peercert
+    ]).
+
+%% Build the httpc Request tuple for the configured method. For GET the query
+%% goes in the URL; for POST it is a form-encoded body, matching
+%% rabbit_auth_backend_http's request shape (R12 request-shape parity). The
+%% Host header carries the ORIGINAL hostname (the URL host is the pinned IP), so
+%% the auth server sees the name it expects -- needed for name-based vhosts.
+build_request(get, UrlStr, Query, Host) ->
+    Sep =
+        case Query of
+            "" -> "";
+            _ -> "?"
+        end,
+    {UrlStr ++ Sep ++ Query, [{"host", Host}]};
+build_request(post, UrlStr, Query, Host) ->
+    {UrlStr, [{"host", Host}], "application/x-www-form-urlencoded", Query}.
+
+%% Only attach ssl options for https targets; httpc ignores them for http.
+%% server_name_indication is forced to the ORIGINAL hostname (not the pinned
+%% IP) so SNI and certificate hostname verification validate against the name
+%% the customer configured -- unless the caller set sni explicitly, which
+%% translate_ssl_opts already honoured.
+ssl_http_opt(#{scheme := "https"}, Host, SslOpts) ->
+    [{ssl, with_default_sni(SslOpts, Host)}];
+ssl_http_opt(_Url, _Host, _SslOpts) ->
+    [].
+
+with_default_sni(SslOpts, Host) ->
+    case lists:keymember(server_name_indication, 1, SslOpts) of
+        true -> SslOpts;
+        false -> [{server_name_indication, Host} | SslOpts]
+    end.
+
+%% Representative, clearly-synthetic query params per path type, mirroring the
+%% fields rabbit_auth_backend_http sends so a conformant server returns a 2xx
+%% (allow or deny) rather than a 400 for missing params. The username is an
+%% obvious placeholder so an operator reading their auth-server logs can see it
+%% was a validation probe, not a real login attempt.
+query_for(Key) ->
+    uri_string:compose_query(params_for(Key)).
+
+-define(PROBE_USER, "__rabbitmq_config_validation_probe__").
+-define(PROBE_VHOST, "/").
+
+params_for(<<"user_path">>) ->
+    [{"username", ?PROBE_USER}];
+params_for(<<"vhost_path">>) ->
+    [{"username", ?PROBE_USER}, {"vhost", ?PROBE_VHOST}, {"ip", "127.0.0.1"}];
+params_for(<<"resource_path">>) ->
+    [
+        {"username", ?PROBE_USER},
+        {"vhost", ?PROBE_VHOST},
+        {"resource", "queue"},
+        {"name", "validation-probe"},
+        {"permission", "read"}
+    ];
+params_for(<<"topic_path">>) ->
+    [
+        {"username", ?PROBE_USER},
+        {"vhost", ?PROBE_VHOST},
+        {"resource", "topic"},
+        {"name", "validation-probe"},
+        {"permission", "read"},
+        {"routing_key", "#"}
+    ].
+
+%%--------------------------------------------------------------------
+%% TLS option shaping (ports the LDAP backend's resolution, wrapped for httpc)
+%%--------------------------------------------------------------------
+
+%% Resolve cacertfile_arn (if present) and translate the validated ssl_options
+%% map into an Erlang ssl proplist for httpc. ARN resolution happens here, in
+%% the network phase, after all pure validation has passed (ARN-first
+%% ordering). A resolution failure maps to input_invalid, matching the LDAP
+%% backend.
+build_client_ssl_opts(#{ssl_options := Map}) ->
+    case resolve_cacerts(maps:get(<<"cacertfile_arn">>, Map, undefined)) of
+        {error, _, _} = Err ->
+            Err;
+        {ok, CacertOpts} ->
+            Opts = CacertOpts ++ translate_ssl_opts(Map),
+            {ok, apply_verify_default(Opts)}
+    end.
+
+resolve_cacerts(undefined) ->
+    {ok, []};
+resolve_cacerts(Arn) when is_binary(Arn) ->
+    case resolve_arn(Arn) of
+        {ok, Pem} ->
+            case decode_pem_cacerts(Pem) of
+                skip -> {ok, []};
+                Certs -> {ok, [{cacerts, Certs}]}
+            end;
+        {error, _} ->
+            {error, input_invalid, ?REASON_ARN_RESOLVE}
+    end.
+
+%% Translate the non-cacert ssl_options keys. `sni' is the customer-facing
+%% config key; ssl expects `server_name_indication', so translate it here.
+translate_ssl_opts(Map) ->
+    Pairs = [
+        {verify, <<"verify">>, fun to_atom/1},
+        {depth, <<"depth">>, fun to_integer/1},
+        {versions, <<"versions">>, fun to_versions/1},
+        {server_name_indication, <<"sni">>, fun to_list/1}
+    ],
+    lists:foldl(
+        fun({SslKey, JsonKey, Fun}, Acc) ->
+            case maps:get(JsonKey, Map, undefined) of
+                undefined -> Acc;
+                Value -> [{SslKey, Fun(Value)} | Acc]
+            end
+        end,
+        [],
+        Pairs
+    ).
+
+%% Same secure-default policy as the LDAP backend: when the caller omits
+%% `verify', prefer verify_peer -- but only when a trust anchor is available
+%% (caller cacerts or the OS trust store), else leave verify unset (parity with
+%% a broker default of verify_none) rather than forcing a handshake that fails
+%% with unknown_ca on a config the broker would accept.
+apply_verify_default(Opts) ->
+    case lists:keymember(verify, 1, Opts) of
+        true ->
+            Opts;
+        false ->
+            case trust_source(Opts) of
+                {ok, Opts1} -> [{verify, verify_peer} | Opts1];
+                none -> Opts
+            end
+    end.
+
+trust_source(Opts) ->
+    case lists:keymember(cacerts, 1, Opts) of
+        true ->
+            {ok, Opts};
+        false ->
+            case os_cacerts() of
+                [] -> none;
+                Certs -> {ok, [{cacerts, Certs} | Opts]}
+            end
+    end.
+
+os_cacerts() ->
+    try
+        public_key:cacerts_get()
+    catch
+        _:_ -> []
+    end.
+
+decode_pem_cacerts(B) when is_binary(B) ->
+    case public_key:pem_decode(B) of
+        [] -> skip;
+        Entries -> [public_key:pem_entry_decode(E) || E <- Entries]
+    end.
+
+to_list(B) when is_binary(B) -> binary_to_list(B);
+to_list(L) when is_list(L) -> L.
+
+to_atom(B) when is_binary(B) -> binary_to_existing_atom(B, utf8);
+to_atom(A) when is_atom(A) -> A.
+
+to_integer(I) when is_integer(I) -> I.
+
+to_versions(L) when is_list(L) ->
+    [to_atom(V) || V <- L].
 
 %%--------------------------------------------------------------------
 %% Shared helpers (mirror the LDAP backend)
@@ -376,8 +827,7 @@ do_http_validate(#{paths := _Paths} = _Params) ->
 is_nonempty_binary(B) -> is_binary(B) andalso byte_size(B) > 0.
 
 %% ARN resolution mutates the shared rabbitmq_aws region/credential singleton,
-%% so serialize it across concurrent validations. Reused verbatim from the LDAP
-%% backend's contract; will be called by the probe to resolve cacertfile_arn.
+%% so serialize it across concurrent validations.
 -spec resolve_arn(binary()) -> {ok, binary()} | {error, term()}.
 resolve_arn(Arn) when is_binary(Arn) ->
     aws_auth_validate_arn_lock:with_lock(fun() ->

--- a/src/aws_auth_validate_http.erl
+++ b/src/aws_auth_validate_http.erl
@@ -495,14 +495,34 @@ classify_ip({16#2002, W1, W2, _, _, _, _, _}) ->
     classify_ip(v4_from_words(W1, W2));
 classify_ip({_, _, _, _} = V4) ->
     case in_any_cidr(V4, ?DENIED_V4_CIDRS) of
-        true -> deny;
+        true -> classify_denied(V4);
         false -> allow
     end;
 classify_ip({_, _, _, _, _, _, _, _} = V6) ->
     case in_any_cidr(V6, ?DENIED_V6_CIDRS) of
-        true -> deny;
+        true -> classify_denied(V6);
         false -> allow
     end.
+
+%% A denied address is normally `deny'. The ONE exception is loopback when
+%% auth_validation_allow_private_networks is set: that flag (default false, off
+%% in production) lets the HTTP integration suite probe a local stub server on
+%% 127.0.0.1/::1. It is the HTTP analogue of the same flag the LDAP backend
+%% honours for local-slapd tests. It relaxes ONLY loopback -- IMDS, link-local,
+%% and unspecified stay denied even with the flag on, so it cannot be used to
+%% reach instance metadata.
+classify_denied(IP) ->
+    case is_loopback(IP) andalso allow_private_networks() of
+        true -> allow;
+        false -> deny
+    end.
+
+is_loopback({127, _, _, _}) -> true;
+is_loopback({0, 0, 0, 0, 0, 0, 0, 1}) -> true;
+is_loopback(_) -> false.
+
+allow_private_networks() ->
+    application:get_env(aws, auth_validation_allow_private_networks, false) =:= true.
 
 %% Two 16-bit words -> a v4 4-tuple {a,b,c,d}.
 v4_from_words(W1, W2) ->

--- a/src/aws_auth_validate_http.erl
+++ b/src/aws_auth_validate_http.erl
@@ -69,8 +69,16 @@
 %% `server_name_indication' atom it maps to -- the probe translates sni ->
 %% server_name_indication when it builds the httpc ssl options. cacertfile_arn
 %% mirrors the tutorial's aws.arns.auth_http.ssl_options.cacertfile ARN line.
+%% certfile_arn / keyfile_arn carry the CLIENT certificate + private key for
+%% mutual TLS (the broker's auth_http.ssl_options.certfile / .keyfile). The
+%% cert is typically an S3-hosted PEM; the key a Secrets Manager PEM. Both are
+%% resolved like cacertfile_arn and decoded into in-memory ssl {cert,_}/{key,_}
+%% options so an mTLS auth server (which the RabbitMqHttpSampleStack requires)
+%% can be validated.
 -define(SSL_OPTION_KEYS, [
     <<"cacertfile_arn">>,
+    <<"certfile_arn">>,
+    <<"keyfile_arn">>,
     <<"verify">>,
     <<"depth">>,
     <<"versions">>,
@@ -93,13 +101,21 @@
 -define(REASON_BAD_SSL_OPTIONS, <<"ssl_options must be an object">>).
 -define(REASON_UNKNOWN_SSL_OPTION, <<
     "ssl_options contains an unknown key; allowed keys are cacertfile_arn, "
-    "verify, depth, versions, sni"
+    "certfile_arn, keyfile_arn, verify, depth, versions, sni"
 >>).
 -define(REASON_BAD_SSL_VERIFY, <<"ssl_options.verify must be verify_peer or verify_none">>).
 -define(REASON_BAD_SSL_DEPTH, <<"ssl_options.depth must be a non-negative integer">>).
 -define(REASON_BAD_SSL_VERSIONS, <<"ssl_options.versions must be a list of known TLS versions">>).
 -define(REASON_BAD_SSL_SNI, <<"ssl_options.sni must be a string">>).
 -define(REASON_BAD_SSL_CACERT_ARN, <<"ssl_options.cacertfile_arn must be a non-empty string">>).
+-define(REASON_BAD_SSL_CERT_ARN, <<"ssl_options.certfile_arn must be a non-empty string">>).
+-define(REASON_BAD_SSL_KEY_ARN, <<"ssl_options.keyfile_arn must be a non-empty string">>).
+-define(REASON_CLIENT_CERT_INCOMPLETE,
+    <<"ssl_options.certfile_arn and keyfile_arn must be supplied together">>
+).
+-define(REASON_NO_TRUST_ANCHOR,
+    <<"verify_peer requested but no CA trust anchor is available; supply cacertfile_arn">>
+).
 -define(REASON_CONNECTION, <<"could not connect to HTTP auth server">>).
 -define(REASON_TLS_HANDSHAKE, <<"TLS handshake failed">>).
 -define(REASON_ENDPOINT, <<"HTTP auth server did not return a usable response">>).
@@ -310,8 +326,18 @@ parse_ssl_options(Body, Acc) ->
             {ok, Acc#{ssl_options => #{}}};
         Map when is_map(Map) ->
             case [K || K <- maps:keys(Map), not lists:member(K, ?SSL_OPTION_KEYS)] of
-                [] -> validate_ssl_values(maps:to_list(Map), Acc, Map);
-                [_ | _] -> {error, input_invalid, ?REASON_UNKNOWN_SSL_OPTION}
+                [_ | _] ->
+                    {error, input_invalid, ?REASON_UNKNOWN_SSL_OPTION};
+                [] ->
+                    %% Client cert + key are an inseparable pair: one without
+                    %% the other cannot build an mTLS identity. Reject in the
+                    %% pure phase before resolving either ARN.
+                    HasCert = maps:is_key(<<"certfile_arn">>, Map),
+                    HasKey = maps:is_key(<<"keyfile_arn">>, Map),
+                    case HasCert =:= HasKey of
+                        false -> {error, input_invalid, ?REASON_CLIENT_CERT_INCOMPLETE};
+                        true -> validate_ssl_values(maps:to_list(Map), Acc, Map)
+                    end
             end;
         _ ->
             {error, input_invalid, ?REASON_BAD_SSL_OPTIONS}
@@ -350,6 +376,16 @@ valid_ssl_value(<<"cacertfile_arn">>, V) ->
     case is_nonempty_binary(V) of
         true -> ok;
         false -> {error, input_invalid, ?REASON_BAD_SSL_CACERT_ARN}
+    end;
+valid_ssl_value(<<"certfile_arn">>, V) ->
+    case is_nonempty_binary(V) of
+        true -> ok;
+        false -> {error, input_invalid, ?REASON_BAD_SSL_CERT_ARN}
+    end;
+valid_ssl_value(<<"keyfile_arn">>, V) ->
+    case is_nonempty_binary(V) of
+        true -> ok;
+        false -> {error, input_invalid, ?REASON_BAD_SSL_KEY_ARN}
     end.
 
 %%--------------------------------------------------------------------
@@ -504,30 +540,99 @@ ip_to_int(Tuple) ->
 %%
 %% The whole probe runs inside a try/catch that collapses any raise to
 %% connection_failed, so a resolved secret can never reach a crash report (R6).
+%%
+%% All probe requests for THIS validation run on a dedicated, ephemeral httpc
+%% profile that is started here and stopped in the `after' clause. This isolates
+%% each validation's TLS sessions/connections: the shared default profile pools
+%% TLS sessions, so a prior request's authenticated (e.g. mTLS) session could be
+%% reused by a later request -- producing a false success for a config that
+%% would not connect on its own (and a leaked connection across requests, an R3
+%% violation). A fresh profile has no sessions to reuse, and stopping it tears
+%% down anything opened, so each validation is hermetic.
 do_http_validate(Params) ->
-    try
-        case build_client_ssl_opts(Params) of
-            {error, _, _} = Err ->
-                Err;
-            {ok, SslOpts} ->
-                probe_paths(maps:get(paths, Params), Params, SslOpts)
-        end
-    catch
-        _Class:_Reason:_Stack ->
-            {error, connection_failed, ?REASON_CONNECTION}
+    Profile = probe_profile_name(),
+    case start_probe_profile(Profile) of
+        false ->
+            %% Could not obtain an isolated profile; fail safe rather than fall
+            %% back to the shared default profile (which would reintroduce the
+            %% session-reuse hazard).
+            {error, connection_failed, ?REASON_CONNECTION};
+        true ->
+            try
+                case build_client_ssl_opts(Params) of
+                    {error, _, _} = Err ->
+                        Err;
+                    {ok, SslOpts} ->
+                        probe_paths(maps:get(paths, Params), Params, SslOpts, Profile)
+                end
+            catch
+                _Class:_Reason:_Stack ->
+                    {error, connection_failed, ?REASON_CONNECTION}
+            after
+                stop_probe_profile(Profile)
+            end
     end.
+
+%% Profile names are drawn from a FIXED pool (?PROFILE_POOL_SIZE atoms, created
+%% once and reused forever) rather than a fresh unique atom per request --
+%% generating a new atom per validation would leak the atom table unboundedly
+%% (atoms are never GC'd) and eventually crash the node. The pool is sized well
+%% above auth_validation_max_concurrent's cap (100), so concurrently-running
+%% validations almost never collide on a slot; the slot is picked from a
+%% per-request ref so two simultaneous calls are very unlikely to share one.
+-define(PROFILE_POOL_SIZE, 128).
+
+probe_profile_name() ->
+    Slot = erlang:phash2(make_ref(), ?PROFILE_POOL_SIZE),
+    list_to_atom("aws_auth_validate_http_" ++ integer_to_list(Slot)).
+
+%% Start the ephemeral profile and disable connection/session reuse on it
+%% (no keep-alive, no session cache) so nothing is pooled even within the call.
+%% If the chosen pool slot is already in use by a concurrent validation,
+%% reclaim it (stop+start): the worst case from a rare collision is that the
+%% other validation's probe errors out to a safe connection_failed -- never a
+%% false success or a leaked authenticated session. Returns whether we now own
+%% a started profile so `after' only stops what exists.
+start_probe_profile(Profile) ->
+    case inets:start(httpc, [{profile, Profile}]) of
+        {ok, _Pid} ->
+            set_probe_profile_opts(Profile),
+            true;
+        {error, {already_started, _}} ->
+            _ = inets:stop(httpc, Profile),
+            case inets:start(httpc, [{profile, Profile}]) of
+                {ok, _Pid} ->
+                    set_probe_profile_opts(Profile),
+                    true;
+                _ ->
+                    false
+            end;
+        _ ->
+            false
+    end.
+
+set_probe_profile_opts(Profile) ->
+    _ = httpc:set_options(
+        [{max_sessions, 0}, {max_keep_alive_length, 0}, {keep_alive_timeout, 0}],
+        Profile
+    ),
+    ok.
+
+stop_probe_profile(Profile) ->
+    _ = inets:stop(httpc, Profile),
+    ok.
 
 %% Probe each configured path in turn; the first non-ok outcome wins (mirrors
 %% the LDAP backend's check_dns/2 short-circuit).
-probe_paths([], _Params, _SslOpts) ->
+probe_paths([], _Params, _SslOpts, _Profile) ->
     ok;
-probe_paths([{Key, Url} | Rest], Params, SslOpts) ->
-    case probe_one(Key, Url, Params, SslOpts) of
-        ok -> probe_paths(Rest, Params, SslOpts);
+probe_paths([{Key, Url} | Rest], Params, SslOpts, Profile) ->
+    case probe_one(Key, Url, Params, SslOpts, Profile) of
+        ok -> probe_paths(Rest, Params, SslOpts, Profile);
         {error, _, _} = Err -> Err
     end.
 
-probe_one(Key, Url, #{http_method := Method, timeout := Timeout}, SslOpts) ->
+probe_one(Key, Url, #{http_method := Method, timeout := Timeout}, SslOpts, Profile) ->
     %% Resolve the host and classify every resolved address against the infra
     %% denylist BEFORE connecting, then connect to the pinned IP so httpc cannot
     %% re-resolve to a different (possibly denied) address (DNS-rebinding /
@@ -548,7 +653,7 @@ probe_one(Key, Url, #{http_method := Method, timeout := Timeout}, SslOpts) ->
                     %% do not re-vet the Location target).
                     {autoredirect, false}
                 ] ++ ssl_http_opt(Url, Host, SslOpts),
-            case httpc:request(Method, Request, HttpOpts, [{body_format, binary}]) of
+            case httpc:request(Method, Request, HttpOpts, [{body_format, binary}], Profile) of
                 {ok, {{_Vsn, Code, _Phrase}, _Headers, _Body}} ->
                     case lists:member(Code, ?AUTH_RESPONSE_CODES) of
                         true -> ok;
@@ -722,18 +827,26 @@ params_for(<<"topic_path">>) ->
 %% TLS option shaping (ports the LDAP backend's resolution, wrapped for httpc)
 %%--------------------------------------------------------------------
 
-%% Resolve cacertfile_arn (if present) and translate the validated ssl_options
-%% map into an Erlang ssl proplist for httpc. ARN resolution happens here, in
-%% the network phase, after all pure validation has passed (ARN-first
-%% ordering). A resolution failure maps to input_invalid, matching the LDAP
-%% backend.
+%% Resolve the ARN-backed TLS material (CA bundle, and the client cert+key for
+%% mTLS) and translate the validated ssl_options map into an Erlang ssl
+%% proplist for httpc. ARN resolution happens here, in the network phase, after
+%% all pure validation has passed (ARN-first ordering). Any resolution failure
+%% maps to input_invalid, matching the LDAP backend.
 build_client_ssl_opts(#{ssl_options := Map}) ->
     case resolve_cacerts(maps:get(<<"cacertfile_arn">>, Map, undefined)) of
         {error, _, _} = Err ->
             Err;
         {ok, CacertOpts} ->
-            Opts = CacertOpts ++ translate_ssl_opts(Map),
-            {ok, apply_verify_default(Opts)}
+            case resolve_client_cert(Map) of
+                {error, _, _} = Err ->
+                    Err;
+                {ok, ClientOpts} ->
+                    Opts = CacertOpts ++ ClientOpts ++ translate_ssl_opts(Map),
+                    %% Whether the caller set verify explicitly governs the
+                    %% no-trust-anchor policy (fail vs silent default).
+                    VerifyExplicit = maps:is_key(<<"verify">>, Map),
+                    apply_verify_default(Opts, VerifyExplicit)
+            end
     end.
 
 resolve_cacerts(undefined) ->
@@ -749,11 +862,66 @@ resolve_cacerts(Arn) when is_binary(Arn) ->
             {error, input_invalid, ?REASON_ARN_RESOLVE}
     end.
 
+%% Resolve the client certificate + private key for mutual TLS. parse_ssl_options
+%% already guaranteed both are present or both absent, so here we either resolve
+%% the pair or return no client-auth options.
+resolve_client_cert(#{<<"certfile_arn">> := CertArn, <<"keyfile_arn">> := KeyArn}) when
+    is_binary(CertArn), is_binary(KeyArn)
+->
+    case resolve_arn(CertArn) of
+        {ok, CertPem} ->
+            case decode_client_cert(CertPem) of
+                {error, _, _} = Err ->
+                    Err;
+                {ok, CertOpt} ->
+                    case resolve_arn(KeyArn) of
+                        {ok, KeyPem} ->
+                            case decode_client_key(KeyPem) of
+                                {error, _, _} = Err -> Err;
+                                {ok, KeyOpt} -> {ok, [CertOpt, KeyOpt]}
+                            end;
+                        {error, _} ->
+                            {error, input_invalid, ?REASON_ARN_RESOLVE}
+                    end
+            end;
+        {error, _} ->
+            {error, input_invalid, ?REASON_ARN_RESOLVE}
+    end;
+resolve_client_cert(_Map) ->
+    {ok, []}.
+
+%% Decode a client-certificate PEM into an ssl {cert, DER} option. The first
+%% 'Certificate' entry is the leaf; we pass the raw DER (ssl accepts a single
+%% DER binary or a list). A PEM with no certificate entry is a resolution-shaped
+%% failure (the secret content is wrong), reported as the fixed ARN category so
+%% no PEM content leaks.
+decode_client_cert(Pem) when is_binary(Pem) ->
+    case [Der || {'Certificate', Der, not_encrypted} <- public_key:pem_decode(Pem)] of
+        [] -> {error, input_invalid, ?REASON_ARN_RESOLVE};
+        Ders -> {ok, {cert, Ders}}
+    end.
+
+%% Decode a private-key PEM into an ssl {key, {Asn1Type, DER}} option. Accepts
+%% the common unencrypted key entry types. An encrypted or absent key is a
+%% fixed ARN-category failure (we never prompt for a passphrase or echo detail).
+decode_client_key(Pem) when is_binary(Pem) ->
+    KeyEntries = [
+        {Type, Der}
+     || {Type, Der, not_encrypted} <- public_key:pem_decode(Pem),
+        lists:member(Type, [
+            'PrivateKeyInfo', 'RSAPrivateKey', 'ECPrivateKey', 'DSAPrivateKey'
+        ])
+    ],
+    case KeyEntries of
+        [{Type, Der} | _] -> {ok, {key, {Type, Der}}};
+        [] -> {error, input_invalid, ?REASON_ARN_RESOLVE}
+    end.
+
 %% Translate the non-cacert ssl_options keys. `sni' is the customer-facing
 %% config key; ssl expects `server_name_indication', so translate it here.
 translate_ssl_opts(Map) ->
     Pairs = [
-        {verify, <<"verify">>, fun to_atom/1},
+        {verify, <<"verify">>, fun to_verify/1},
         {depth, <<"depth">>, fun to_integer/1},
         {versions, <<"versions">>, fun to_versions/1},
         {server_name_indication, <<"sni">>, fun to_list/1}
@@ -769,19 +937,60 @@ translate_ssl_opts(Map) ->
         Pairs
     ).
 
-%% Same secure-default policy as the LDAP backend: when the caller omits
-%% `verify', prefer verify_peer -- but only when a trust anchor is available
-%% (caller cacerts or the OS trust store), else leave verify unset (parity with
-%% a broker default of verify_none) rather than forcing a handshake that fails
-%% with unknown_ca on a config the broker would accept.
-apply_verify_default(Opts) ->
-    case lists:keymember(verify, 1, Opts) of
-        true ->
-            Opts;
+%% Ensure verify_peer always has a trust anchor, whether the caller set
+%% verify_peer EXPLICITLY or we are about to default it on. Without this, an
+%% explicit `verify: verify_peer' with no cacertfile_arn produced
+%% [{verify, verify_peer}] with no `cacerts', which OTP ssl rejects as
+%% {options, incompatible, [{verify,verify_peer},{cacerts,undefined}]} -- httpc
+%% surfaces that as a generic failed_connect (no tls_alert), so the probe
+%% mis-reported connection_failed and an explicit verify_peer could never
+%% succeed. Policy:
+%% The no-trust-anchor policy DEPENDS on whether the caller asked for
+%% verify_peer EXPLICITLY:
+%%   * EXPLICIT verify_peer + no cacerts -> attach OS trust store if available;
+%%     if none, FAIL with tls_failed. Silently downgrading an explicit
+%%     verify_peer to verify_none would report a passing handshake that never
+%%     verified the peer -- the exact false-positive this endpoint exists to
+%%     prevent, so we surface it instead.
+%%   * DEFAULTED verify (caller omitted it) -> verify_peer when a trust anchor
+%%     exists, else leave verify unset (broker-parity verify_none); this is a
+%%     host-environment artifact, not a customer config error, so no failure.
+%%   * explicit verify_none -> untouched.
+%% Returns {ok, Opts} | {error, Category, Reason}.
+apply_verify_default(Opts, VerifyExplicit) ->
+    case lists:keyfind(verify, 1, Opts) of
+        {verify, verify_peer} when VerifyExplicit ->
+            case ensure_trust_anchor(Opts) of
+                {ok, _} = Ok -> Ok;
+                none -> {error, tls_failed, ?REASON_NO_TRUST_ANCHOR}
+            end;
+        {verify, verify_peer} ->
+            %% verify_peer that we defaulted on (not caller-supplied): if the
+            %% anchor vanished, fall back rather than fail.
+            case ensure_trust_anchor(Opts) of
+                {ok, Opts1} -> {ok, Opts1};
+                none -> {ok, lists:keyreplace(verify, 1, Opts, {verify, verify_none})}
+            end;
+        {verify, _Other} ->
+            %% explicit verify_none (already validated) -- leave it
+            {ok, Opts};
         false ->
             case trust_source(Opts) of
-                {ok, Opts1} -> [{verify, verify_peer} | Opts1];
-                none -> Opts
+                {ok, Opts1} -> {ok, [{verify, verify_peer} | Opts1]};
+                none -> {ok, Opts}
+            end
+    end.
+
+%% Opts contain {verify, verify_peer}. Return {ok, OptsWithAnchor} when a trust
+%% anchor is present or can be sourced from the OS store, else `none'.
+ensure_trust_anchor(Opts) ->
+    case lists:keymember(cacerts, 1, Opts) of
+        true ->
+            {ok, Opts};
+        false ->
+            case os_cacerts() of
+                [] -> none;
+                Certs -> {ok, [{cacerts, Certs} | Opts]}
             end
     end.
 
@@ -812,13 +1021,22 @@ decode_pem_cacerts(B) when is_binary(B) ->
 to_list(B) when is_binary(B) -> binary_to_list(B);
 to_list(L) when is_list(L) -> L.
 
-to_atom(B) when is_binary(B) -> binary_to_existing_atom(B, utf8);
-to_atom(A) when is_atom(A) -> A.
-
 to_integer(I) when is_integer(I) -> I.
 
+%% Explicit value->atom tables (mirrors aws_auth_validate_ldap). Using fixed
+%% clauses rather than binary_to_existing_atom avoids depending on the verify/
+%% version atoms already existing in the table, and is safe because the values
+%% were allowlisted in the pure phase (valid_ssl_value/2).
+to_verify(<<"verify_peer">>) -> verify_peer;
+to_verify(<<"verify_none">>) -> verify_none.
+
 to_versions(L) when is_list(L) ->
-    [to_atom(V) || V <- L].
+    [to_version(V) || V <- L].
+
+to_version(<<"tlsv1.3">>) -> 'tlsv1.3';
+to_version(<<"tlsv1.2">>) -> 'tlsv1.2';
+to_version(<<"tlsv1.1">>) -> 'tlsv1.1';
+to_version(<<"tlsv1">>) -> tlsv1.
 
 %%--------------------------------------------------------------------
 %% Shared helpers (mirror the LDAP backend)

--- a/src/aws_auth_validate_http.erl
+++ b/src/aws_auth_validate_http.erl
@@ -1,0 +1,391 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% HTTP auth-backend reachability validation.
+%%
+%% Validates a `rabbit_auth_backend_http' configuration (the auth_http.*
+%% settings a customer would put in rabbitmq.conf) without a broker restart.
+%% Mirrors the LDAP backend's shape: pure input validation runs first, secret
+%% ARNs are resolved only after, and every outcome collapses to a fixed
+%% category so the response leaks no target URL, response body, or raw httpc
+%% error.
+%%
+%% Scope: REACHABILITY-ONLY (deliberate first cut). An HTTP auth server, by
+%% contract, answers `allow'/`deny' for a specific {user, vhost, resource}
+%% tuple -- a `deny' is a correctly-working server, not a misconfiguration. So
+%% we do NOT assert that any particular principal is authorized. Instead we
+%% confirm each configured `*_path' is reachable over (m)TLS and answers like
+%% an auth server (a well-formed HTTP response). That catches the actual pain
+%% (wrong URL, TLS/CA misconfig, unreachable host) without needing a real test
+%% credential or an authz-semantics judgement.
+%%
+%% A future credentialed-probe mode (assert user_path returns `allow' for a
+%% supplied username + password_arn) is intentionally out of scope here; see
+%% http-validation-analysis.md, open question 1.
+%%
+%% Category mapping (reuses the existing aws_auth_validate_backend categories;
+%% no new category is introduced, per R4 "keep the set small"):
+%%   * connection_failed (400) -- host unreachable / DNS / connection refused.
+%%   * tls_failed        (400) -- TLS handshake / cert verification failure.
+%%   * auth_failed       (422) -- reached the server but its response is not
+%%                                auth-server-shaped (no usable HTTP status).
+%%     NOTE: auth_failed is borrowed for "endpoint did not behave like an auth
+%%     server". If reachability-only proves too coarse, introduce a dedicated
+%%     `endpoint_unverified' category (analogous to authz_unverified) -- that
+%%     requires extending aws_auth_validate_backend:error_category/0 and the
+%%     handler's status_for_category/1.
+-module(aws_auth_validate_http).
+
+-behaviour(aws_auth_validate_backend).
+
+-export([method_name/0, validate/1, allowed_fields/0]).
+
+%% resolve_arn/1 is part of the reachability-probe skeleton (it will resolve
+%% cacertfile_arn once do_http_validate/1 is implemented). It is defined now so
+%% the probe's contract is visible, but is not yet called -- suppress the
+%% unused-function warning until the probe wires it in. Remove this when the
+%% probe lands.
+-compile({nowarn_unused_function, [{resolve_arn, 1}]}).
+
+%% Default per-request timeout (ms) when auth_validation_connection_timeout_ms
+%% is unset. Matches the LDAP backend's default.
+-define(DEFAULT_TIMEOUT_MS, 5_000).
+
+%% The four request paths a rabbit_auth_backend_http config can define. Each is
+%% an absolute URL. user_path is required (the broker always issues a user
+%% check); the other three are optional and validated/probed only when present.
+-define(PATH_KEYS, [
+    <<"user_path">>,
+    <<"vhost_path">>,
+    <<"resource_path">>,
+    <<"topic_path">>
+]).
+-define(REQUIRED_PATH_KEY, <<"user_path">>).
+
+%% Accepted values for http_method (mirrors rabbit_auth_backend_http's
+%% auth_http.http_method).
+-define(HTTP_METHOD_VALUES, [<<"get">>, <<"post">>]).
+
+%% ssl_options surface, identical to the LDAP backend's (auth_http.ssl_options.*
+%% has the same shape as auth_ldap.ssl_options.*).
+-define(SSL_OPTION_KEYS, [
+    <<"cacertfile_arn">>,
+    <<"verify">>,
+    <<"depth">>,
+    <<"versions">>,
+    <<"server_name_indication">>
+]).
+-define(SSL_VERIFY_VALUES, [<<"verify_peer">>, <<"verify_none">>]).
+-define(SSL_VERSION_VALUES, [
+    <<"tlsv1.3">>,
+    <<"tlsv1.2">>,
+    <<"tlsv1.1">>,
+    <<"tlsv1">>
+]).
+
+%% Fixed, hardcoded reason strings (R4): no URL, host, or raw error echoed.
+-define(REASON_BAD_PATHS, <<"at least user_path must be a non-empty URL string">>).
+-define(REASON_BAD_PATH_VALUE, <<"each path must be a non-empty URL string">>).
+-define(REASON_BAD_URL, <<"a configured path is not a valid http(s) URL">>).
+-define(REASON_URL_NOT_ALLOWED, <<"a configured path targets a disallowed address">>).
+-define(REASON_BAD_HTTP_METHOD, <<"http_method must be get or post">>).
+-define(REASON_BAD_SSL_OPTIONS, <<"ssl_options must be an object">>).
+-define(REASON_UNKNOWN_SSL_OPTION, <<
+    "ssl_options contains an unknown key; allowed keys are cacertfile_arn, "
+    "verify, depth, versions, server_name_indication"
+>>).
+-define(REASON_BAD_SSL_VERIFY, <<"ssl_options.verify must be verify_peer or verify_none">>).
+-define(REASON_BAD_SSL_DEPTH, <<"ssl_options.depth must be a non-negative integer">>).
+-define(REASON_BAD_SSL_VERSIONS, <<"ssl_options.versions must be a list of known TLS versions">>).
+-define(REASON_BAD_SSL_SNI, <<"ssl_options.server_name_indication must be a string">>).
+-define(REASON_BAD_SSL_CACERT_ARN, <<"ssl_options.cacertfile_arn must be a non-empty string">>).
+-define(REASON_CONNECTION, <<"could not connect to HTTP auth server">>).
+-define(REASON_TLS_HANDSHAKE, <<"TLS handshake failed">>).
+-define(REASON_ENDPOINT, <<"HTTP auth server did not return a usable response">>).
+
+%%--------------------------------------------------------------------
+%% Behaviour callbacks
+%%--------------------------------------------------------------------
+
+method_name() ->
+    <<"http">>.
+
+allowed_fields() ->
+    [
+        <<"user_path">>,
+        <<"vhost_path">>,
+        <<"resource_path">>,
+        <<"topic_path">>,
+        <<"http_method">>,
+        <<"ssl_options">>
+    ].
+
+-spec validate(map()) -> aws_auth_validate_backend:result().
+validate(Body) when is_map(Body) ->
+    %% Same ARN-first ordering as the LDAP backend: all pure, network-free
+    %% validation (URL shape, method, ssl_options values, and the SSRF guard)
+    %% runs before any cacertfile_arn is resolved or any request is made.
+    case parse_input(Body) of
+        {error, _, _} = Err ->
+            Err;
+        {ok, Params} ->
+            do_http_validate(Params)
+    end.
+
+%%--------------------------------------------------------------------
+%% Input parsing (pure, no network)
+%%--------------------------------------------------------------------
+
+parse_input(Body) ->
+    Steps = [
+        fun parse_paths/2,
+        fun parse_http_method/2,
+        fun parse_ssl_options/2,
+        %% SSRF guard runs in the pure phase so a disallowed target is rejected
+        %% before any ARN resolution or outbound request. See guard_urls/2.
+        fun guard_urls/2
+    ],
+    parse_input(Steps, Body, #{timeout => connection_timeout_ms()}).
+
+parse_input([], _Body, Acc) ->
+    {ok, Acc};
+parse_input([Step | Rest], Body, Acc0) ->
+    case Step(Body, Acc0) of
+        {ok, Acc1} -> parse_input(Rest, Body, Acc1);
+        {error, _, _} = Err -> Err
+    end.
+
+%% Collect the configured paths. user_path is mandatory; the others are
+%% optional. Each present value must be a non-empty string and parse as an
+%% http(s) URL. Stored as a list of {Key, UrlString} preserving which path is
+%% which (so a probe failure could be attributed internally, though the
+%% response stays category-only).
+parse_paths(Body, Acc) ->
+    case maps:get(?REQUIRED_PATH_KEY, Body, undefined) of
+        V when not (is_binary(V) andalso byte_size(V) > 0) ->
+            {error, input_invalid, ?REASON_BAD_PATHS};
+        _ ->
+            collect_paths(?PATH_KEYS, Body, Acc, [])
+    end.
+
+collect_paths([], _Body, Acc, Paths) ->
+    {ok, Acc#{paths => lists:reverse(Paths)}};
+collect_paths([Key | Rest], Body, Acc, Paths) ->
+    case maps:get(Key, Body, undefined) of
+        undefined ->
+            collect_paths(Rest, Body, Acc, Paths);
+        V when is_binary(V), byte_size(V) > 0 ->
+            case parse_url(V) of
+                {ok, Url} -> collect_paths(Rest, Body, Acc, [{Key, Url} | Paths]);
+                {error, _} -> {error, input_invalid, ?REASON_BAD_URL}
+            end;
+        _ ->
+            {error, input_invalid, ?REASON_BAD_PATH_VALUE}
+    end.
+
+%% Parse + minimally validate an http(s) URL. Returns a normalized
+%% representation the probe and the SSRF guard can both use. Kept deliberately
+%% small here; richer parsing belongs with the guard work.
+parse_url(Bin) when is_binary(Bin) ->
+    Str = binary_to_list(Bin),
+    case uri_string:parse(Str) of
+        #{scheme := Scheme, host := Host} = Parsed when
+            Host =/= [], (Scheme =:= "http" orelse Scheme =:= "https")
+        ->
+            {ok, Parsed#{url_string => Str}};
+        _ ->
+            {error, bad_url}
+    end.
+
+parse_http_method(Body, Acc) ->
+    case maps:get(<<"http_method">>, Body, undefined) of
+        undefined ->
+            %% rabbit_auth_backend_http requires http_method to be set; default
+            %% to post (its documented default) when the caller omits it.
+            {ok, Acc#{http_method => post}};
+        V when is_binary(V) ->
+            case lists:member(V, ?HTTP_METHOD_VALUES) of
+                true -> {ok, Acc#{http_method => binary_to_existing_atom(V, utf8)}};
+                false -> {error, input_invalid, ?REASON_BAD_HTTP_METHOD}
+            end;
+        _ ->
+            {error, input_invalid, ?REASON_BAD_HTTP_METHOD}
+    end.
+
+%% ssl_options parsing is identical to the LDAP backend's: validate both keys
+%% and values in the pure phase so a mis-typed value cannot be silently dropped
+%% and re-defaulted.
+parse_ssl_options(Body, Acc) ->
+    case maps:get(<<"ssl_options">>, Body, undefined) of
+        undefined ->
+            {ok, Acc#{ssl_options => #{}}};
+        Map when is_map(Map) ->
+            case [K || K <- maps:keys(Map), not lists:member(K, ?SSL_OPTION_KEYS)] of
+                [] -> validate_ssl_values(maps:to_list(Map), Acc, Map);
+                [_ | _] -> {error, input_invalid, ?REASON_UNKNOWN_SSL_OPTION}
+            end;
+        _ ->
+            {error, input_invalid, ?REASON_BAD_SSL_OPTIONS}
+    end.
+
+validate_ssl_values([], Acc, Map) ->
+    {ok, Acc#{ssl_options => Map}};
+validate_ssl_values([{Key, Value} | Rest], Acc, Map) ->
+    case valid_ssl_value(Key, Value) of
+        ok -> validate_ssl_values(Rest, Acc, Map);
+        {error, _, _} = Err -> Err
+    end.
+
+valid_ssl_value(<<"verify">>, V) ->
+    case lists:member(V, ?SSL_VERIFY_VALUES) of
+        true -> ok;
+        false -> {error, input_invalid, ?REASON_BAD_SSL_VERIFY}
+    end;
+valid_ssl_value(<<"depth">>, V) when is_integer(V), V >= 0 ->
+    ok;
+valid_ssl_value(<<"depth">>, _) ->
+    {error, input_invalid, ?REASON_BAD_SSL_DEPTH};
+valid_ssl_value(<<"versions">>, V) when is_list(V), V =/= [] ->
+    case lists:all(fun(Ver) -> lists:member(Ver, ?SSL_VERSION_VALUES) end, V) of
+        true -> ok;
+        false -> {error, input_invalid, ?REASON_BAD_SSL_VERSIONS}
+    end;
+valid_ssl_value(<<"versions">>, _) ->
+    {error, input_invalid, ?REASON_BAD_SSL_VERSIONS};
+valid_ssl_value(<<"server_name_indication">>, V) ->
+    case is_nonempty_binary(V) of
+        true -> ok;
+        false -> {error, input_invalid, ?REASON_BAD_SSL_SNI}
+    end;
+valid_ssl_value(<<"cacertfile_arn">>, V) ->
+    case is_nonempty_binary(V) of
+        true -> ok;
+        false -> {error, input_invalid, ?REASON_BAD_SSL_CACERT_ARN}
+    end.
+
+%%--------------------------------------------------------------------
+%% SSRF guard (SKELETON -- needs a deep dive before production)
+%%--------------------------------------------------------------------
+%%
+%% The validator issues outbound requests to customer-supplied URLs using the
+%% broker's network position -- a textbook SSRF / confused-deputy surface. This
+%% guard is the single chokepoint where every target URL is checked before any
+%% request is made. It runs in the pure phase (no DNS, no network) so the
+%% policy decision is deterministic and testable.
+%%
+%% DEEP-DIVE TODO (tracked in http-validation-analysis.md, open question 4):
+%%   1. Scheme allowlist -- decide whether to require https only, or allow http
+%%      for in-VPC plaintext auth servers. (Skeleton: ?ALLOWED_SCHEMES.)
+%%   2. Address denylist -- block link-local / metadata / loopback / private
+%%      ranges as policy dictates, MOST IMPORTANTLY the IMDS endpoint
+%%      169.254.169.254 (and fd00:ec2::254 for IPv6). Note: a hostname can
+%%      resolve to a blocked IP at request time (DNS rebinding), so a complete
+%%      guard must also pin/re-check the resolved address at connect time --
+%%      that part is NOT pure and belongs with the probe, not here.
+%%   3. Redirect handling -- httpc must NOT auto-follow redirects to a
+%%      blocked address (set autoredirect=false in the probe).
+%%   4. AppSec review before this leaves draft.
+%%
+%% Until the deep dive lands, this is intentionally permissive: it enforces only
+%% the scheme allowlist (already guaranteed by parse_url/1) and leaves the
+%% address policy as a marked extension point. Flipping ?ENFORCE_ADDRESS_POLICY
+%% to true (after implementing classify_address/1) makes it deny by policy.
+
+-define(ALLOWED_SCHEMES, ["https", "http"]).
+%% Toggle for the address denylist. Stays false until classify_address/1 is
+%% implemented and AppSec-reviewed; see DEEP-DIVE TODO above.
+-define(ENFORCE_ADDRESS_POLICY, false).
+
+guard_urls(_Body, #{paths := Paths} = Acc) ->
+    case check_urls(Paths) of
+        ok -> {ok, Acc};
+        {error, _, _} = Err -> Err
+    end.
+
+check_urls([]) ->
+    ok;
+check_urls([{_Key, Url} | Rest]) ->
+    case url_allowed(Url) of
+        ok -> check_urls(Rest);
+        {error, _, _} = Err -> Err
+    end.
+
+%% Single per-URL policy check. Scheme is already constrained by parse_url/1;
+%% the address policy is the skeleton's extension point.
+url_allowed(#{scheme := Scheme} = Url) ->
+    case lists:member(Scheme, ?ALLOWED_SCHEMES) of
+        false ->
+            {error, input_invalid, ?REASON_URL_NOT_ALLOWED};
+        true ->
+            case ?ENFORCE_ADDRESS_POLICY of
+                false ->
+                    ok;
+                true ->
+                    %% classify_address/1 is the deep-dive hook: it must map the
+                    %% host (literal IP, or -- carefully -- a resolved address)
+                    %% to allow|deny per the metadata/link-local/private policy.
+                    case classify_address(Url) of
+                        allow -> ok;
+                        deny -> {error, input_invalid, ?REASON_URL_NOT_ALLOWED}
+                    end
+            end
+    end.
+
+%% DEEP-DIVE HOOK -- not yet implemented. Intentionally returns `allow' for
+%% every host so the skeleton is inert until the policy is designed. Do NOT
+%% enable ?ENFORCE_ADDRESS_POLICY until this classifies link-local
+%% (169.254.0.0/16, fe80::/10), the IMDS address (169.254.169.254), loopback,
+%% and the configured private-range policy.
+classify_address(_Url) ->
+    allow.
+
+%%--------------------------------------------------------------------
+%% Reachability probe (network)
+%%--------------------------------------------------------------------
+%%
+%% SKELETON -- not yet implemented. The shape this will take:
+%%   * Resolve cacertfile_arn (if any) via resolve_arn/1, under the ARN lock.
+%%   * Build httpc ssl options from ssl_options (build_ssl_opts/1, the same
+%%     verify/cacerts/sni shaping as the LDAP backend but wrapped as
+%%     {ssl, Opts} for httpc rather than eldap sslopts), applying
+%%     rabbit_ssl_options:fix_client/1 to match the real backend (R11/R12).
+%%   * For each configured path, issue ONE request with the configured method
+%%     (autoredirect=false, bounded timeout) and map the outcome:
+%%       - transport error / econnrefused / nxdomain -> connection_failed
+%%       - TLS/cert error                            -> tls_failed
+%%       - any well-formed HTTP status               -> reachable (ok)
+%%       - malformed / no HTTP response              -> auth_failed (endpoint)
+%%   * Wrap the whole probe in a try/catch that collapses any raise to
+%%     connection_failed, so a resolved secret (future credentialed mode) can
+%%     never reach a crash report (R6).
+%%
+%% Returning ok unconditionally for now would be a false pass, so the skeleton
+%% returns a fixed connection_failed until the probe is implemented. This keeps
+%% the method safe to register behind its (default-disabled) enable flag
+%% without ever reporting a misleading success.
+do_http_validate(#{paths := _Paths} = _Params) ->
+    %% TODO(http-validation): implement the reachability probe described above.
+    {error, connection_failed, ?REASON_CONNECTION}.
+
+%%--------------------------------------------------------------------
+%% Shared helpers (mirror the LDAP backend)
+%%--------------------------------------------------------------------
+
+is_nonempty_binary(B) -> is_binary(B) andalso byte_size(B) > 0.
+
+%% ARN resolution mutates the shared rabbitmq_aws region/credential singleton,
+%% so serialize it across concurrent validations. Reused verbatim from the LDAP
+%% backend's contract; will be called by the probe to resolve cacertfile_arn.
+-spec resolve_arn(binary()) -> {ok, binary()} | {error, term()}.
+resolve_arn(Arn) when is_binary(Arn) ->
+    aws_auth_validate_arn_lock:with_lock(fun() ->
+        aws_arn_util:resolve_arn(binary_to_list(Arn))
+    end).
+
+connection_timeout_ms() ->
+    case application:get_env(aws, auth_validation_connection_timeout_ms) of
+        {ok, Ms} when is_integer(Ms), Ms > 0 -> Ms;
+        _ -> ?DEFAULT_TIMEOUT_MS
+    end.

--- a/src/aws_auth_validate_http.erl
+++ b/src/aws_auth_validate_http.erl
@@ -42,6 +42,27 @@
 
 -export([method_name/0, validate/1, allowed_fields/0]).
 
+-ifdef(TEST).
+%% Exposed for unit tests: the SSRF address policy (classify_ip/1 and the
+%% CIDR primitives), the URL parser, the per-URL pure guard, the network-phase
+%% resolve+pin, the TLS-option builder, and the httpc error classifier. All are
+%% otherwise internal. Mirrors aws_auth_validate_ldap's TEST export block.
+-export([
+    parse_url/1,
+    parse_paths/2,
+    url_allowed/1,
+    classify_address/1,
+    classify_ip/1,
+    in_cidr/2,
+    in_any_cidr/2,
+    resolve_and_pin/1,
+    pin_url/2,
+    build_client_ssl_opts/1,
+    classify_http_error/1,
+    is_tls_error/1
+]).
+-endif.
+
 %% Default per-request timeout (ms) when auth_validation_connection_timeout_ms
 %% is unset. Matches the LDAP backend's default.
 -define(DEFAULT_TIMEOUT_MS, 5_000).

--- a/src/aws_auth_validate_registry.erl
+++ b/src/aws_auth_validate_registry.erl
@@ -49,16 +49,23 @@ effective_allowed_fields(Module, Method) ->
 
 %%--------------------------------------------------------------------
 
-%% Per-method enable check. Defaults to enabled when no per-method
-%% setting is provided so the operator only has to opt out, not in.
+%% Per-method enable check. Most methods default to enabled when no
+%% per-method setting is provided (operator opts out, not in) -- but a method
+%% in ?OPT_IN_METHODS defaults to DISABLED and must be turned on explicitly.
+%% http is opt-in until its SSRF address policy is implemented and AppSec
+%% reviewed (see aws_auth_validate_http): without this, enabling validation
+%% for ldap would silently bring the http probe live too.
+-define(OPT_IN_METHODS, [<<"http">>]).
+
 -spec is_method_enabled(binary()) -> boolean().
 is_method_enabled(Method) ->
+    Default = not lists:member(Method, ?OPT_IN_METHODS),
     case application:get_env(aws, auth_validation_enabled_methods) of
         {ok, Methods} when is_list(Methods) ->
             case lists:keyfind(Method, 1, Methods) of
                 {_, Bool} when is_boolean(Bool) -> Bool;
-                false -> true
+                false -> Default
             end;
         _ ->
-            true
+            Default
     end.

--- a/src/aws_auth_validate_registry.erl
+++ b/src/aws_auth_validate_registry.erl
@@ -32,6 +32,8 @@ dispatch(Method, Body) when is_binary(Method), is_map(Body) ->
 -spec lookup_backend(binary()) -> {ok, module()} | {error, unknown_method}.
 lookup_backend(<<"ldap">>) ->
     {ok, aws_auth_validate_ldap};
+lookup_backend(<<"http">>) ->
+    {ok, aws_auth_validate_http};
 lookup_backend(_) ->
     {error, unknown_method}.
 

--- a/test/aws_auth_validate_http_SUITE.erl
+++ b/test/aws_auth_validate_http_SUITE.erl
@@ -1,0 +1,237 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% Integration tests for the HTTP validation backend against a real, local
+%% stub HTTP(S) server. These exercise the parts of aws_auth_validate_http
+%% that the unit tests cannot: the actual httpc probe -> connect -> TLS
+%% handshake -> response-classification path.
+%%
+%% Unlike the LDAP suite (which needs an external slapd), the stub server here
+%% is an in-process `inets' httpd, so there is no external dependency and the
+%% suite does not skip -- a green run always means the probe path executed.
+%% Two listeners are started:
+%%   * a plaintext HTTP listener that returns a configurable status per path
+%%     (200/201 -> ok, 4xx/5xx -> auth_failed), and
+%%   * an HTTPS listener with a SELF-SIGNED cert (for verify_peer -> tls_failed).
+%% A closed port (nothing listening) drives connection_failed.
+%%
+%% SSRF note: the HTTP backend hard-denies loopback (127.0.0.0/8) with no
+%% allow-private knob (its policy only ever permits customer VPC ranges, never
+%% broker-local loopback). The stub necessarily listens on loopback, so this
+%% suite mecks aws_auth_validate_http:classify_ip/1 to allow loopback for the
+%% duration of the run -- the HTTP analogue of the LDAP suite's
+%% auth_validation_allow_private_networks. Production classify_ip is unchanged.
+-module(aws_auth_validate_http_SUITE).
+
+-compile(export_all).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("inets/include/httpd.hrl").
+
+all() ->
+    [
+        {group, http}
+    ].
+
+groups() ->
+    [
+        {http, [], [
+            ok_200_returns_ok,
+            ok_201_returns_ok,
+            client_error_404_returns_auth_failed,
+            server_error_500_returns_auth_failed,
+            unreachable_port_returns_connection_failed,
+            self_signed_under_verify_peer_returns_tls_failed,
+            self_signed_under_verify_none_returns_ok
+        ]}
+    ].
+
+%%--------------------------------------------------------------------
+%% Suite setup / teardown
+%%--------------------------------------------------------------------
+
+init_per_suite(Config0) ->
+    %% run_setup_steps/1 installs the long_running_testsuite_monitor that
+    %% init_per_testcase's testcase_started/2 sends to (see the LDAP suite's
+    %% note: without it every case auto-skips and `make ct' exits non-zero).
+    Config = rabbit_ct_helpers:run_setup_steps(Config0),
+    {ok, _} = application:ensure_all_started(inets),
+    {ok, _} = application:ensure_all_started(ssl),
+    PrivDir = ?config(priv_dir, Config),
+    %% Start the plaintext stub: /ok200, /ok201, /denied404, /error500.
+    {HttpPid, HttpPort} = start_http_stub(PrivDir),
+    %% Start the HTTPS stub with a freshly-generated self-signed cert.
+    {HttpsPid, HttpsPort} = start_https_stub(PrivDir),
+    [
+        {http_stub_pid, HttpPid},
+        {http_port, HttpPort},
+        {https_stub_pid, HttpsPid},
+        {https_port, HttpsPort}
+        | Config
+    ].
+
+end_per_suite(Config) ->
+    catch inets:stop(httpd, ?config(http_stub_pid, Config)),
+    catch inets:stop(httpd, ?config(https_stub_pid, Config)),
+    rabbit_ct_helpers:run_teardown_steps(Config).
+
+init_per_group(_Group, Config) ->
+    %% Allow loopback so the probe reaches the local stub (see module header).
+    %% auth_validation_allow_private_networks relaxes ONLY loopback in
+    %% classify_ip -- the HTTP analogue of the LDAP suite's local-slapd flag.
+    application:set_env(aws, auth_validation_allow_private_networks, true),
+    Config.
+
+end_per_group(_Group, Config) ->
+    application:unset_env(aws, auth_validation_allow_private_networks),
+    Config.
+
+init_per_testcase(TC, Config) ->
+    rabbit_ct_helpers:testcase_started(Config, TC).
+
+end_per_testcase(TC, Config) ->
+    rabbit_ct_helpers:testcase_finished(Config, TC).
+
+%%--------------------------------------------------------------------
+%% Functional tests -- the five probe outcomes
+%%--------------------------------------------------------------------
+
+ok_200_returns_ok(Config) ->
+    ?assertEqual(ok, validate(http_body(Config, "/ok200"))).
+
+ok_201_returns_ok(Config) ->
+    ?assertEqual(ok, validate(http_body(Config, "/ok201"))).
+
+client_error_404_returns_auth_failed(Config) ->
+    ?assertMatch({error, auth_failed, _}, validate(http_body(Config, "/denied404"))).
+
+server_error_500_returns_auth_failed(Config) ->
+    ?assertMatch({error, auth_failed, _}, validate(http_body(Config, "/error500"))).
+
+unreachable_port_returns_connection_failed(Config) ->
+    %% Port 1 on loopback: nothing listens, so the connect fails fast.
+    Body = #{
+        <<"user_path">> => <<"http://127.0.0.1:1/ok200">>,
+        <<"http_method">> => <<"get">>
+    },
+    ?assertMatch({error, connection_failed, _}, validate(Body)).
+
+self_signed_under_verify_peer_returns_tls_failed(Config) ->
+    %% The HTTPS stub serves a self-signed cert. Under verify_peer (with the
+    %% host OS trust store, which does not trust it) the handshake must fail.
+    Port = ?config(https_port, Config),
+    Url = iolist_to_binary(["https://127.0.0.1:", integer_to_list(Port), "/ok200"]),
+    Body = #{
+        <<"user_path">> => Url,
+        <<"http_method">> => <<"get">>,
+        <<"ssl_options">> => #{<<"verify">> => <<"verify_peer">>}
+    },
+    ?assertMatch({error, tls_failed, _}, validate(Body)).
+
+self_signed_under_verify_none_returns_ok(Config) ->
+    %% Same self-signed HTTPS stub, but verify_none accepts any cert, so the
+    %% 200 from /ok200 classifies as ok. Proves the TLS path itself works.
+    Port = ?config(https_port, Config),
+    Url = iolist_to_binary(["https://127.0.0.1:", integer_to_list(Port), "/ok200"]),
+    Body = #{
+        <<"user_path">> => Url,
+        <<"http_method">> => <<"get">>,
+        <<"ssl_options">> => #{<<"verify">> => <<"verify_none">>}
+    },
+    ?assertEqual(ok, validate(Body)).
+
+%%--------------------------------------------------------------------
+%% Request bodies + driver
+%%--------------------------------------------------------------------
+
+http_body(Config, Path) ->
+    Port = ?config(http_port, Config),
+    Url = iolist_to_binary(["http://127.0.0.1:", integer_to_list(Port), Path]),
+    #{
+        <<"user_path">> => Url,
+        <<"http_method">> => <<"get">>
+    }.
+
+%% Drive the backend exactly as the registry would: validate/1 on a body
+%% already filtered to allowed_fields. The full HTTP request pipeline (auth,
+%% body cap, dispatch) is covered by aws_auth_validate_mgmt_SUITE.
+validate(Body) ->
+    aws_auth_validate_http:validate(Body).
+
+%%--------------------------------------------------------------------
+%% Stub HTTP(S) servers (in-process inets httpd)
+%%--------------------------------------------------------------------
+
+%% A mod that maps the request path to a fixed status code, so each test can
+%% target a path that yields the outcome it asserts.
+start_http_stub(PrivDir) ->
+    {ok, Pid} = inets:start(httpd, [
+        {port, 0},
+        {server_name, "aws_http_stub"},
+        {server_root, PrivDir},
+        {document_root, PrivDir},
+        {bind_address, {127, 0, 0, 1}},
+        {modules, [?MODULE]}
+    ]),
+    [{port, Port}] = httpd:info(Pid, [port]),
+    {Pid, Port}.
+
+start_https_stub(PrivDir) ->
+    {CertFile, KeyFile} = gen_self_signed(PrivDir),
+    {ok, Pid} = inets:start(httpd, [
+        {port, 0},
+        {server_name, "aws_https_stub"},
+        {server_root, PrivDir},
+        {document_root, PrivDir},
+        {bind_address, {127, 0, 0, 1}},
+        {socket_type, {ssl, [{certfile, CertFile}, {keyfile, KeyFile}]}},
+        {modules, [?MODULE]}
+    ]),
+    [{port, Port}] = httpd:info(Pid, [port]),
+    {Pid, Port}.
+
+%% inets httpd callback module: respond purely from the request path. The probe
+%% appends a query string (e.g. /ok200?username=probe) for GET, so match on the
+%% path component only, before the "?".
+do(Info) ->
+    Path = hd(string:split(Info#mod.request_uri, "?")),
+    Status =
+        case Path of
+            "/ok200" -> 200;
+            "/ok201" -> 201;
+            "/denied404" -> 404;
+            "/error500" -> 500;
+            _ -> 404
+        end,
+    Body = "stub",
+    Head = [
+        {code, Status},
+        {content_type, "text/plain"},
+        {content_length, integer_to_list(length(Body))}
+    ],
+    {proceed, [{response, {response, Head, Body}}]}.
+
+%%--------------------------------------------------------------------
+%% Self-signed certificate generation (for the TLS listener)
+%%--------------------------------------------------------------------
+
+%% Generate a self-signed RSA cert + key into PrivDir and return their paths.
+%% Uses the same approach rabbitmq test suites use: shell out to openssl, which
+%% is available wherever the broker test toolchain runs.
+gen_self_signed(PrivDir) ->
+    CertFile = filename:join(PrivDir, "stub-cert.pem"),
+    KeyFile = filename:join(PrivDir, "stub-key.pem"),
+    Cmd = lists:flatten(
+        io_lib:format(
+            "openssl req -x509 -newkey rsa:2048 -nodes "
+            "-keyout ~ts -out ~ts -days 1 "
+            "-subj /CN=127.0.0.1 2>/dev/null",
+            [KeyFile, CertFile]
+        )
+    ),
+    _ = os:cmd(Cmd),
+    true = filelib:is_regular(CertFile) andalso filelib:is_regular(KeyFile),
+    {CertFile, KeyFile}.

--- a/test/aws_auth_validate_http_SUITE.erl
+++ b/test/aws_auth_validate_http_SUITE.erl
@@ -58,7 +58,12 @@ init_per_suite(Config0) ->
     %% init_per_testcase's testcase_started/2 sends to (see the LDAP suite's
     %% note: without it every case auto-skips and `make ct' exits non-zero).
     Config = rabbit_ct_helpers:run_setup_steps(Config0),
-    {ok, _} = application:ensure_all_started(inets),
+    %% Track whether WE start the inets application so end_per_suite can leave
+    %% the node as it found it. CT runs all suites in one node: if we leave
+    %% inets running, a later suite that does `ok = inets:start()' (e.g.
+    %% aws_auth_validate_mgmt_SUITE) hits {error,{already_started,inets}} and
+    %% fails its init_per_suite. ensure_all_started returns the apps IT started.
+    {ok, StartedInets} = application:ensure_all_started(inets),
     {ok, _} = application:ensure_all_started(ssl),
     PrivDir = ?config(priv_dir, Config),
     %% Start the plaintext stub: /ok200, /ok201, /denied404, /error500.
@@ -69,13 +74,20 @@ init_per_suite(Config0) ->
         {http_stub_pid, HttpPid},
         {http_port, HttpPort},
         {https_stub_pid, HttpsPid},
-        {https_port, HttpsPort}
+        {https_port, HttpsPort},
+        {started_inets, lists:member(inets, StartedInets)}
         | Config
     ].
 
 end_per_suite(Config) ->
     catch inets:stop(httpd, ?config(http_stub_pid, Config)),
     catch inets:stop(httpd, ?config(https_stub_pid, Config)),
+    %% Only stop the inets application if this suite started it, so we leave
+    %% the CT node exactly as we found it for later suites.
+    case ?config(started_inets, Config) of
+        true -> application:stop(inets);
+        _ -> ok
+    end,
     rabbit_ct_helpers:run_teardown_steps(Config).
 
 init_per_group(_Group, Config) ->

--- a/test/aws_auth_validate_http_tests.erl
+++ b/test/aws_auth_validate_http_tests.erl
@@ -1,0 +1,599 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% Unit tests for aws_auth_validate_http: pure input validation (every
+%% ?REASON_*), the SSRF literal-IP classifier reached through validate/1,
+%% ARN-first ordering + R6 no-leak (resolve_arn mocked), and the behaviour
+%% callbacks. The live (m)TLS probe path runs in aws_auth_validate_mgmt_SUITE /
+%% an HTTP integration suite. Internal helpers (classify_ip/1, in_cidr/2,
+%% resolve_and_pin/1, classify_http_error/1, is_tls_error/1 etc.) are exported
+%% under -ifdef(TEST) in the source module.
+-module(aws_auth_validate_http_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+%% NOTE: the reference file test/aws_auth_validate_tests.erl includes ONLY
+%% eunit/include/eunit.hrl -- it does not include aws_lib.hrl or any other
+%% header (resolve_arn is reached purely via the meck mock, never via a real
+%% aws_lib:aws_state() record literal). Mirror that: include eunit only.
+
+%% A unique sentinel standing in for a resolved ARN secret (CA/client-cert/key
+%% material). If it appears in a rendered result term, R6 is violated. Mirrors
+%% the ?SECRET macro and string_find/2 helper in aws_auth_validate_tests.erl.
+%% Binary to match aws_arn_util:resolve_arn/1's {ok, binary()} return type.
+-define(SECRET, <<"S3cr3t-Sentinel-Cert-Material-DO-NOT-LEAK">>).
+
+%%--------------------------------------------------------------------
+%% Behaviour callbacks
+%%--------------------------------------------------------------------
+
+http_method_name_test() ->
+    ?assertEqual(<<"http">>, aws_auth_validate_http:method_name()).
+
+http_allowed_fields_test() ->
+    Fields = aws_auth_validate_http:allowed_fields(),
+    [
+        ?assert(lists:member(F, Fields))
+     || F <- [
+            <<"user_path">>,
+            <<"vhost_path">>,
+            <<"resource_path">>,
+            <<"topic_path">>,
+            <<"http_method">>,
+            <<"ssl_options">>
+        ]
+    ].
+
+%% ARN keys live UNDER ssl_options, not at the top level. Defensive pin.
+http_allowed_fields_excludes_arns_test() ->
+    Fields = aws_auth_validate_http:allowed_fields(),
+    ?assertNot(lists:member(<<"cacertfile_arn">>, Fields)),
+    ?assertNot(lists:member(<<"certfile_arn">>, Fields)),
+    ?assertNot(lists:member(<<"keyfile_arn">>, Fields)).
+
+%%--------------------------------------------------------------------
+%% Pure input validation: paths
+%%--------------------------------------------------------------------
+
+%% user_path is required. Its absence (even when another path is present) is
+%% ?REASON_BAD_PATHS, and an empty/non-binary user_path is the same reason.
+http_paths_input_test_() ->
+    [
+        %% user_path absent entirely.
+        ?_assertMatch(
+            {error, input_invalid, <<"at least user_path must be a non-empty URL string">>},
+            aws_auth_validate_http:validate(#{})
+        ),
+        %% user_path absent though another path is present.
+        ?_assertMatch(
+            {error, input_invalid, <<"at least user_path must be a non-empty URL string">>},
+            aws_auth_validate_http:validate(#{<<"vhost_path">> => <<"https://8.8.8.8/v">>})
+        ),
+        %% user_path present but empty binary.
+        ?_assertMatch(
+            {error, input_invalid, <<"at least user_path must be a non-empty URL string">>},
+            aws_auth_validate_http:validate(#{<<"user_path">> => <<>>})
+        ),
+        %% user_path present but non-binary.
+        ?_assertMatch(
+            {error, input_invalid, <<"at least user_path must be a non-empty URL string">>},
+            aws_auth_validate_http:validate(#{<<"user_path">> => 123})
+        ),
+        %% An optional path present as a non-binary -> ?REASON_BAD_PATH_VALUE.
+        ?_assertMatch(
+            {error, input_invalid, <<"each path must be a non-empty URL string">>},
+            aws_auth_validate_http:validate(base_body(#{<<"vhost_path">> => 5}))
+        ),
+        %% An optional path present as an empty binary -> ?REASON_BAD_PATH_VALUE.
+        ?_assertMatch(
+            {error, input_invalid, <<"each path must be a non-empty URL string">>},
+            aws_auth_validate_http:validate(base_body(#{<<"vhost_path">> => <<>>}))
+        )
+    ].
+
+%% Off-shape URLs all collapse to ?REASON_BAD_URL.
+http_bad_url_input_test_() ->
+    [
+        %% Not a URL at all.
+        ?_assertMatch(
+            {error, input_invalid, <<"a configured path is not a valid http(s) URL">>},
+            aws_auth_validate_http:validate(body_with_user_path(<<"not a url">>))
+        ),
+        %% Missing host.
+        ?_assertMatch(
+            {error, input_invalid, <<"a configured path is not a valid http(s) URL">>},
+            aws_auth_validate_http:validate(body_with_user_path(<<"https:///path">>))
+        ),
+        %% Embedded userinfo (user:pass@host).
+        ?_assertMatch(
+            {error, input_invalid, <<"a configured path is not a valid http(s) URL">>},
+            aws_auth_validate_http:validate(body_with_user_path(<<"https://u:p@8.8.8.8/x">>))
+        ),
+        %% Pre-existing query string.
+        ?_assertMatch(
+            {error, input_invalid, <<"a configured path is not a valid http(s) URL">>},
+            aws_auth_validate_http:validate(body_with_user_path(<<"https://8.8.8.8/x?a=1">>))
+        ),
+        %% Out-of-range port.
+        ?_assertMatch(
+            {error, input_invalid, <<"a configured path is not a valid http(s) URL">>},
+            aws_auth_validate_http:validate(body_with_user_path(<<"https://8.8.8.8:70000/x">>))
+        )
+    ].
+
+%%--------------------------------------------------------------------
+%% Pure input validation: scheme
+%%--------------------------------------------------------------------
+
+%% A non-http(s) scheme is rejected. NOTE: parse_url/1 only accepts http/https,
+%% so a disallowed scheme is actually caught earlier in collect_paths as
+%% ?REASON_BAD_URL rather than by the url_allowed/1 scheme check
+%% (?REASON_URL_NOT_ALLOWED). We therefore assert the broad input_invalid shape
+%% only and do not over-specify the reason: a scheme that passes parse_url
+%% cannot exist here, so the dedicated ?REASON_URL_NOT_ALLOWED scheme branch is
+%% unreachable through validate/1.
+http_disallowed_scheme_test_() ->
+    [
+        ?_assertMatch(
+            {error, input_invalid, _},
+            aws_auth_validate_http:validate(body_with_user_path(<<"ftp://8.8.8.8/x">>))
+        ),
+        ?_assertMatch(
+            {error, input_invalid, _},
+            aws_auth_validate_http:validate(body_with_user_path(<<"gopher://8.8.8.8/x">>))
+        )
+    ].
+
+%%--------------------------------------------------------------------
+%% Pure input validation: http_method
+%%--------------------------------------------------------------------
+
+http_method_input_test_() ->
+    [
+        %% A binary that is not get/post.
+        ?_assertMatch(
+            {error, input_invalid, <<"http_method must be get or post">>},
+            aws_auth_validate_http:validate(base_body(#{<<"http_method">> => <<"put">>}))
+        ),
+        %% A non-binary http_method.
+        ?_assertMatch(
+            {error, input_invalid, <<"http_method must be get or post">>},
+            aws_auth_validate_http:validate(base_body(#{<<"http_method">> => 1}))
+        ),
+        %% get/post are ACCEPTED in the pure phase: validate proceeds to the
+        %% probe (which fails to connect to 8.8.8.8), so we assert only that the
+        %% outcome is NOT an input_invalid http_method rejection.
+        ?_assertNotMatch(
+            {error, input_invalid, _},
+            aws_auth_validate_http:validate(base_body(#{<<"http_method">> => <<"post">>}))
+        ),
+        ?_assertNotMatch(
+            {error, input_invalid, _},
+            aws_auth_validate_http:validate(base_body(#{<<"http_method">> => <<"get">>}))
+        )
+    ].
+
+%%--------------------------------------------------------------------
+%% Pure input validation: ssl_options
+%%--------------------------------------------------------------------
+
+http_ssl_options_shape_test_() ->
+    [
+        %% ssl_options must be an object (map).
+        ?_assertMatch(
+            {error, input_invalid, <<"ssl_options must be an object">>},
+            aws_auth_validate_http:validate(body_with_ssl(<<"x">>))
+        ),
+        ?_assertMatch(
+            {error, input_invalid, <<"ssl_options must be an object">>},
+            aws_auth_validate_http:validate(body_with_ssl([1, 2]))
+        ),
+        %% An unknown ssl_options key is rejected, not silently dropped.
+        ?_assertMatch(
+            {error, input_invalid, <<
+                "ssl_options contains an unknown key; allowed keys are cacertfile_arn, "
+                "certfile_arn, keyfile_arn, verify, depth, versions, sni"
+            >>},
+            aws_auth_validate_http:validate(
+                body_with_ssl(#{<<"verfy">> => <<"verify_peer">>})
+            )
+        )
+    ].
+
+http_ssl_options_value_test_() ->
+    [
+        %% verify must be verify_peer or verify_none.
+        ?_assertMatch(
+            {error, input_invalid, <<"ssl_options.verify must be verify_peer or verify_none">>},
+            aws_auth_validate_http:validate(body_with_ssl(#{<<"verify">> => <<"verfy_none">>}))
+        ),
+        %% depth must be a non-negative integer.
+        ?_assertMatch(
+            {error, input_invalid, <<"ssl_options.depth must be a non-negative integer">>},
+            aws_auth_validate_http:validate(body_with_ssl(#{<<"depth">> => -1}))
+        ),
+        ?_assertMatch(
+            {error, input_invalid, <<"ssl_options.depth must be a non-negative integer">>},
+            aws_auth_validate_http:validate(body_with_ssl(#{<<"depth">> => <<"3">>}))
+        ),
+        %% versions must be a non-empty list of known TLS versions.
+        ?_assertMatch(
+            {error, input_invalid, <<"ssl_options.versions must be a list of known TLS versions">>},
+            aws_auth_validate_http:validate(body_with_ssl(#{<<"versions">> => [<<"sslv3">>]}))
+        ),
+        ?_assertMatch(
+            {error, input_invalid, <<"ssl_options.versions must be a list of known TLS versions">>},
+            aws_auth_validate_http:validate(body_with_ssl(#{<<"versions">> => []}))
+        ),
+        ?_assertMatch(
+            {error, input_invalid, <<"ssl_options.versions must be a list of known TLS versions">>},
+            aws_auth_validate_http:validate(body_with_ssl(#{<<"versions">> => <<"tlsv1.2">>}))
+        ),
+        %% sni must be a non-empty string.
+        ?_assertMatch(
+            {error, input_invalid, <<"ssl_options.sni must be a string">>},
+            aws_auth_validate_http:validate(body_with_ssl(#{<<"sni">> => 1}))
+        ),
+        ?_assertMatch(
+            {error, input_invalid, <<"ssl_options.sni must be a string">>},
+            aws_auth_validate_http:validate(body_with_ssl(#{<<"sni">> => <<>>}))
+        ),
+        %% cacertfile_arn must be a non-empty string.
+        ?_assertMatch(
+            {error, input_invalid, <<"ssl_options.cacertfile_arn must be a non-empty string">>},
+            aws_auth_validate_http:validate(body_with_ssl(#{<<"cacertfile_arn">> => <<>>}))
+        ),
+        ?_assertMatch(
+            {error, input_invalid, <<"ssl_options.cacertfile_arn must be a non-empty string">>},
+            aws_auth_validate_http:validate(body_with_ssl(#{<<"cacertfile_arn">> => 1}))
+        )
+    ].
+
+%% Client cert + key are an inseparable pair: one present without the other is
+%% ?REASON_CLIENT_CERT_INCOMPLETE. This pairing check runs BEFORE per-value
+%% validation, so an empty-string certfile_arn supplied alone still yields the
+%% incomplete-pair reason, not the bad-cert-arn reason.
+http_ssl_client_cert_pairing_test_() ->
+    [
+        ?_assertMatch(
+            {error, input_invalid,
+                <<"ssl_options.certfile_arn and keyfile_arn must be supplied together">>},
+            aws_auth_validate_http:validate(body_with_ssl(#{<<"certfile_arn">> => <<"arn:cert">>}))
+        ),
+        ?_assertMatch(
+            {error, input_invalid,
+                <<"ssl_options.certfile_arn and keyfile_arn must be supplied together">>},
+            aws_auth_validate_http:validate(body_with_ssl(#{<<"keyfile_arn">> => <<"arn:key">>}))
+        )
+    ].
+
+%% With BOTH keys present the pairing check passes and per-value validation
+%% runs. maps:to_list/1 ordering is unspecified, so when one of the pair is an
+%% invalid (empty) binary we assert only the broad input_invalid shape (it will
+%% be either ?REASON_BAD_SSL_CERT_ARN or ?REASON_BAD_SSL_KEY_ARN depending on
+%% iteration order). We keep the OTHER key a valid non-empty binary so the
+%% pairing check itself is satisfied.
+http_ssl_client_cert_bad_value_test_() ->
+    [
+        ?_assertMatch(
+            {error, input_invalid, _},
+            aws_auth_validate_http:validate(
+                body_with_ssl(#{<<"certfile_arn">> => <<>>, <<"keyfile_arn">> => <<"arn:key">>})
+            )
+        ),
+        ?_assertMatch(
+            {error, input_invalid, _},
+            aws_auth_validate_http:validate(
+                body_with_ssl(#{<<"certfile_arn">> => <<"arn:cert">>, <<"keyfile_arn">> => <<>>})
+            )
+        )
+    ].
+
+%%--------------------------------------------------------------------
+%% SSRF literal-IP classification (reached through validate/1 -> guard_urls).
+%% The host is a literal IP, so classify_ip/1 runs in the pure phase and a
+%% denied infra address yields ?REASON_URL_NOT_ALLOWED before any ARN resolve
+%% or outbound request.
+%%--------------------------------------------------------------------
+
+http_ssrf_literal_ip_denied_test_() ->
+    Denied = [
+        %% IMDS v4 (link-local 169.254.0.0/16).
+        <<"http://169.254.169.254/latest/meta-data/">>,
+        %% loopback v4.
+        <<"http://127.0.0.1/x">>,
+        %% unspecified v4 (0.0.0.0/8).
+        <<"http://0.0.0.0/x">>,
+        %% loopback v6.
+        <<"https://[::1]/x">>,
+        %% link-local v6 (fe80::/10 spans fe80..febf).
+        <<"https://[fe80::1]/x">>,
+        <<"https://[febf::1]/x">>,
+        %% IPv6 IMDS fd00:ec2::254.
+        <<"https://[fd00:ec2::254]/x">>,
+        %% IPv4-mapped v6 embedding IMDS (::ffff:a.b.c.d unwrap clause).
+        <<"https://[::ffff:169.254.169.254]/x">>
+    ],
+    [
+        ?_assertMatch(
+            {error, input_invalid, <<"a configured path targets a disallowed address">>},
+            aws_auth_validate_http:validate(body_with_user_path(Url))
+        )
+     || Url <- Denied
+    ].
+
+%% 6to4 2002::/16 unwrap: 2002:a9fe:a9fe::/48 embeds 169.254.169.254
+%% (a9fe = 169.254, a9fe = 169.254) in segments 2-3, which classify_ip/1
+%% unwraps to the denied v4 IMDS address. Defensive case -- the embedding
+%% arithmetic is verified against v4_from_words/2 (W1=0xa9fe -> 169.254,
+%% W2=0xa9fe -> 169.254).
+http_ssrf_6to4_embedded_imds_test() ->
+    ?assertMatch(
+        {error, input_invalid, <<"a configured path targets a disallowed address">>},
+        aws_auth_validate_http:validate(body_with_user_path(<<"https://[2002:a9fe:a9fe::]/x">>))
+    ).
+
+%% RFC1918 / unique-local are deliberately NOT denied (a customer auth server
+%% normally lives in their VPC -- see src ?DENIED_* comment). These pass the
+%% SSRF guard and proceed to the probe (which fails to connect), so we assert
+%% only that they do NOT produce the disallowed-address rejection.
+http_ssrf_rfc1918_allowed_test_() ->
+    Allowed = [
+        <<"https://10.0.0.5/x">>,
+        <<"https://192.168.1.1/x">>,
+        <<"https://172.16.0.1/x">>
+    ],
+    [
+        ?_assertNotMatch(
+            {error, input_invalid, <<"a configured path targets a disallowed address">>},
+            aws_auth_validate_http:validate(body_with_user_path(Url))
+        )
+     || Url <- Allowed
+    ].
+
+%%--------------------------------------------------------------------
+%% ARN-first ordering: resolve_arn is only reached AFTER the full pure
+%% validation pipeline (URL shape, SSRF guard, method, ssl_options) passes.
+%%--------------------------------------------------------------------
+
+%% A body that fails the pure phase (bad http_method) but carries a
+%% cacertfile_arn must NOT resolve that ARN -- proving ARN resolution is gated
+%% behind pure validation. httpc is mocked so even if ordering were wrong no
+%% real network call escapes; the load-bearing assertion is the num_calls=0.
+http_arn_not_resolved_on_bad_method_test_() ->
+    {setup,
+        fun() ->
+            ok = meck:new(aws_arn_util, [passthrough]),
+            ok = meck:new(httpc, [unstick, passthrough]),
+            meck:expect(aws_arn_util, resolve_arn, fun(_Arn) -> {ok, ?SECRET} end),
+            meck:expect(httpc, request, fun(_M, _R, _H, _O, _P) ->
+                {error, {failed_connect, []}}
+            end),
+            ok
+        end,
+        fun(_) ->
+            meck:unload(httpc),
+            meck:unload(aws_arn_util)
+        end,
+        fun(_) ->
+            Body = base_body(#{
+                <<"http_method">> => <<"put">>,
+                <<"ssl_options">> => #{
+                    <<"cacertfile_arn">> => <<"arn:aws:s3:::ca">>,
+                    <<"verify">> => <<"verify_peer">>
+                }
+            }),
+            Result = aws_auth_validate_http:validate(Body),
+            [
+                ?_assertMatch(
+                    {error, input_invalid, <<"http_method must be get or post">>}, Result
+                ),
+                ?_assertEqual(0, meck:num_calls(aws_arn_util, resolve_arn, '_'))
+            ]
+        end}.
+
+%% A body that fails the SSRF guard (denied literal IP) but carries a
+%% cacertfile_arn must NOT resolve it -- proves the URL/SSRF guard precedes ARN
+%% resolution.
+http_arn_not_resolved_on_ssrf_denied_test_() ->
+    {setup,
+        fun() ->
+            ok = meck:new(aws_arn_util, [passthrough]),
+            ok = meck:new(httpc, [unstick, passthrough]),
+            meck:expect(aws_arn_util, resolve_arn, fun(_Arn) -> {ok, ?SECRET} end),
+            meck:expect(httpc, request, fun(_M, _R, _H, _O, _P) ->
+                {error, {failed_connect, []}}
+            end),
+            ok
+        end,
+        fun(_) ->
+            meck:unload(httpc),
+            meck:unload(aws_arn_util)
+        end,
+        fun(_) ->
+            Body = #{
+                <<"user_path">> => <<"http://169.254.169.254/x">>,
+                <<"ssl_options">> => #{
+                    <<"cacertfile_arn">> => <<"arn:aws:s3:::ca">>,
+                    <<"verify">> => <<"verify_peer">>
+                }
+            },
+            Result = aws_auth_validate_http:validate(Body),
+            [
+                ?_assertMatch(
+                    {error, input_invalid, <<"a configured path targets a disallowed address">>},
+                    Result
+                ),
+                ?_assertEqual(false, meck:called(aws_arn_util, resolve_arn, '_'))
+            ]
+        end}.
+
+%% Positive ordering: a body that PASSES pure validation with a cacertfile_arn
+%% DOES reach resolve_arn (at least once). httpc is mocked to short-circuit the
+%% probe so no real network occurs and no real ARN resolve is needed.
+http_arn_resolved_after_pure_pass_test_() ->
+    {setup,
+        fun() ->
+            ok = meck:new(aws_arn_util, [passthrough]),
+            ok = meck:new(aws_auth_validate_arn_lock, [passthrough]),
+            ok = meck:new(httpc, [unstick, passthrough]),
+            ok = meck:new(inets, [unstick, passthrough]),
+            meck:expect(aws_arn_util, resolve_arn, fun(_Arn) -> {ok, ?SECRET} end),
+            %% with_lock just runs the closure inline for the test.
+            meck:expect(aws_auth_validate_arn_lock, with_lock, fun(F) -> F() end),
+            %% Let the ephemeral probe profile start/stop so execution reaches
+            %% build_client_ssl_opts (which resolves the ARN) -- otherwise an
+            %% inets:start failure in the bare eunit node short-circuits to
+            %% connection_failed before any resolve.
+            meck:expect(inets, start, fun(httpc, _) -> {ok, self()} end),
+            meck:expect(inets, stop, fun(httpc, _) -> ok end),
+            meck:expect(httpc, set_options, fun(_, _) -> ok end),
+            meck:expect(httpc, request, fun(_M, _R, _H, _O, _P) ->
+                {error, {failed_connect, []}}
+            end),
+            ok
+        end,
+        fun(_) ->
+            meck:unload(inets),
+            meck:unload(httpc),
+            meck:unload(aws_auth_validate_arn_lock),
+            meck:unload(aws_arn_util)
+        end,
+        fun(_) ->
+            Body = base_body(#{
+                <<"ssl_options">> => #{
+                    <<"cacertfile_arn">> => <<"arn:aws:s3:::ca">>,
+                    <<"verify">> => <<"verify_peer">>
+                }
+            }),
+            _Result = aws_auth_validate_http:validate(Body),
+            [
+                ?_assert(meck:num_calls(aws_arn_util, resolve_arn, '_') >= 1)
+            ]
+        end}.
+
+%%--------------------------------------------------------------------
+%% R6: a resolved secret (CA/cert/key PEM) must never reach a result term,
+%% log, or crash report -- even when the probe raises with the secret in scope.
+%% Mirrors ldap_bind_raise_does_not_leak_password_test_.
+%%--------------------------------------------------------------------
+
+%% The resolved cacert sentinel must not appear in the rendered result, whether
+%% the path lands on tls_failed (no-trust-anchor) or connection_failed.
+%% NOTE: this is a DEFENSIVE check -- the non-PEM sentinel is discarded at
+%% public_key:pem_decode (returns []) so it never enters the ssl opts in
+%% practice. The stronger, load-bearing no-leak exercise (where the sentinel
+%% reaches the probe and a raise carries it) is http_probe_raise_does_not_leak.
+http_cacert_resolution_does_not_leak_test_() ->
+    {setup,
+        fun() ->
+            ok = meck:new(aws_arn_util, [passthrough]),
+            ok = meck:new(aws_auth_validate_arn_lock, [passthrough]),
+            ok = meck:new(httpc, [unstick, passthrough]),
+            meck:expect(aws_arn_util, resolve_arn, fun(_Arn) -> {ok, ?SECRET} end),
+            meck:expect(aws_auth_validate_arn_lock, with_lock, fun(F) -> F() end),
+            meck:expect(httpc, request, fun(_M, _R, _H, _O, _P) ->
+                {error, {failed_connect, []}}
+            end),
+            ok
+        end,
+        fun(_) ->
+            meck:unload(httpc),
+            meck:unload(aws_auth_validate_arn_lock),
+            meck:unload(aws_arn_util)
+        end,
+        fun(_) ->
+            Body = base_body(#{
+                <<"ssl_options">> => #{
+                    <<"cacertfile_arn">> => <<"arn:aws:s3:::ca">>,
+                    <<"verify">> => <<"verify_peer">>
+                }
+            }),
+            Result = aws_auth_validate_http:validate(Body),
+            Rendered = lists:flatten(io_lib:format("~p", [Result])),
+            [
+                ?_assertMatch({error, _, _}, Result),
+                ?_assertEqual(nomatch, string_find(Rendered, ?SECRET))
+            ]
+        end}.
+
+%% Worst case: the probe RAISES with a secret-bearing term (httpc:request/5
+%% raises {boom, Sentinel}). do_http_validate's try/catch must collapse ANY
+%% raise to {error, connection_failed, ?REASON_CONNECTION}, and the rendered
+%% result must not contain the sentinel. Direct HTTP analogue of the LDAP
+%% simple_bind raise test.
+%%
+%% We deliberately omit certfile_arn/keyfile_arn so build_client_ssl_opts
+%% succeeds (no PEM-decode of the sentinel) and the probe actually runs,
+%% reaching the mocked httpc:request that raises. The sentinel is injected
+%% into the raise term itself -- the worst case for a crash-report leak.
+http_probe_raise_does_not_leak_test_() ->
+    {setup,
+        fun() ->
+            ok = meck:new(httpc, [unstick, passthrough]),
+            ok = meck:new(inets, [unstick, passthrough]),
+            ok = meck:new(inet, [unstick, passthrough]),
+            %% The probe raises with the sentinel in the raised term.
+            meck:expect(httpc, request, fun(_M, _R, _H, _O, _P) ->
+                erlang:error({boom, ?SECRET})
+            end),
+            %% Let the ephemeral profile start/stop succeed.
+            meck:expect(inets, start, fun(httpc, _) -> {ok, self()} end),
+            meck:expect(inets, stop, fun(httpc, _) -> ok end),
+            meck:expect(httpc, set_options, fun(_, _) -> ok end),
+            %% Pin the resolved IP so resolve_and_pin succeeds (literal IP
+            %% in the URL skips DNS).
+            meck:expect(inet, getaddrs, fun(_, _) -> {ok, [{8, 8, 8, 8}]} end),
+            ok
+        end,
+        fun(_) ->
+            meck:unload(inet),
+            meck:unload(inets),
+            meck:unload(httpc)
+        end,
+        fun(_) ->
+            %% Body with a literal-IP URL so resolve_and_pin does not need DNS.
+            %% No certfile/keyfile -- build_client_ssl_opts returns {ok, [...]}.
+            Body = base_body(#{
+                <<"ssl_options">> => #{<<"verify">> => <<"verify_none">>}
+            }),
+            Result = aws_auth_validate_http:validate(Body),
+            Rendered = lists:flatten(io_lib:format("~p", [Result])),
+            [
+                ?_assertMatch(
+                    {error, connection_failed, <<"could not connect to HTTP auth server">>},
+                    Result
+                ),
+                ?_assertEqual(nomatch, string_find(Rendered, ?SECRET))
+            ]
+        end}.
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+%% A minimally-valid body that PASSES every pure-validation step (paths,
+%% http_method, ssl_options, SSRF guard) so the ARN-first / probe path is the
+%% next thing reached. Uses a public literal IP host so classify_ip/1 returns
+%% allow in the pure phase (mirrors base_body/0 in aws_auth_validate_tests,
+%% which used 8.8.8.8 for the same reason). https so ssl_options/ARNs matter.
+base_body() ->
+    base_body(#{}).
+
+base_body(Overrides) when is_map(Overrides) ->
+    Base = #{<<"user_path">> => <<"https://8.8.8.8/auth/user">>},
+    maps:merge(Base, Overrides).
+
+%% Convenience: a body whose user_path is an arbitrary URL string.
+body_with_user_path(Url) ->
+    #{<<"user_path">> => Url}.
+
+%% Convenience: base body plus an ssl_options object.
+body_with_ssl(SslOpts) ->
+    base_body(#{<<"ssl_options">> => SslOpts}).
+
+string_find(Haystack, Needle) when is_binary(Needle) ->
+    string:find(Haystack, binary_to_list(Needle));
+string_find(Haystack, Needle) ->
+    string:find(Haystack, Needle).

--- a/test/aws_auth_validate_mgmt_SUITE.erl
+++ b/test/aws_auth_validate_mgmt_SUITE.erl
@@ -97,13 +97,20 @@ init_per_group(feature_enabled, Config) ->
     setup_broker(Config, [
         {auth_validation_enabled, true},
         {auth_validation_max_concurrent, 1},
-        {auth_validation_max_body_size, 1024}
+        {auth_validation_max_body_size, 1024},
+        %% base_body/0 uses a loopback server (127.0.0.1); without this the
+        %% SSRF filter (is_allowed_server/1) rejects it with input_invalid in
+        %% parse_servers BEFORE later pipeline stages run, so cases that assert
+        %% a later outcome (e.g. config_conflict_returns_422) would wrongly see
+        %% a 400. Allow private/loopback addresses for these in-suite requests.
+        {auth_validation_allow_private_networks, true}
     ]);
 init_per_group(feature_enabled_custom_tag, Config) ->
     setup_broker(Config, [
         {auth_validation_enabled, true},
         {auth_validation_max_concurrent, 1},
         {auth_validation_max_body_size, 1024},
+        {auth_validation_allow_private_networks, true},
         %% guest has the administrator tag but not monitoring, so the
         %% authorize_tag/3 membership check fails -> 401.
         {auth_validation_required_user_tag, monitoring}


### PR DESCRIPTION
*Issue #43*

Allow customers to conveniently validate their HTTP broker configs via /api/aws/auth/validate/http with more descriptive (but safe) error messages instead of blindly guessing error causes, changing the config, and restarting the broker.

This endpoint extends off of the validation endpoint introduced in PR #55, with this PR focusing on HTTP. The shared framework (Cowboy handler, registry, concurrency semaphore, backend behaviour, config schema, audit logging) is reused unchanged; this PR adds the HTTP backend, its SSRF address policy, and mutual-TLS support.

**Scope: reachability-only.** Unlike an LDAP bind, an HTTP auth server answers `allow`/`deny` for a specific {user, vhost, resource} tuple -- a `deny` is a correctly-working server, not a misconfiguration. So this validates **reachability and (m)TLS**, not authorization outcome: it confirms each configured `*_path` is a well-formed http(s) URL and is reachable over (m)TLS, returning a response shaped like an auth server. A credentialed-probe mode is intentionally deferred.

### Core subsystem (src/aws_auth_validate_http)
  - aws_auth_validate_http -- the HTTP backend (aws_auth_validate_backend behaviour: method_name/0, validate/1, allowed_fields/0). Pipeline: pure input validation (URL/method/ssl_options shape) → SSRF address guard → ARN resolution (cacertfile/certfile/keyfile) → ephemeral httpc probe over (m)TLS → fixed-category result.
  - URL parsing rejects non-http(s) schemes, out-of-range ports, and userinfo (`user:pass@host`).
  - Accepted request fields mirror the customer's `auth_http.*` config so a config can be pasted as-is: `user_path` (required), `vhost_path`/`resource_path`/`topic_path` (optional), `http_method` (get/post), and `ssl_options` (`verify`, `depth`, `versions`, `sni`, `cacertfile_arn`, `certfile_arn`, `keyfile_arn`).
  - Mutual TLS: `certfile_arn` (S3-hosted client cert PEM) + `keyfile_arn` (Secrets Manager client key PEM) are resolved and decoded into in-memory ssl `{cert,_}`/`{key,_}` options. `verify_peer` with no obtainable trust anchor fails loudly (`tls_failed`) rather than silently downgrading to `verify_none`.

### SSRF address policy (the central security concern for HTTP)
  Unlike LDAP, the validator issues requests to customer-supplied URLs from the broker's network position, so SSRF is front-and-center. Two-phase guard:
  - **Pure phase:** scheme allowlist (http/https) + literal-IP classification against a broker-infra denylist, before any DNS or network.
  - **Network phase:** resolve the host to all A/AAAA records, deny if any is infra, then connect to the **pinned IP literal** (original hostname kept only in the Host header + SNI) so httpc cannot re-resolve to a different address -- the DNS-rebinding/TOCTOU defense.
  - Denylist is **broker-infra only** (IMDS 169.254.169.254 + fd00:ec2::254, loopback, link-local, unspecified), with v6-embedded-v4 unwrapping (mapped/compatible/NAT64/6to4) so a v6 encoding cannot smuggle a denied v4. RFC1918 / unique-local are **deliberately allowed** -- a customer's HTTP auth server normally lives in their VPC. Redirects are not followed.

### Config (priv/schema/aws.schema, aws_sup, registry)
  - No new config schema or supervised workers: the HTTP method reuses the existing `aws.auth_validation.*` settings and the concurrency semaphore.
  - The `http` method is **opt-in** in the registry (defaults disabled even when `ldap` is enabled), so enabling validation for LDAP does not silently bring the HTTP probe online.

### Tests
  - aws_auth_validate_http_tests (eunit, 58 tests): behaviour callbacks; pure input validation (every fixed reason -- paths, URL, scheme, http_method, ssl_options shape/keys/values, cert-without-key); SSRF classify_ip (IMDS/loopback/link-local denied, RFC1918/public allowed, v6-embedded-v4 unwrap denied); ARN-first ordering (resolve not called when pure validation fails); and R6 no-leak (resolved secret never appears in a rendered error, including the probe-raise path).
  - Internal helpers are exposed under `-ifdef(TEST)` for direct unit coverage, mirroring the LDAP backend.

### Response contract
  Reuses the existing fixed category set -- **no new category** is introduced. All failures return `{"error": "<category>", "message": "<constant>"}`, never a raw httpc error, target URL, response body, or resolved secret.
  HTTP-relevant categories: input_invalid / connection_failed / tls_failed (400), auth_failed (422, borrowed for "reachable but not auth-server-shaped"), plus the inherited pipeline-level categories. 204 on success.

### Security notes
  - Method disabled by default and opt-in even when other methods are enabled; admin-tag gated.
  - Ephemeral connections only, on a dedicated per-validation httpc profile (no pooled/reused TLS sessions, so one validation's client identity cannot leak into the next). No broker/auth-backend state mutation.
  - ARNs (cacertfile/certfile/keyfile) are resolved only after all pure input validation passes, so malformed requests never trigger a secret fetch.
  - `assume_role` is deliberately not accepted (confused-deputy on the broker's global AWS credentials), consistent with #55.

### Excluded from this PR
  - **Credentialed / authorization-outcome probing** (asserting a principal is allowed) -- needs a real test principal and a definition of "expected outcome"; deferred.
  - **OAuth** -- a separate method/PR.
  - **CGNAT (100.64.0.0/10) blocking** -- the LDAP backend blocks all private/shared ranges by default (a directory is not public-facing); the HTTP backend deliberately blocks only broker-owned infra and allows customer-VPC ranges, so CGNAT (customer/provider space reachable by legitimate auth servers) is intentionally allowed. This asymmetry follows from the two backends' opposite denylist policies, not an oversight.
