### PR TITLE
Dead code removal + introduce validation fallback to config assume_role

### DIFF
--- a/src/aws_auth_validate_ldap.erl
+++ b/src/aws_auth_validate_ldap.erl
@@ -55,16 +55,6 @@
 
 -define(DEFAULT_TIMEOUT_MS, 5_000).
 
-%% Upper bound on the number of distinct literal DNs probed in one request.
-%% Each literal DN is one base-scoped eldap:search bounded by the request
-%% timeout (default 5s, max 60s), and all probes run sequentially while holding
-%% a semaphore permit, so an unbounded set would let a single request pin a
-%% permit for a long time and starve the bounded pool. A legitimate config has
-%% a handful of literal group DNs across the four query types; 100 is well above
-%% that. Enforced in the pure (network-free) phase, so an over-budget request is
-%% rejected before any secret fetch or outbound connection.
--define(MAX_LITERAL_DNS, 100).
-
 %% Accepted query names within the `queries' object. Mirrors the broker's
 %% auth_ldap.queries.* config keys.
 -define(QUERY_NAMES, [
@@ -134,9 +124,6 @@
 -define(REASON_BAD_QUERIES, <<"queries must be an object of query strings">>).
 -define(REASON_BAD_QUERY_VALUE, <<"each query must be a non-empty string">>).
 -define(REASON_QUERY_PARSE, <<"one or more authorization queries are not valid">>).
--define(REASON_TOO_MANY_LITERAL_DNS,
-    <<"authorization queries reference too many distinct literal DNs to verify">>
-).
 -define(REASON_DN_LOOKUP_BASE_UNVERIFIED,
     <<"dn_lookup_base does not exist or is not readable by the bind user">>
 ).
@@ -459,27 +446,6 @@ parse_query_map([{Name, Value} | Rest], Acc, Parsed) ->
                     {error, input_invalid, ?REASON_BAD_QUERY_VALUE}
             end
     end.
-
-%% Compute the distinct literal DNs the authz queries will make us probe and
-%% reject the request if there are too many (see ?MAX_LITERAL_DNS). Runs in the
-%% pure phase, after parse_queries/2, so an over-budget request never resolves a
-%% secret or opens a connection. The computed set is stored so check_authz_
-%% queries/2 probes exactly this set rather than recomputing it (single source
-%% of truth: the count we bound is the count we probe).
-limit_literal_dns(_Body, #{queries := Queries} = Acc) ->
-    LiteralDns = literal_dns(Queries),
-    case length(LiteralDns) > ?MAX_LITERAL_DNS of
-        true -> {error, input_invalid, ?REASON_TOO_MANY_LITERAL_DNS};
-        false -> {ok, Acc#{literal_dns => LiteralDns}}
-    end.
-
-literal_dns(Queries) ->
-    lists:usort(
-        lists:flatmap(
-            fun({_Name, Query}) -> aws_auth_validate_ldap_query:literal_dns(Query) end,
-            Queries
-        )
-    ).
 
 is_nonempty_binary(B) -> is_binary(B) andalso byte_size(B) > 0.
 

--- a/src/aws_auth_validate_ldap.erl
+++ b/src/aws_auth_validate_ldap.erl
@@ -118,6 +118,7 @@
 -define(REASON_TLS_HANDSHAKE, <<"TLS handshake failed">>).
 -define(REASON_AUTH, <<"LDAP simple bind rejected the supplied credentials">>).
 -define(REASON_ARN_RESOLVE, <<"failed to resolve ARN">>).
+-define(REASON_ASSUME_ROLE, <<"failed to assume the configured role">>).
 -define(REASON_BAD_DN_LOOKUP_BASE, <<"dn_lookup_base must be a non-empty string">>).
 -define(REASON_BAD_DN_LOOKUP_ATTR, <<"dn_lookup_attribute must be a non-empty string">>).
 -define(REASON_BAD_USERNAME, <<"username must be a non-empty string">>).
@@ -170,16 +171,67 @@ validate(Body) when is_map(Body) ->
                 {error, _, _} = Err ->
                     Err;
                 ok ->
-                    case resolve_password(Body, Params) of
+                    case resolve_request_state(Params) of
                         {error, _, _} = Err ->
                             Err;
-                        {ok, Params1} ->
-                            case resolve_cacert(Params1) of
-                                {error, _, _} = Err -> Err;
-                                {ok, Params2} -> do_ldap_validate(Params2)
+                        {ok, Params0} ->
+                            case resolve_password(Body, Params0) of
+                                {error, _, _} = Err ->
+                                    Err;
+                                {ok, Params1} ->
+                                    case resolve_cacert(Params1) of
+                                        {error, _, _} = Err -> Err;
+                                        {ok, Params2} -> do_ldap_validate(Params2)
+                                    end
                             end
                     end
             end
+    end.
+
+%% Build the per-request aws_lib state used for every ARN fetch in this request.
+%% Runs in the network phase, after all pure input validation has passed, so a
+%% malformed request never triggers an STS AssumeRole call.
+%%
+%% When the operator configured `aws.arns.assume_role_arn', assume that role
+%% into the request's aws_lib state -- the SAME role the plugin already assumes
+%% at boot to resolve every configured ARN (aws_arn_config:maybe_assume_role/1).
+%% Honoring it here closes a parity gap: without it the validate endpoint would
+%% resolve password_arn/cacertfile_arn with the broker's bare ambient (EC2
+%% instance) role even though the operator told the plugin to use a specific
+%% role for ARN resolution. This is operator config, not caller input, so it
+%% raises no confused-deputy concern. With no role configured, a default state
+%% is used and ARNs resolve with the ambient role -- the prior behavior.
+%%
+%% The state is request-local (aws_lib threads credentials per call -- there is
+%% no global singleton to clobber), so the assumed role's credentials are
+%% visible only to this request's ARN resolutions and are discarded when the
+%% request ends.
+resolve_request_state(Params) ->
+    case configured_assume_role_arn() of
+        none ->
+            {ok, Params#{aws_state => aws_lib:new()}};
+        RoleArn ->
+            case aws_iam:assume_role(RoleArn, aws_lib:new()) of
+                {ok, State} -> {ok, Params#{aws_state => State}};
+                {error, _} -> {error, input_invalid, ?REASON_ASSUME_ROLE}
+            end
+    end.
+
+%% The operator-configured boot-time assume role (aws.arns.assume_role_arn),
+%% read from the same `aws, arn_config' env the boot sequence uses
+%% (aws_arn_config:maybe_assume_role/1). Returns the role ARN string, or `none'
+%% when unset.
+configured_assume_role_arn() ->
+    case application:get_env(aws, arn_config) of
+        {ok, ArnConfig} when is_list(ArnConfig) ->
+            case proplists:get_value(assume_role_arn, ArnConfig) of
+                undefined -> none;
+                Arn when is_list(Arn) -> Arn;
+                Arn when is_binary(Arn) -> binary_to_list(Arn);
+                _ -> none
+            end;
+        _ ->
+            none
     end.
 
 %%--------------------------------------------------------------------
@@ -249,10 +301,10 @@ parse_user_dn(Body, Acc) ->
 %% fetch. The resolved password is added to the params map and never logged
 %% or returned. Validated for shape here (rather than in parse_input) so the
 %% network call stays out of the pure pipeline.
-resolve_password(Body, Params) ->
+resolve_password(Body, #{aws_state := State} = Params) ->
     case maps:get(<<"password_arn">>, Body, undefined) of
         Arn when is_binary(Arn), byte_size(Arn) > 0 ->
-            case resolve_arn(Arn) of
+            case resolve_arn(Arn, State) of
                 {ok, Password} -> {ok, Params#{password => Password}};
                 {error, _} -> {error, input_invalid, ?REASON_ARN_RESOLVE}
             end;
@@ -277,12 +329,12 @@ resolve_password(Body, Params) ->
 %% fetch and could reject an otherwise-valid plaintext config.
 resolve_cacert(#{use_ssl := false, use_starttls := false} = Params) ->
     {ok, Params};
-resolve_cacert(#{ssl_options := SslOpts} = Params) ->
+resolve_cacert(#{ssl_options := SslOpts, aws_state := State} = Params) ->
     case maps:get(<<"cacertfile_arn">>, SslOpts, undefined) of
         undefined ->
             {ok, Params};
         Arn when is_binary(Arn) ->
-            case resolve_arn(Arn) of
+            case resolve_arn(Arn, State) of
                 {ok, PemData} ->
                     %% pem_entry_decode/1 can raise on a malformed entry; an
                     %% empty/undecodable PEM returns `skip'. Both mean the ARN
@@ -1047,17 +1099,18 @@ decode_pem_cacerts(B) when is_binary(B) ->
 
 %%--------------------------------------------------------------------
 
-%% Each request builds its own aws_state(); region and credentials are
-%% threaded through that value rather than written to a shared singleton, so
-%% concurrent validations can no longer clobber each other's region and no
-%% lock is needed. R6 is preserved -- resolution runs in the caller process and
-%% the resolved secret is neither logged nor returned (only adapted to the
-%% caller's {ok, Binary} contract). R3 is preserved -- this still runs only
-%% after the pure validation pipeline. The 3-tuple {ok, Data, State1} from
+%% Resolve an ARN using the request's threaded aws_state(). The state is built
+%% once per request by resolve_request_state/1 -- a default state (broker's
+%% ambient role) or one with the operator-configured assume_role assumed -- and
+%% passed to every ARN fetch in the request. Region and credentials live in that
+%% value, not a shared singleton, so concurrent validations cannot clobber each
+%% other. R6 is preserved -- resolution runs in the caller process and the
+%% resolved secret is neither logged nor returned (only adapted to the caller's
+%% {ok, Binary} contract). R3 is preserved -- this still runs only after the pure
+%% validation pipeline. The 3-tuple {ok, Data, State1} from
 %% aws_arn_util:resolve_arn/2 is adapted back to the {ok, Binary} contract the
-%% two callers expect; the threaded state is request-scoped and discarded here.
-resolve_arn(Arn) when is_binary(Arn) ->
-    State = aws_lib:new(),
+%% callers expect; the returned state is request-scoped and discarded here.
+resolve_arn(Arn, State) when is_binary(Arn) ->
     case aws_arn_util:resolve_arn(binary_to_list(Arn), State) of
         {ok, Data, _State1} -> {ok, Data};
         {error, _} = Error -> Error

--- a/test/aws_auth_validate_tests.erl
+++ b/test/aws_auth_validate_tests.erl
@@ -11,6 +11,7 @@
 -module(aws_auth_validate_tests).
 
 -include_lib("eunit/include/eunit.hrl").
+-include("aws_lib.hrl").
 
 %%--------------------------------------------------------------------
 %% Semaphore
@@ -466,6 +467,105 @@ ldap_queries_input_test_() ->
             )
         )
     ].
+
+%%--------------------------------------------------------------------
+%% Configured assume-role fallback (aws.arns.assume_role_arn)
+%%--------------------------------------------------------------------
+%% When the operator configured aws.arns.assume_role_arn, the validate endpoint
+%% assumes that role and resolves the request's ARNs under it, instead of the
+%% broker's bare ambient role. Mirrors the boot-path coverage in
+%% aws_arn_config_tests: meck aws_iam:assume_role/2 and aws_arn_util:resolve_arn/2
+%% and assert which credentials reach the resolve. The mecked resolve fails so no
+%% real connection is attempted; the password_arn resolve is the observation point.
+ldap_configured_assume_role_test_() ->
+    {foreach,
+        fun() ->
+            ok = meck:new(aws_iam, [no_link]),
+            ok = meck:new(aws_arn_util, [passthrough, no_link]),
+            ok
+        end,
+        fun(_) ->
+            application:unset_env(aws, arn_config),
+            catch meck:unload(aws_arn_util),
+            catch meck:unload(aws_iam),
+            ok
+        end,
+        [
+            {
+                "no configured role: assume_role is never called and the ambient "
+                "(credential-free) state reaches ARN resolution",
+                fun assume_role_not_configured_uses_ambient_state/0
+            },
+            {"configured role: the assumed credentials reach ARN resolution",
+                fun assume_role_configured_threads_assumed_credentials/0},
+            {
+                "configured role that fails to assume: input_invalid before any "
+                "ARN resolve",
+                fun assume_role_configured_failure_returns_input_invalid/0
+            }
+        ]}.
+
+%% A state carrying these credentials is distinguishable, via
+%% aws_lib:get_credentials/1, from the credential-free aws_lib:new().
+assume_role_test_assumed_state() ->
+    {ok, S} = aws_lib:set_credentials("assumed-key", "secret", "token", aws_lib:new()),
+    S.
+
+assume_role_test_access_key(State) ->
+    case aws_lib:get_credentials(State) of
+        {ok, #aws_credentials{access_key = Key}} -> Key;
+        {error, undefined} -> undefined
+    end.
+
+assume_role_not_configured_uses_ambient_state() ->
+    application:unset_env(aws, arn_config),
+    Self = self(),
+    ok = meck:expect(aws_arn_util, resolve_arn, fun(_Arn, State) ->
+        Self ! {resolve_key, assume_role_test_access_key(State)},
+        {error, stop_here}
+    end),
+    %% resolve fails -> input_invalid, but we only care which state was threaded.
+    ?assertMatch({error, input_invalid, _}, aws_auth_validate_ldap:validate(base_body(#{}))),
+    ?assertEqual(0, meck:num_calls(aws_iam, assume_role, '_')),
+    receive
+        {resolve_key, Key} -> ?assertEqual(undefined, Key)
+    after 1_000 -> ?assert(false)
+    end.
+
+assume_role_configured_threads_assumed_credentials() ->
+    application:set_env(aws, arn_config, [
+        {assume_role_arn, "arn:aws:iam::123456789012:role/r"}
+    ]),
+    Self = self(),
+    ok = meck:expect(aws_iam, assume_role, fun(_RoleArn, _State) ->
+        {ok, assume_role_test_assumed_state()}
+    end),
+    ok = meck:expect(aws_arn_util, resolve_arn, fun(_Arn, State) ->
+        Self ! {resolve_key, assume_role_test_access_key(State)},
+        {error, stop_here}
+    end),
+    ?assertMatch({error, input_invalid, _}, aws_auth_validate_ldap:validate(base_body(#{}))),
+    ?assertEqual(1, meck:num_calls(aws_iam, assume_role, '_')),
+    receive
+        {resolve_key, Key} -> ?assertEqual("assumed-key", Key)
+    after 1_000 -> ?assert(false)
+    end.
+
+assume_role_configured_failure_returns_input_invalid() ->
+    application:set_env(aws, arn_config, [
+        {assume_role_arn, "arn:aws:iam::123456789012:role/r"}
+    ]),
+    ok = meck:expect(aws_iam, assume_role, fun(_RoleArn, _State) ->
+        {error, boom}
+    end),
+    ok = meck:expect(aws_arn_util, resolve_arn, fun(_Arn, _State) ->
+        erlang:error(resolve_should_not_be_reached)
+    end),
+    ?assertEqual(
+        {error, input_invalid, <<"failed to assume the configured role">>},
+        aws_auth_validate_ldap:validate(base_body(#{}))
+    ),
+    ?assertEqual(0, meck:num_calls(aws_arn_util, resolve_arn, '_')).
 
 %%--------------------------------------------------------------------
 %% R6: password must never reach a crash report / log, even on a raise

--- a/test/aws_auth_validate_tests.erl
+++ b/test/aws_auth_validate_tests.erl
@@ -467,47 +467,6 @@ ldap_queries_input_test_() ->
         )
     ].
 
-%% The literal-DN probe budget (?MAX_LITERAL_DNS = 100) is enforced in the pure
-%% phase, before any secret fetch or connection. resolve_arn is mocked to fail
-%% so the at-limit case (which passes the budget gate) cannot dial out; the
-%% over-limit case is rejected before resolve_arn is ever reached.
-ldap_literal_dn_budget_test_() ->
-    {setup,
-        fun() ->
-            ok = meck:new(aws_arn_util, [passthrough]),
-            meck:expect(aws_arn_util, resolve_arn, fun(_Arn, _State) -> {error, mocked} end),
-            ok
-        end,
-        fun(_) -> meck:unload(aws_arn_util) end, fun(_) ->
-            Over = base_body(#{<<"queries">> => #{<<"tags">> => or_in_group_query(101)}}),
-            AtLimit = base_body(#{<<"queries">> => #{<<"tags">> => or_in_group_query(100)}}),
-            [
-                %% 101 distinct literal DNs is rejected with the specific
-                %% too-many reason in the pure phase.
-                ?_assertEqual(
-                    {error, input_invalid,
-                        <<"authorization queries reference too many distinct literal DNs to verify">>},
-                    aws_auth_validate_ldap:validate(Over)
-                ),
-                %% Exactly 100 passes the budget gate and proceeds to password-
-                %% ARN resolution (mocked to fail), so the result is the ARN-
-                %% resolve failure, NOT the too-many-DNs reason.
-                ?_assertEqual(
-                    {error, input_invalid, <<"failed to resolve ARN">>},
-                    aws_auth_validate_ldap:validate(AtLimit)
-                )
-            ]
-        end}.
-
-%% Build an `or' query of N distinct {in_group, DN} terms, yielding N distinct
-%% literal DNs.
-or_in_group_query(N) ->
-    Terms = [
-        lists:flatten(io_lib:format("{in_group, \"cn=g~b,dc=example,dc=com\"}", [I]))
-     || I <- lists:seq(1, N)
-    ],
-    list_to_binary("{'or', [" ++ string:join(Terms, ", ") ++ "]}").
-
 %%--------------------------------------------------------------------
 %% R6: password must never reach a crash report / log, even on a raise
 %%--------------------------------------------------------------------


### PR DESCRIPTION
Remove dead code that was failing builds, and introduce a fallback for validation requests to use the assume role ARN provided by the broker config, as opposed to using the EC2 instance role for fallbacks

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
