### PR TITLE
Lower the auth-validation max_body_size ceiling to 1 MB

### DIFF
--- a/priv/schema/aws.schema
+++ b/priv/schema/aws.schema
@@ -129,7 +129,7 @@
 %% the app env only when an operator sets it explicitly.
 
 %% @doc Maximum HTTP request body size in bytes (effective default 65536).
-%% The 1..10000000 bound is enforced at runtime by
+%% The 1..1048576 bound is enforced at runtime by
 %% aws_auth_validate_mgmt:max_body_size/0, which falls back to the default for
 %% an out-of-range value. The datatype is plain `integer' rather than an inline
 %% {integer, [{min, _}, {max, _}]}: the constrained form is rejected by older

--- a/src/aws_auth_validate_mgmt.erl
+++ b/src/aws_auth_validate_mgmt.erl
@@ -27,8 +27,9 @@
 
 -ifdef(TEST).
 %% Exposed for unit tests: status_for_category/1 maps a backend error category
-%% to an HTTP status, including the catch-all for an unexpected category.
--export([status_for_category/1]).
+%% to an HTTP status, including the catch-all for an unexpected category;
+%% max_body_size/0 resolves the configured body-size limit against its bounds.
+-export([status_for_category/1, max_body_size/0]).
 -endif.
 
 -include_lib("rabbitmq_web_dispatch/include/rabbitmq_web_dispatch_records.hrl").
@@ -302,7 +303,7 @@ feature_enabled() ->
 
 max_body_size() ->
     case application:get_env(aws, auth_validation_max_body_size) of
-        {ok, N} when is_integer(N), N > 0, N =< 10_000_000 -> N;
+        {ok, N} when is_integer(N), N > 0, N =< 1_048_576 -> N;
         _ -> ?DEFAULT_MAX_BODY_SIZE
     end.
 

--- a/test/aws_auth_validate_tests.erl
+++ b/test/aws_auth_validate_tests.erl
@@ -133,6 +133,50 @@ status_for_category_unknown_test() ->
     ?assertEqual(500, aws_auth_validate_mgmt:status_for_category(some_future_category)).
 
 %%--------------------------------------------------------------------
+%% Mgmt body-size bound
+%%--------------------------------------------------------------------
+
+%% max_body_size/0 honours an in-range configured value and falls back to the
+%% effective default for anything outside 1..1_048_576 (the 1 MB ceiling). The
+%% effective default (65_536) is asserted indirectly via the out-of-range cases.
+max_body_size_bound_test_() ->
+    {foreach, fun() -> application:unset_env(aws, auth_validation_max_body_size) end,
+        fun(_) -> application:unset_env(aws, auth_validation_max_body_size) end, [
+            fun() ->
+                application:set_env(aws, auth_validation_max_body_size, 4096),
+                ?assertEqual(4096, aws_auth_validate_mgmt:max_body_size())
+            end,
+            %% The ceiling itself is accepted.
+            fun() ->
+                application:set_env(aws, auth_validation_max_body_size, 1_048_576),
+                ?assertEqual(1_048_576, aws_auth_validate_mgmt:max_body_size())
+            end,
+            %% One byte over the ceiling falls back to the default.
+            fun() ->
+                application:set_env(aws, auth_validation_max_body_size, 1_048_577),
+                ?assertEqual(65_536, aws_auth_validate_mgmt:max_body_size())
+            end,
+            %% The old 10 MB ceiling is now out of range and falls back.
+            fun() ->
+                application:set_env(aws, auth_validation_max_body_size, 10_000_000),
+                ?assertEqual(65_536, aws_auth_validate_mgmt:max_body_size())
+            end,
+            %% Non-positive and non-integer values fall back too.
+            fun() ->
+                application:set_env(aws, auth_validation_max_body_size, 0),
+                ?assertEqual(65_536, aws_auth_validate_mgmt:max_body_size())
+            end,
+            fun() ->
+                application:set_env(aws, auth_validation_max_body_size, not_an_integer),
+                ?assertEqual(65_536, aws_auth_validate_mgmt:max_body_size())
+            end,
+            %% Unset reads as the default.
+            fun() ->
+                ?assertEqual(65_536, aws_auth_validate_mgmt:max_body_size())
+            end
+        ]}.
+
+%%--------------------------------------------------------------------
 %% LDAP backend (input parsing only - the real bind path needs slapd)
 %%--------------------------------------------------------------------
 


### PR DESCRIPTION
The auth-validation endpoint capped request bodies at 10 MB, two orders of magnitude above any legitimate request. A validation body carries no inline secrets -- the password and CA cert arrive as ARN references (password_arn, ssl_options.cacertfile_arn), not inline blobs -- and the only field that can grow, queries, is independently bounded: at most four query strings whose literal DNs are capped at ?MAX_LITERAL_DNS (100). A genuine worst-case body is comfortably under the 64 KB effective default. read_body/2 reads up to the ceiling into memory before the concurrency semaphore is acquired, so the body-size limit is the only gate on that allocation; 10 MB let an authenticated caller force a large per-request allocation for no legitimate reason.

Lower the runtime guard in max_body_size/0 from 10_000_000 to 1_048_576 (1 MB) and update the schema doc comment to match. 1 MB is ~16x the effective default, leaving generous headroom for future backends without another schema change while cutting the worst-case allocation by 10x. The effective default (65_536) is unchanged -- it was already correctly sized; only the ceiling moved. If a future backend needs more, the limit can be scoped per method (max_body_size/0 already runs where the method is known).

Export max_body_size/0 under -ifdef(TEST) and add max_body_size_bound_test_ covering an in-range value, the 1 MB ceiling, one byte over, the old 10 MB value (now out of range), and non-positive/non-integer inputs -- all falling back to the default.

Surfaced during the PR #68 security review (item #3); closes #70.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
