### PR TITLE
Evaluate LDAP authorization queries for a supplied principal

### DIFF
--- a/src/aws_auth_validate_ldap.erl
+++ b/src/aws_auth_validate_ldap.erl
@@ -120,6 +120,7 @@
 -define(REASON_ARN_RESOLVE, <<"failed to resolve ARN">>).
 -define(REASON_BAD_DN_LOOKUP_BASE, <<"dn_lookup_base must be a non-empty string">>).
 -define(REASON_BAD_DN_LOOKUP_ATTR, <<"dn_lookup_attribute must be a non-empty string">>).
+-define(REASON_BAD_USERNAME, <<"username must be a non-empty string">>).
 -define(REASON_BAD_QUERIES, <<"queries must be an object of query strings">>).
 -define(REASON_BAD_QUERY_VALUE, <<"each query must be a non-empty string">>).
 -define(REASON_QUERY_PARSE, <<"one or more authorization queries are not valid">>).
@@ -128,6 +129,12 @@
 ).
 -define(REASON_AUTHZ_UNVERIFIED,
     <<"a DN referenced by an authorization query could not be verified">>
+).
+-define(REASON_NOT_MEMBER,
+    <<"the supplied username is not authorized by one or more authorization queries">>
+).
+-define(REASON_USERNAME_UNRESOLVED,
+    <<"the supplied username could not be resolved to a single directory entry">>
 ).
 
 method_name() ->
@@ -144,6 +151,7 @@ allowed_fields() ->
         <<"ssl_options">>,
         <<"dn_lookup_base">>,
         <<"dn_lookup_attribute">>,
+        <<"username">>,
         <<"queries">>
     ].
 
@@ -190,6 +198,7 @@ parse_input(Body) ->
         fun parse_ssl_options/2,
         fun parse_dn_lookup_base/2,
         fun parse_dn_lookup_attribute/2,
+        fun parse_username/2,
         fun parse_queries/2
     ],
     parse_input(Steps, Body, #{timeout => connection_timeout_ms()}).
@@ -382,6 +391,22 @@ parse_dn_lookup_attribute(Body, Acc) ->
             {ok, Acc#{dn_lookup_attribute => binary_to_list(Attr)}};
         _ ->
             {error, input_invalid, ?REASON_BAD_DN_LOOKUP_ATTR}
+    end.
+
+%% Optional principal to evaluate authorization queries against. When absent we
+%% store `none' and the authz check stays in its literal-DN reachability mode
+%% (exactly today's behavior). When present, the bound service connection
+%% resolves it to a user DN and the queries' ${username}/${user_dn} placeholders
+%% are filled so membership is actually evaluated. The username is an identifier,
+%% not a credential -- no principal password is accepted (see resolve_user_dn/2).
+parse_username(Body, Acc) ->
+    case maps:get(<<"username">>, Body, undefined) of
+        undefined ->
+            {ok, Acc#{username => none}};
+        Username when is_binary(Username), byte_size(Username) > 0 ->
+            {ok, Acc#{username => binary_to_list(Username)}};
+        _ ->
+            {error, input_invalid, ?REASON_BAD_USERNAME}
     end.
 
 %% `queries' is an optional object mapping query names (tags, vhost_access,
@@ -607,13 +632,61 @@ peer_allowed({ok, {IP, _Port}}) when tuple_size(IP) =:= 8 ->
 peer_allowed(_) ->
     blocked.
 
-%% After a successful bind, run the optional DN-lookup and authorization
-%% checks in sequence on the same bound handle. The first failure wins; if
-%% none are configured (or all pass) the request succeeds with `ok'.
+%% After a successful bind, run the optional DN-lookup, principal resolution,
+%% and authorization checks in sequence on the same bound handle. The first
+%% failure wins; if none are configured (or all pass) the request succeeds with
+%% `ok'. When a username was supplied we resolve it to a user DN here (between
+%% the dn_lookup-base reachability check and the query evaluation) so the authz
+%% queries can be evaluated for that principal rather than only reachability-
+%% checked.
 post_bind_checks(Handle, Params) ->
     case check_dn_lookup(Handle, Params) of
-        ok -> check_authz_queries(Handle, Params);
-        {error, _, _} = Err -> Err
+        ok ->
+            case resolve_principal_dn(Handle, Params) of
+                {ok, UserDn} ->
+                    check_authz_queries(Handle, Params#{resolved_user_dn => UserDn});
+                {error, _, _} = Err ->
+                    Err
+            end;
+        {error, _, _} = Err ->
+            Err
+    end.
+
+%% Resolve the request-supplied username to a single user DN, using the bound
+%% service connection -- the same equalityMatch(dn_lookup_attribute, username)
+%% search rabbit_auth_backend_ldap:dn_lookup/2 runs. This is a read over the
+%% admin's own credentials; no principal password is involved. We read the
+%% matched entry's object_name (its DN), not an attribute value. Unlike the
+%% broker -- which silently falls back to an escaped user_dn pattern on 0/many
+%% matches -- the endpoint treats anything other than exactly one match as
+%% authz_unverified, since at validation time an unresolvable username is
+%% precisely the misconfiguration the admin wants surfaced.
+%%
+%% `none' means no username was supplied (or no dn_lookup config to resolve it
+%% with): we return `unknown', and query evaluation falls back to the literal-DN
+%% reachability path -- exactly today's behavior.
+resolve_principal_dn(_Handle, #{username := none}) ->
+    {ok, unknown};
+resolve_principal_dn(_Handle, #{dn_lookup_base := none}) ->
+    {ok, unknown};
+resolve_principal_dn(_Handle, #{dn_lookup_attribute := none}) ->
+    {ok, unknown};
+resolve_principal_dn(Handle, #{
+    username := Username,
+    dn_lookup_base := Base,
+    dn_lookup_attribute := Attr
+}) ->
+    case
+        eldap:search(Handle, [
+            {base, Base},
+            {filter, eldap:equalityMatch(Attr, Username)},
+            {attributes, ["distinguishedName"]}
+        ])
+    of
+        {ok, #eldap_search_result{entries = [#eldap_entry{object_name = Dn}]}} ->
+            {ok, Dn};
+        _ ->
+            {error, authz_unverified, ?REASON_USERNAME_UNRESOLVED}
     end.
 
 %%--------------------------------------------------------------------
@@ -637,18 +710,35 @@ check_dn_lookup(Handle, #{dn_lookup_base := Base}) ->
 %% Authorization query validation
 %%--------------------------------------------------------------------
 
-%% For each parsed query, extract the fully-literal DNs (those with no
-%% ${...} runtime placeholder) and confirm each exists and is readable by
-%% the bound user. Queries that reference only runtime-filled DNs contribute
-%% no checks -- they were already validated for grammar at parse time.
-check_authz_queries(Handle, #{queries := Queries}) ->
+%% Two modes, selected by whether a principal was resolved:
+%%
+%%   * No principal (resolved_user_dn = unknown) -- today's behavior. For each
+%%     parsed query, extract the fully-literal DNs (no ${...} placeholder) and
+%%     confirm each exists and is readable. Queries that reference only
+%%     runtime-filled DNs contribute no checks (grammar-validated at parse time).
+%%
+%%   * With a principal -- fill each query's ${username}/${user_dn}/${ad_*}
+%%     placeholders for that user, then *evaluate* it against the bound handle
+%%     (membership, existence, attribute comparisons), mirroring how
+%%     rabbit_auth_backend_ldap evaluates the same query. A query that evaluates
+%%     false is the real misconfiguration signal (the user is not authorized);
+%%     a node still carrying an unfillable per-operation placeholder
+%%     (${vhost}/${resource}/...) is grammar-checked-only and degrades rather
+%%     than failing.
+check_authz_queries(Handle, #{queries := Queries, resolved_user_dn := unknown}) ->
     LiteralDns = lists:usort(
         lists:flatmap(
             fun({_Name, Query}) -> aws_auth_validate_ldap_query:literal_dns(Query) end,
             Queries
         )
     ),
-    check_dns(Handle, LiteralDns).
+    check_dns(Handle, LiteralDns);
+check_authz_queries(Handle, #{queries := Queries, resolved_user_dn := UserDn} = Params) ->
+    Username = maps:get(username, Params),
+    Args =
+        [{username, Username}, {user_dn, UserDn}] ++
+            aws_auth_validate_ldap_query:ad_args(Username),
+    eval_queries(Handle, Queries, Args).
 
 check_dns(_Handle, []) ->
     ok;
@@ -657,6 +747,146 @@ check_dns(Handle, [DN | Rest]) ->
         true -> check_dns(Handle, Rest);
         _ -> {error, authz_unverified, ?REASON_AUTHZ_UNVERIFIED}
     end.
+
+%% Evaluate each query for the resolved principal. The first query that is
+%% conclusively false (the user is not authorized by it) wins and maps to
+%% authz_unverified; a query that cannot be evaluated (only unfillable
+%% per-operation placeholders) is skipped. All-pass/all-degrade -> ok.
+eval_queries(_Handle, [], _Args) ->
+    ok;
+eval_queries(Handle, [{_Name, Query} | Rest], Args) ->
+    Filled = aws_auth_validate_ldap_query:fill(Query, Args),
+    UserDn = proplists:get_value(user_dn, Args),
+    case eval_query(Handle, Filled, UserDn) of
+        skip -> eval_queries(Handle, Rest, Args);
+        true -> eval_queries(Handle, Rest, Args);
+        false -> {error, authz_unverified, ?REASON_NOT_MEMBER}
+    end.
+
+%% Evaluate one (already principal-filled) query against the bound handle,
+%% mirroring rabbit_auth_backend_ldap:evaluate0/4 minus the connection/creds
+%% machinery (the bind identity is fixed = the service account; the broker's
+%% as_user path is unreachable since no principal password exists). Returns
+%% `true' | `false' | `skip', where `skip' means the term could not be
+%% evaluated at validation time (an unfillable ${vhost}/${resource}/... DN, or a
+%% sub-result that itself degraded) and must not be treated as a failure.
+%% Composition guards against non-boolean (skipped) sub-results so `not'/`and'/
+%% `or' never badarg the way the broker's raw boolean ops could. UserDn is
+%% threaded through composition so nested membership terms can still evaluate.
+eval_query(_Handle, {constant, Bool}, _UserDn) when is_boolean(Bool) ->
+    Bool;
+eval_query(Handle, {exists, DN}, _UserDn) ->
+    eval_dn_probe(DN, fun(Dn) -> object_exists(Handle, Dn) end);
+eval_query(Handle, {in_group, DN}, UserDn) ->
+    eval_query(Handle, {in_group, DN, "member"}, UserDn);
+eval_query(Handle, {in_group, DN, Desc}, UserDn) ->
+    eval_membership(Handle, DN, Desc, UserDn);
+eval_query(Handle, {in_group_nested, DN}, UserDn) ->
+    eval_query(Handle, {in_group_nested, DN, "member"}, UserDn);
+eval_query(Handle, {in_group_nested, DN, Desc}, UserDn) ->
+    %% Nested membership needs a group-search base the endpoint does not model
+    %% (the broker's group_lookup_base). Rather than search a wrong base, fall
+    %% back to direct membership at the named group -- a safe subset that still
+    %% catches the common "is the user in THIS group" case; deeper nesting
+    %% degrades to that single hop.
+    eval_membership(Handle, DN, Desc, UserDn);
+eval_query(Handle, {in_group_nested, DN, Desc, _Scope}, UserDn) ->
+    eval_membership(Handle, DN, Desc, UserDn);
+eval_query(Handle, {'not', Sub}, UserDn) ->
+    %% Negate only a conclusive sub-result; a skipped sub-result stays skipped.
+    case eval_query(Handle, Sub, UserDn) of
+        skip -> skip;
+        Bool -> not Bool
+    end;
+eval_query(Handle, {'and', Subs}, UserDn) when is_list(Subs) ->
+    eval_and(Handle, Subs, UserDn);
+eval_query(Handle, {'or', Subs}, UserDn) when is_list(Subs) ->
+    eval_or(Handle, Subs, UserDn);
+eval_query(_Handle, _Other, _UserDn) ->
+    %% equals/match/for and any residual shape need per-operation context
+    %% (${vhost}/${resource}/...) or attribute reads the endpoint does not model
+    %% for validation; degrade rather than guess.
+    skip.
+
+%% Conjunction over true/false/skip: any conclusive false short-circuits to
+%% false; otherwise the result is true only if every conjunct is true, else skip
+%% (at least one conjunct degraded).
+eval_and(_Handle, [], _UserDn) ->
+    true;
+eval_and(Handle, [Sub | Rest], UserDn) ->
+    case eval_query(Handle, Sub, UserDn) of
+        false -> false;
+        skip -> eval_and_skip(Handle, Rest, UserDn);
+        true -> eval_and(Handle, Rest, UserDn)
+    end.
+
+%% After a conjunct degraded, a later conclusive false still makes the whole
+%% `and' false; otherwise it can only be skip (cannot prove all-true).
+eval_and_skip(_Handle, [], _UserDn) ->
+    skip;
+eval_and_skip(Handle, [Sub | Rest], UserDn) ->
+    case eval_query(Handle, Sub, UserDn) of
+        false -> false;
+        _ -> eval_and_skip(Handle, Rest, UserDn)
+    end.
+
+%% Disjunction over true/false/skip: any conclusive true short-circuits to true;
+%% otherwise false only if every disjunct is false, else skip.
+eval_or(_Handle, [], _UserDn) ->
+    false;
+eval_or(Handle, [Sub | Rest], UserDn) ->
+    case eval_query(Handle, Sub, UserDn) of
+        true -> true;
+        skip -> eval_or_skip(Handle, Rest, UserDn);
+        false -> eval_or(Handle, Rest, UserDn)
+    end.
+
+eval_or_skip(_Handle, [], _UserDn) ->
+    skip;
+eval_or_skip(Handle, [Sub | Rest], UserDn) ->
+    case eval_query(Handle, Sub, UserDn) of
+        true -> true;
+        _ -> eval_or_skip(Handle, Rest, UserDn)
+    end.
+
+%% Resolve a (filled) DN to a probe result, degrading when a placeholder
+%% survived (per-operation context we cannot supply).
+eval_dn_probe(DN, Probe) ->
+    case aws_auth_validate_ldap_query:is_evaluable(DN) of
+        true -> Probe(dn_str(DN));
+        false -> skip
+    end.
+
+%% Membership probe mirroring rabbit_auth_backend_ldap in_group/3: a base-scoped
+%% search at the group DN with an equalityMatch on the membership attribute
+%% (default "member") against the resolved user DN. A match means the user is a
+%% member. Distinct from object_exists/2, which only proves the group EXISTS;
+%% reusing that here would wrongly pass a real-but-non-member group. Any
+%% non-{ok,_} collapses to false (never raises -- R6).
+eval_membership(_Handle, _DN, _Desc, undefined) ->
+    %% No resolved principal in scope for this sub-result; degrade.
+    skip;
+eval_membership(Handle, DN, Desc, UserDn) ->
+    eval_dn_probe(DN, fun(GroupDn) -> member_exists(Handle, GroupDn, Desc, UserDn) end).
+
+member_exists(Handle, GroupDn, Desc, UserDn) ->
+    case
+        eldap:search(Handle, [
+            {base, GroupDn},
+            {filter, eldap:equalityMatch(Desc, UserDn)},
+            {attributes, ["objectClass"]},
+            {scope, eldap:baseObject()}
+        ])
+    of
+        {ok, #eldap_search_result{entries = Entries}} ->
+            length(Entries) > 0;
+        _ ->
+            false
+    end.
+
+dn_str({string, Pattern}) -> dn_str(Pattern);
+dn_str(DN) when is_binary(DN) -> binary_to_list(DN);
+dn_str(DN) when is_list(DN) -> DN.
 
 %% Base-scoped existence probe. Mirrors rabbit_auth_backend_ldap:object_exists/3
 %% (base object, present(objectClass) filter) so a DN this returns true for is

--- a/src/aws_auth_validate_ldap_query.erl
+++ b/src/aws_auth_validate_ldap_query.erl
@@ -13,7 +13,7 @@
 %% validation endpoint must not diverge from rabbit_auth_backend_ldap). A
 %% parity test in aws_auth_validate_tests guards against drift.
 %%
-%% Two deliberate differences from the upstream helper:
+%% Three deliberate differences from the upstream helper:
 %%   1. It returns {ok, Query} | {error, Reason} instead of throwing via
 %%      cuttlefish:invalid/2 -- this runs in the request path, not at
 %%      config-load time.
@@ -21,9 +21,18 @@
 %%      DNs that are fully literal (contain no ${...} runtime placeholder).
 %%      Those are the only DNs the endpoint can check for existence without
 %%      a runtime principal, and they drive the static reachability check.
+%%   3. It adds fill/2 (and ad_args/1, is_evaluable/1), which substitute a
+%%      request-supplied principal into ${...} placeholders so the backend can
+%%      *evaluate* membership queries, not just reachability-check static DNs.
+%%      fill/2 mirrors rabbit_auth_backend_ldap_util:fill/2 (raw substitution
+%%      for value sinks) and rabbit_ldap_rfc4514:fill_dn/2 (RFC 4514 escaping
+%%      for DN sinks, exempting the user_dn key). It is re-implemented here
+%%      rather than called directly because rabbitmq_auth_backend_ldap is only
+%%      a TEST_DEP, not a runtime dependency (same rationale as parse/1); a
+%%      parity test guards against drift.
 -module(aws_auth_validate_ldap_query).
 
--export([parse/1, literal_dns/1, is_literal/1]).
+-export([parse/1, literal_dns/1, is_literal/1, fill/2, is_evaluable/1, ad_args/1]).
 
 -export_type([query/0]).
 
@@ -178,6 +187,175 @@ dn_to_list(DN) when is_list(DN) -> DN.
 %% runtime by the broker's fill/2 (e.g. ${username}, ${vhost}).
 has_placeholder(Str) ->
     string:find(Str, "${") =/= nomatch.
+
+%% True when a DN pattern is *evaluable*: a concrete string that, after fill/2
+%% has substituted the principal placeholders, no longer contains any ${...}
+%% placeholder. Distinct from is_literal/1 only in intent -- is_literal/1 gates
+%% the no-principal reachability path (a DN that was literal to begin with);
+%% is_evaluable/1 gates the post-fill evaluation path (a DN that became concrete
+%% once the username/user_dn were filled in). A residual placeholder means the
+%% term keyed on per-operation context (${vhost}/${resource}/...) we cannot
+%% supply, so the backend skips (degrades) rather than failing it.
+-spec is_evaluable(term()) -> boolean().
+is_evaluable(DN) ->
+    is_literal(DN).
+
+%%--------------------------------------------------------------------
+%% Placeholder filling (principal substitution)
+%%--------------------------------------------------------------------
+
+%% Substitute the principal placeholders in a parsed query, returning a query
+%% term of the SAME shape with its DN/value sinks filled. Mirrors the broker's
+%% two-mode fill: DN-bearing operands (exists/in_group/in_group_nested/
+%% attribute) are RFC 4514-escaped per Args value (except the user_dn key,
+%% which already holds a complete DN), while value operands of equals/match and
+%% bare/{string,_} terms are filled raw (they are ACL value sinks, not DNs).
+%%
+%% Args is the principal context the endpoint can supply without a live AMQP
+%% operation: [{username, U}, {user_dn, D} | ad_args(U)]. Keys absent from a
+%% template are left untouched; values that cannot be stringified are dropped to
+%% "" (to_repl parity). Placeholders keyed on per-operation context
+%% (${vhost}/${resource}/${name}/${permission}) are simply not in Args, so they
+%% survive unfilled and the DN stays non-evaluable (the backend degrades it).
+-spec fill(query(), [{atom(), term()}]) -> query().
+fill({constant, _} = T, _Args) ->
+    T;
+fill({exists, DN}, Args) ->
+    {exists, fill_dn(DN, Args)};
+fill({in_group, DN}, Args) ->
+    {in_group, fill_dn(DN, Args)};
+fill({in_group, DN, Desc}, Args) ->
+    {in_group, fill_dn(DN, Args), Desc};
+fill({in_group_nested, DN}, Args) ->
+    {in_group_nested, fill_dn(DN, Args)};
+fill({in_group_nested, DN, Desc}, Args) ->
+    {in_group_nested, fill_dn(DN, Args), Desc};
+fill({in_group_nested, DN, Desc, Scope}, Args) ->
+    {in_group_nested, fill_dn(DN, Args), Desc, Scope};
+fill({attribute, DN, AttrName}, Args) ->
+    {attribute, fill_dn(DN, Args), AttrName};
+fill({'not', SubQuery}, Args) ->
+    {'not', fill(SubQuery, Args)};
+fill({'and', Queries}, Args) when is_list(Queries) ->
+    {'and', [fill(Q, Args) || Q <- Queries]};
+fill({'or', Queries}, Args) when is_list(Queries) ->
+    {'or', [fill(Q, Args) || Q <- Queries]};
+fill({for, Clauses}, Args) when is_list(Clauses) ->
+    {for, [fill_for_clause(C, Args) || C <- Clauses]};
+fill({equals, A1, A2}, Args) ->
+    {equals, fill_value(A1, Args), fill_value(A2, Args)};
+fill({match, A1, A2}, Args) ->
+    {match, fill_value(A1, Args), fill_value(A2, Args)};
+%% tag_queries: a list of {Tag, SubQuery} pairs. Recurse into the sub-query of
+%% each pair; leave any non-pair element untouched.
+fill(List, Args) when is_list(List) ->
+    [fill_list_element(E, Args) || E <- List];
+fill(Other, _Args) ->
+    Other.
+
+fill_for_clause({Type, Value, SubQuery}, Args) ->
+    {Type, Value, fill(SubQuery, Args)};
+fill_for_clause(Other, _Args) ->
+    Other.
+
+fill_list_element({Tag, SubQuery}, Args) ->
+    {Tag, fill(SubQuery, Args)};
+fill_list_element(Other, _Args) ->
+    Other.
+
+%% A value operand of equals/match: a {string, Pattern} or a bare string is an
+%% ACL value sink and is filled RAW (no DN escaping); an embedded DN-bearing
+%% term (e.g. {attribute, DN, _}) recurses through fill/2 so its DN is escaped.
+fill_value({string, Pattern}, Args) ->
+    {string, fill_raw(Pattern, Args)};
+fill_value(Operand, Args) when is_tuple(Operand) ->
+    fill(Operand, Args);
+fill_value(Operand, Args) ->
+    case is_dn_string(to_str(Operand)) of
+        true -> fill_raw(Operand, Args);
+        false -> Operand
+    end.
+
+%% Active-Directory split: a DOMAIN\user username yields ${ad_domain}/${ad_user}
+%% fill args; any other shape yields none. Mirrors
+%% rabbit_auth_backend_ldap_util:get_active_directory_args/1.
+-spec ad_args(string() | binary()) -> [{atom(), string()}].
+ad_args(Username) when is_binary(Username) ->
+    ad_args(binary_to_list(Username));
+ad_args(Username) when is_list(Username) ->
+    case string:split(Username, "\\", all) of
+        [Domain, User] when Domain =/= [], User =/= [] ->
+            [{ad_domain, Domain}, {ad_user, User}];
+        _ ->
+            []
+    end;
+ad_args(_) ->
+    [].
+
+%% Fill a DN sink: RFC 4514-escape every Args value except user_dn (which is
+%% already a complete DN), then substitute. Mirrors rabbit_ldap_rfc4514:fill_dn/2.
+fill_dn({string, Pattern}, Args) ->
+    {string, fill_dn(Pattern, Args)};
+fill_dn(DN, Args) ->
+    fill_raw(DN, [{K, escape_arg(K, V)} || {K, V} <- Args]).
+
+escape_arg(user_dn, V) -> V;
+escape_arg(_, V) -> escape_value(V).
+
+%% Raw template fill: replace each ${Key} with to_repl(Value), per Args entry,
+%% globally. Mirrors rabbit_auth_backend_ldap_util:fill/2 exactly (including the
+%% & / backslash escaping in to_repl that protects re:replace's replacement
+%% syntax). Operates on, and returns, a flat string.
+fill_raw(Fmt, []) ->
+    to_str(Fmt);
+fill_raw(Fmt, [{K, V} | T]) ->
+    Var = "\\$\\{" ++ atom_to_list(K) ++ "\\}",
+    fill_raw(re:replace(to_str(Fmt), Var, to_repl(V), [global, {return, list}]), T).
+
+%% Escape backslash and ampersand so a substituted value cannot inject
+%% re:replace replacement directives. Unstringifiable values become "".
+to_repl(V) when is_atom(V) -> to_repl(atom_to_list(V));
+to_repl(V) when is_binary(V) -> to_repl(binary_to_list(V));
+to_repl([]) -> [];
+to_repl([$\\ | T]) -> [$\\, $\\ | to_repl(T)];
+to_repl([$& | T]) -> [$\\, $& | to_repl(T)];
+to_repl([H | T]) when is_integer(H) -> [H | to_repl(T)];
+to_repl(_) -> [].
+
+%% RFC 4514 escaping of a DN attribute value (Section 2.4): backslash-escape
+%%   , + " \ < > ; and NUL anywhere; a leading SPACE or #; a trailing SPACE.
+%% Mirrors rabbit_ldap_rfc4514:escape_value/1.
+escape_value(V) when is_binary(V) -> escape_value(binary_to_list(V));
+escape_value(V) when is_atom(V) -> escape_value(atom_to_list(V));
+escape_value([]) -> [];
+escape_value([H | T]) when H =:= $\s; H =:= $# -> [$\\, H | escape_middle(T)];
+escape_value(V) when is_list(V) -> escape_middle(V);
+escape_value(V) -> V.
+
+escape_middle([]) ->
+    [];
+escape_middle([$\s]) ->
+    [$\\, $\s];
+escape_middle([H | T]) ->
+    case is_special(H) of
+        true -> [$\\, H | escape_middle(T)];
+        false -> [H | escape_middle(T)]
+    end.
+
+is_special($,) -> true;
+is_special($+) -> true;
+is_special($") -> true;
+is_special($\\) -> true;
+is_special($<) -> true;
+is_special($>) -> true;
+is_special($;) -> true;
+is_special(0) -> true;
+is_special(_) -> false.
+
+to_str(V) when is_binary(V) -> binary_to_list(V);
+to_str(V) when is_list(V) -> V;
+to_str(V) when is_atom(V) -> atom_to_list(V);
+to_str(V) -> V.
 
 %% A printable flat string (proper list of integers in a sane char range).
 is_dn_string([]) ->

--- a/test/aws_auth_validate_ldap_SUITE.erl
+++ b/test/aws_auth_validate_ldap_SUITE.erl
@@ -43,8 +43,12 @@
 %% A second user, used as a group member / DN-lookup target.
 -define(ALICE_DN, "cn=alice,ou=people,dc=rabbitmq,dc=com").
 -define(ALICE_PW, "alice-password").
-%% A group that really exists (for authz query reachability checks).
+%% A group that really exists (for authz query reachability checks). Both svc
+%% and alice are members.
 -define(ADMINS_GROUP_DN, "cn=admins,ou=groups,dc=rabbitmq,dc=com").
+%% A group that exists but does NOT include alice (only svc), for the negative
+%% membership case.
+-define(OTHERS_GROUP_DN, "cn=others,ou=groups,dc=rabbitmq,dc=com").
 %% A group that does NOT exist (for the negative authz case).
 -define(MISSING_GROUP_DN, "cn=does-not-exist,ou=groups,dc=rabbitmq,dc=com").
 
@@ -72,6 +76,12 @@ groups() ->
             authz_query_existing_group_returns_ok,
             authz_query_missing_group_returns_authz_unverified,
             authz_query_runtime_placeholder_returns_ok,
+            username_in_group_returns_ok,
+            username_in_group_placeholder_dn_returns_ok,
+            username_not_in_group_returns_authz_unverified,
+            username_unresolvable_returns_authz_unverified,
+            username_runtime_placeholder_degrades_returns_ok,
+            username_membership_parity_with_backend,
             parity_with_backend_bind
         ]}
     ].
@@ -253,13 +263,147 @@ authz_query_missing_group_returns_authz_unverified(Config) ->
     ?assertMatch({error, authz_unverified, _}, validate(Config, Body)).
 
 %% A query whose only DN contains a ${...} placeholder has no literal DN to
-%% check, so it passes (grammar-validated, not directory-checked).
+%% check, so it passes (grammar-validated, not directory-checked). NOTE: this
+%% case supplies NO username, so it exercises the unchanged literal-DN path --
+%% a backward-compatibility guard for the new username feature below.
 authz_query_runtime_placeholder_returns_ok(Config) ->
     Query = <<"{in_group, \"cn=${username},ou=groups,dc=rabbitmq,dc=com\"}">>,
     Body = (base_body(Config))#{
         <<"queries">> => #{<<"tags">> => Query}
     },
     ?assertEqual(ok, validate(Config, Body)).
+
+%%--------------------------------------------------------------------
+%% Authorization query EVALUATION (username supplied)
+%%--------------------------------------------------------------------
+%% These supply a `username', so the endpoint resolves it to a DN over the
+%% bound service handle and evaluates membership -- not just reachability.
+
+%% alice IS a member of cn=admins (member=[svc,alice]); a literal in_group on
+%% that group, evaluated for username=alice, returns ok.
+username_in_group_returns_ok(Config) ->
+    Query = list_to_binary("{in_group, \"" ++ ?ADMINS_GROUP_DN ++ "\"}"),
+    Body = (base_body(Config))#{
+        <<"username">> => <<"alice">>,
+        <<"dn_lookup_base">> => list_to_binary(?PEOPLE_OU),
+        <<"dn_lookup_attribute">> => <<"cn">>,
+        <<"queries">> => #{<<"vhost_access">> => Query}
+    },
+    ?assertEqual(ok, validate(Config, Body)).
+
+%% A ${username} placeholder DN that the broker would fill: with username=alice
+%% it resolves to cn=alice,ou=people and is a real entry, so membership against
+%% admins (filled DN) is evaluated and returns ok. Proves the fill + resolve +
+%% equalityMatch(member, userDN) path, not mere reachability.
+username_in_group_placeholder_dn_returns_ok(Config) ->
+    Query = <<"{in_group, \"cn=admins,ou=groups,dc=rabbitmq,dc=com\"}">>,
+    Body = (base_body(Config))#{
+        <<"username">> => <<"alice">>,
+        <<"dn_lookup_base">> => list_to_binary(?PEOPLE_OU),
+        <<"dn_lookup_attribute">> => <<"cn">>,
+        <<"queries">> => #{<<"tags">> => Query}
+    },
+    ?assertEqual(ok, validate(Config, Body)).
+
+%% alice is NOT a member of cn=others (member=[svc] only); evaluating membership
+%% for username=alice returns authz_unverified even though the group exists.
+username_not_in_group_returns_authz_unverified(Config) ->
+    Query = list_to_binary("{in_group, \"" ++ ?OTHERS_GROUP_DN ++ "\"}"),
+    Body = (base_body(Config))#{
+        <<"username">> => <<"alice">>,
+        <<"dn_lookup_base">> => list_to_binary(?PEOPLE_OU),
+        <<"dn_lookup_attribute">> => <<"cn">>,
+        <<"queries">> => #{<<"vhost_access">> => Query}
+    },
+    ?assertMatch({error, authz_unverified, _}, validate(Config, Body)).
+
+%% A username with no matching directory entry cannot be resolved to a single
+%% DN, so the endpoint returns authz_unverified (deliberate divergence from the
+%% broker's silent escaped-DN fallback: surface the misconfiguration).
+username_unresolvable_returns_authz_unverified(Config) ->
+    Query = list_to_binary("{in_group, \"" ++ ?ADMINS_GROUP_DN ++ "\"}"),
+    Body = (base_body(Config))#{
+        <<"username">> => <<"ghost">>,
+        <<"dn_lookup_base">> => list_to_binary(?PEOPLE_OU),
+        <<"dn_lookup_attribute">> => <<"cn">>,
+        <<"queries">> => #{<<"vhost_access">> => Query}
+    },
+    ?assertMatch({error, authz_unverified, _}, validate(Config, Body)).
+
+%% A DN keyed on per-operation context (${vhost}) cannot be filled even with a
+%% username, so that query node degrades (grammar-checked only) and the request
+%% still succeeds -- graceful degradation, not a hard failure.
+username_runtime_placeholder_degrades_returns_ok(Config) ->
+    Query = <<"{in_group, \"cn=admins,ou=${vhost},dc=rabbitmq,dc=com\"}">>,
+    Body = (base_body(Config))#{
+        <<"username">> => <<"alice">>,
+        <<"dn_lookup_base">> => list_to_binary(?PEOPLE_OU),
+        <<"dn_lookup_attribute">> => <<"cn">>,
+        <<"queries">> => #{<<"vhost_access">> => Query}
+    },
+    ?assertEqual(ok, validate(Config, Body)).
+
+%% R11/R12 membership parity: the endpoint's in_group decision for a resolved
+%% principal must match a direct eldap equalityMatch(member, userDN) search --
+%% the same primitive rabbit_auth_backend_ldap:in_group/3 runs. Check both the
+%% positive (admins) and negative (others) group for alice.
+username_membership_parity_with_backend(Config) ->
+    Port = ?config(ldap_port, Config),
+    AliceDn = ?ALICE_DN,
+    Cases = [
+        {?ADMINS_GROUP_DN, true},
+        {?OTHERS_GROUP_DN, false}
+    ],
+    [
+        begin
+            Query = list_to_binary("{in_group, \"" ++ GroupDn ++ "\"}"),
+            Body = (base_body(Config))#{
+                <<"username">> => <<"alice">>,
+                <<"dn_lookup_base">> => list_to_binary(?PEOPLE_OU),
+                <<"dn_lookup_attribute">> => <<"cn">>,
+                <<"queries">> => #{<<"vhost_access">> => Query}
+            },
+            EndpointOk =
+                case validate(Config, Body) of
+                    ok -> true;
+                    {error, authz_unverified, _} -> false
+                end,
+            BackendOk = direct_member(Port, GroupDn, AliceDn),
+            ?assertEqual(
+                Expected,
+                EndpointOk,
+                lists:flatten(io_lib:format("endpoint membership for ~ts", [GroupDn]))
+            ),
+            ?assertEqual(
+                BackendOk,
+                EndpointOk,
+                lists:flatten(io_lib:format("membership parity for ~ts", [GroupDn]))
+            )
+        end
+     || {GroupDn, Expected} <- Cases
+    ],
+    ok.
+
+%% Direct base-scoped equalityMatch(member, UserDN) at the group DN -- the
+%% broker's in_group primitive -- bound as the rootdn.
+direct_member(Port, GroupDn, UserDn) ->
+    {ok, H} = eldap:open(["localhost"], [{port, Port}]),
+    ok = eldap:simple_bind(H, ?ADMIN_DN, ?ADMIN_PW),
+    Result =
+        case
+            eldap:search(H, [
+                {base, GroupDn},
+                {filter, eldap:equalityMatch("member", UserDn)},
+                {attributes, ["objectClass"]},
+                {scope, eldap:baseObject()}
+            ])
+        of
+            {ok, {eldap_search_result, Entries, _Ref, _Ctrls}} -> length(Entries) > 0;
+            {ok, {eldap_search_result, Entries, _Ref}} -> length(Entries) > 0;
+            _ -> false
+        end,
+    catch eldap:close(H),
+    Result.
 
 %%--------------------------------------------------------------------
 %% R12: parity with the broker's bind path
@@ -395,6 +539,13 @@ seed(Port) ->
             {"cn", ["admins"]},
             {"member", [?BIND_DN, ?ALICE_DN]}
         ]),
+        %% A group alice is NOT a member of (only svc), for the negative
+        %% membership case.
+        ok = add(H, ?OTHERS_GROUP_DN, [
+            {"objectClass", ["groupOfNames"]},
+            {"cn", ["others"]},
+            {"member", [?BIND_DN]}
+        ]),
         ok
     after
         catch eldap:close(H)
@@ -406,6 +557,7 @@ delete_seed(Port) ->
         [
             del(H, DN)
          || DN <- [
+                ?OTHERS_GROUP_DN,
                 ?ADMINS_GROUP_DN,
                 ?ALICE_DN,
                 ?BIND_DN,

--- a/test/aws_auth_validate_tests.erl
+++ b/test/aws_auth_validate_tests.erl
@@ -172,6 +172,7 @@ ldap_allowed_fields_test() ->
             <<"ssl_options">>,
             <<"dn_lookup_base">>,
             <<"dn_lookup_attribute">>,
+            <<"username">>,
             <<"queries">>
         ]
     ].
@@ -673,6 +674,153 @@ literal_dns_bare_string_query_test() ->
     %% value, not a DN, so it contributes nothing.
     {ok, Q} = aws_auth_validate_ldap_query:parse(<<"\"just a string\"">>),
     ?assertEqual([], aws_auth_validate_ldap_query:literal_dns(Q)).
+
+%%--------------------------------------------------------------------
+%% Placeholder filling (aws_auth_validate_ldap_query:fill/2)
+%%--------------------------------------------------------------------
+
+%% A literal in_group DN is unchanged by fill/2 and becomes evaluable.
+fill_in_group_literal_test() ->
+    {ok, Q} = aws_auth_validate_ldap_query:parse(
+        <<"{in_group, \"cn=admins,ou=groups,dc=x,dc=com\"}">>
+    ),
+    {in_group, DN} = aws_auth_validate_ldap_query:fill(Q, [{username, "alice"}]),
+    ?assertEqual("cn=admins,ou=groups,dc=x,dc=com", DN),
+    ?assert(aws_auth_validate_ldap_query:is_evaluable(DN)).
+
+%% A ${username} placeholder in a DN sink is substituted and the result becomes
+%% evaluable.
+fill_username_in_dn_test() ->
+    {ok, Q} = aws_auth_validate_ldap_query:parse(
+        <<"{in_group, \"cn=${username},ou=groups,dc=x,dc=com\"}">>
+    ),
+    {in_group, DN} = aws_auth_validate_ldap_query:fill(Q, [{username, "alice"}]),
+    ?assertEqual("cn=alice,ou=groups,dc=x,dc=com", DN),
+    ?assert(aws_auth_validate_ldap_query:is_evaluable(DN)).
+
+%% DN sinks RFC 4514-escape the substituted value; the user_dn key is exempt
+%% (it already holds a complete DN). A username with a comma must be escaped
+%% inside a DN component but a user_dn value must not.
+fill_dn_escaping_test() ->
+    {ok, Q1} = aws_auth_validate_ldap_query:parse(
+        <<"{in_group, \"cn=${username},dc=x\"}">>
+    ),
+    {in_group, DN1} = aws_auth_validate_ldap_query:fill(Q1, [{username, "a,b"}]),
+    ?assertEqual("cn=a\\,b,dc=x", DN1),
+    {ok, Q2} = aws_auth_validate_ldap_query:parse(
+        <<"{in_group, \"${user_dn}\"}">>
+    ),
+    {in_group, DN2} = aws_auth_validate_ldap_query:fill(
+        Q2, [{user_dn, "cn=a,ou=people,dc=x"}]
+    ),
+    ?assertEqual("cn=a,ou=people,dc=x", DN2).
+
+%% A per-operation placeholder we cannot supply (${vhost}) survives unfilled,
+%% so the DN stays non-evaluable and the backend degrades it.
+fill_residual_placeholder_not_evaluable_test() ->
+    {ok, Q} = aws_auth_validate_ldap_query:parse(
+        <<"{in_group, \"cn=admins,ou=${vhost},dc=x\"}">>
+    ),
+    {in_group, DN} = aws_auth_validate_ldap_query:fill(Q, [{username, "alice"}]),
+    ?assertNot(aws_auth_validate_ldap_query:is_evaluable(DN)).
+
+%% equals/match value operands are filled RAW (no DN escaping) -- they are ACL
+%% value sinks, not DNs.
+fill_value_operand_raw_test() ->
+    {ok, Q} = aws_auth_validate_ldap_query:parse(
+        <<"{equals, \"${username}\", \"a,b\"}">>
+    ),
+    {equals, V1, V2} = aws_auth_validate_ldap_query:fill(Q, [{username, "x,y"}]),
+    ?assertEqual("x,y", value_str(V1)),
+    ?assertEqual("a,b", value_str(V2)).
+
+%% ad_args/1 splits a DOMAIN\\user username and yields nothing for other shapes.
+ad_args_test() ->
+    ?assertEqual(
+        [{ad_domain, "CORP"}, {ad_user, "alice"}],
+        aws_auth_validate_ldap_query:ad_args("CORP\\alice")
+    ),
+    ?assertEqual([], aws_auth_validate_ldap_query:ad_args("alice")),
+    ?assertEqual([], aws_auth_validate_ldap_query:ad_args(<<"alice">>)).
+
+%% No-username path is unchanged: a placeholder-bearing DN is not literal, so
+%% literal_dns/1 still skips it (backward-compat guard).
+fill_does_not_affect_literal_dns_test() ->
+    {ok, Q} = aws_auth_validate_ldap_query:parse(
+        <<"{in_group, \"cn=${username},dc=x\"}">>
+    ),
+    ?assertEqual([], aws_auth_validate_ldap_query:literal_dns(Q)).
+
+value_str({string, S}) -> S;
+value_str(S) when is_list(S) -> S.
+
+%% Parity of fill/2 with the broker's fill machinery (design req R12). Our DN
+%% sinks must match rabbit_ldap_rfc4514:fill_dn/2 and our value sinks must match
+%% rabbit_auth_backend_ldap_util:fill/2. Skips unless both upstream modules are
+%% loadable (same matrix concern as the parser parity test).
+fill_parity_test_() ->
+    case fill_upstream_usable() of
+        true ->
+            [
+                {
+                    "dn:" ++ Fmt,
+                    ?_assertEqual(
+                        rabbit_ldap_rfc4514:fill_dn(Fmt, Args),
+                        fill_dn_via_query(Fmt, Args)
+                    )
+                }
+             || {Fmt, Args} <- fill_dn_corpus()
+            ] ++
+                [
+                    {
+                        "raw:" ++ Fmt,
+                        ?_assertEqual(
+                            rabbit_auth_backend_ldap_util:fill(Fmt, Args),
+                            fill_raw_via_query(Fmt, Args)
+                        )
+                    }
+                 || {Fmt, Args} <- fill_raw_corpus()
+                ];
+        false ->
+            []
+    end.
+
+%% Drive our DN-sink fill through a parsed in_group query and recover the DN.
+fill_dn_via_query(Fmt, Args) ->
+    {ok, Q} = aws_auth_validate_ldap_query:parse(
+        list_to_binary("{in_group, \"" ++ Fmt ++ "\"}")
+    ),
+    {in_group, DN} = aws_auth_validate_ldap_query:fill(Q, Args),
+    DN.
+
+%% Drive our value-sink (raw) fill through the second operand of an equals query.
+fill_raw_via_query(Fmt, Args) ->
+    {ok, Q} = aws_auth_validate_ldap_query:parse(
+        list_to_binary("{equals, \"x\", \"" ++ Fmt ++ "\"}")
+    ),
+    {equals, _, V} = aws_auth_validate_ldap_query:fill(Q, Args),
+    value_str(V).
+
+fill_dn_corpus() ->
+    [
+        {"cn=${username},dc=x", [{username, "alice"}]},
+        {"cn=${username},dc=x", [{username, "a,b+c"}]},
+        {"${user_dn}", [{user_dn, "cn=a,ou=people,dc=x"}]},
+        {"cn=${ad_user},dc=${ad_domain}", [{ad_user, "u"}, {ad_domain, "d"}]}
+    ].
+
+fill_raw_corpus() ->
+    [
+        {"${username}", [{username, "alice"}]},
+        {"${username}", [{username, "a,b"}]},
+        {"pre-${username}-post", [{username, "x"}]}
+    ].
+
+fill_upstream_usable() ->
+    code:ensure_loaded(rabbit_ldap_rfc4514) =/= {error, nofile} andalso
+        code:ensure_loaded(rabbit_auth_backend_ldap_util) =/= {error, nofile} andalso
+        erlang:function_exported(rabbit_ldap_rfc4514, fill_dn, 2) andalso
+        erlang:function_exported(rabbit_auth_backend_ldap_util, fill, 2).
 
 %% Parity with rabbit_auth_backend_ldap_util:parse_query/1 (design req R12).
 %% The broker's parser throws via cuttlefish:invalid/2 on rejection; ours


### PR DESCRIPTION
  - add an optional `username' request field to the LDAP backend. When supplied, the endpoint resolves it to a user DN via the configured dn_lookup_base/dn_lookup_attribute (an equalityMatch search over the already-bound service handle, mirroring rabbit_auth_backend_ldap:dn_lookup/2) and *evaluates* the authorization queries' membership for that principal, rather than only reachability-checking static literal DNs. No principal password is accepted -- username is an identifier, and every read runs over the service credentials from password_arn, so this adds no probing power an admin debugging their own directory did not already have

  - aws_auth_validate_ldap_query: add fill/2, which substitutes ${username}/${user_dn}/${ad_domain}/${ad_user} into a parsed query, RFC 4514- escaping DN sinks (exempting user_dn) and raw-filling value sinks. This mirrors rabbit_auth_backend_ldap_util:fill/2 + rabbit_ldap_rfc4514:fill_dn/2, re-implemented here rather than called directly because rabbitmq_auth_backend_ldap is only a TEST_DEP; a parity test guards drift. Also add ad_args/1 and is_evaluable/1

  - aws_auth_validate_ldap: evaluate filled queries against the bound handle -- in_group/in_group_nested via equalityMatch(member, userDN) (a NEW probe, distinct from object_exists/2 which only proves the group exists), composed through and/or/not with skip-aware logic so a degraded sub-result never badargs. A query keyed on per-operation context (${vhost}/${resource}/...) cannot be filled, so that node degrades to grammar-checked-only rather than failing the request

  - response semantics stay fixed-category (R4): a user not authorized by a query -> authz_unverified (422); a username that resolves to zero or >1 entries -> authz_unverified (422, a deliberate divergence from the broker's silent escaped-DN fallback, to surface the misconfiguration). No new HTTP status; no DN/group/host detail leaked

  - backward compatible: with no `username' the authz check is byte-for-byte the prior literal-DN reachability path

  - tests: 14 eunit cases (fill DN-escaping vs raw, ad_args, residual-placeholder degradation, no-username backward-compat, and a fill parity test against the upstream fill/fill_dn) plus 6 CT cases against slapd (in-group ok, not-in-group authz_unverified, unresolvable username, placeholder-DN evaluated, per-op placeholder degrades, and membership parity vs a direct eldap equalityMatch). Seed a second group (cn=others, svc-only) for the negative membership case


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
