### PR TITLE
Apply the same cacerts DER fix to the LDAP backend

### DIFF
--- a/src/aws_auth_validate_http.erl
+++ b/src/aws_auth_validate_http.erl
@@ -1054,13 +1054,13 @@ os_cacerts() ->
     end.
 
 %% Decode a CA-bundle PEM into the raw DER binaries ssl's {cacerts, _} option
-%% expects. This is DELIBERATELY different from the LDAP backend's identically
-%% named helper: eldap wants pem_entry_decode/1 records, but ssl/httpc wants
-%% DER. Passing decoded #'OTPCertificate'{} records here makes ssl silently
-%% ignore the trust anchor -> unknown_ca -> a spurious tls_failed (see the
-%% custom_ca_under_verify_peer_returns_ok regression guard). Mirror
-%% decode_client_cert/1: take only the 'Certificate' entries, as raw DER. A PEM
-%% with no certificate entry yields no anchor (skip), same as an empty bundle.
+%% expects. Passing decoded #'OTPCertificate'{} records (pem_entry_decode/1
+%% output) makes ssl silently ignore the trust anchor -> unknown_ca -> a
+%% spurious tls_failed (see the custom_ca_under_verify_peer_returns_ok
+%% regression guard). Mirror decode_client_cert/1: take only the 'Certificate'
+%% entries, as raw DER. A PEM with no certificate entry yields no anchor (skip),
+%% same as an empty bundle. The LDAP backend's identically named helper does the
+%% same thing for the same reason -- eldap forwards sslopts to this same ssl.
 decode_pem_cacerts(B) when is_binary(B) ->
     case [Der || {'Certificate', Der, not_encrypted} <- public_key:pem_decode(B)] of
         [] -> skip;

--- a/src/aws_auth_validate_ldap.erl
+++ b/src/aws_auth_validate_ldap.erl
@@ -275,10 +275,10 @@ resolve_cacert(#{ssl_options := SslOpts} = Params) ->
         Arn when is_binary(Arn) ->
             case resolve_arn(Arn) of
                 {ok, PemData} ->
-                    %% pem_entry_decode/1 can raise on a malformed entry; an
-                    %% empty/undecodable PEM returns `skip'. Both mean the ARN
-                    %% does not hold a usable CA cert -- report input_invalid
-                    %% rather than degrading the trust anchor.
+                    %% A malformed PEM can raise during decode; an empty/
+                    %% certless PEM returns `skip'. Both mean the ARN does not
+                    %% hold a usable CA cert -- report input_invalid rather than
+                    %% degrading the trust anchor.
                     try decode_pem_cacerts(PemData) of
                         skip -> {error, input_invalid, ?REASON_CACERT_PEM_INVALID};
                         Certs -> {ok, Params#{ssl_options => SslOpts#{cacerts => Certs}}}
@@ -801,13 +801,19 @@ to_version(<<"tlsv1.2">>) -> 'tlsv1.2';
 to_version(<<"tlsv1.1">>) -> 'tlsv1.1';
 to_version(<<"tlsv1">>) -> tlsv1.
 
-%% Decode PEM data into the decoded cert terms eldap expects under `cacerts'.
-%% Returns `skip' when the data holds no decodable PEM entries (so resolve_cacert/1
-%% can reject it as input_invalid rather than proceeding with an empty trust set).
+%% Decode a CA-bundle PEM into the raw DER binaries ssl's `cacerts' option
+%% expects. eldap has NO special cacerts contract: build_ssl_opts/1's proplist
+%% is handed to eldap:open/2 as {sslopts, _} and to eldap:start_tls/3, both of
+%% which forward it straight to the `ssl' module -- the same ssl httpc uses. ssl
+%% silently ignores decoded #'OTPCertificate'{} records (pem_entry_decode/1
+%% output) as a trust anchor -> unknown_ca -> a spurious tls_failed. So pass raw
+%% DER, exactly as the HTTP backend's decode_pem_cacerts/1 now does. Returns
+%% `skip' when the data holds no certificate entries (so resolve_cacert/1 can
+%% reject it as input_invalid rather than proceeding with an empty trust set).
 decode_pem_cacerts(B) when is_binary(B) ->
-    case public_key:pem_decode(B) of
+    case [Der || {'Certificate', Der, not_encrypted} <- public_key:pem_decode(B)] of
         [] -> skip;
-        Entries -> [public_key:pem_entry_decode(E) || E <- Entries]
+        Ders -> Ders
     end.
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
#69's HTTP fix applies to LDAP too: aws_auth_validate_ldap:decode_pem_cacerts/1 had the identical bug -- it fed ssl decoded #'OTPCertificate'{} records under {cacerts,_}. eldap has no special cacerts contract; build_ssl_opts/1's proplist is forwarded to eldap:open/2 ({sslopts,_}) and eldap:start_tls/3, both of which hand it to the SAME ssl module httpc uses. So ssl ignored the customer CA (unknown_ca -> tls_failed) on the verify_peer + cacertfile_arn success path, exactly as in HTTP.

It went unnoticed because no LDAP test drives a verify_peer handshake against a custom CA: the slapd harness is plaintext and the unit tests only assert the cacert ARN resolves. #69 added that missing coverage for HTTP first.

Pass raw 'Certificate' DER, matching the HTTP fix. Also correct the now-false comments in both backends (eldap does NOT want pem_entry_decode records).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
