### PR TITLE
Treat all 2xx status codes as success in `format_response`

### DIFF
--- a/src/aws_lib.erl
+++ b/src/aws_lib.erl
@@ -518,11 +518,14 @@ do_refresh_credentials(State0) ->
 %% structure. The response body will attempt to be decoded by invoking the
 %% maybe_decode_body/2 method.
 %% @end
-format_response({ok, {{_Version, 200, _Message}, Headers, Body}}) ->
+%% Any 2xx is a success. Every other status (3xx redirects we do not follow,
+%% 4xx, 5xx) is an error: gun is not configured to follow redirects, so a 3xx
+%% is a request we could not complete.
+format_response({ok, {{_Version, StatusCode, _Message}, Headers, Body}}) when
+    StatusCode >= 200, StatusCode < 300
+->
     {ok, {Headers, maybe_decode_body(get_content_type(Headers), Body)}};
-format_response({ok, {{_Version, 206, _Message}, Headers, Body}}) ->
-    {ok, {Headers, maybe_decode_body(get_content_type(Headers), Body)}};
-format_response({ok, {{_Version, StatusCode, Message}, Headers, Body}}) when StatusCode >= 400 ->
+format_response({ok, {{_Version, _StatusCode, Message}, Headers, Body}}) ->
     {error, Message, {Headers, maybe_decode_body(get_content_type(Headers), Body)}};
 format_response({error, Reason}) ->
     {error, Reason, undefined}.

--- a/test/aws_lib_tests.erl
+++ b/test/aws_lib_tests.erl
@@ -167,6 +167,36 @@ format_response_test_() ->
                 {error, "Internal Server Error",
                     {[{"Content-Type", "text/xml"}], [{"error", "Boom"}]}},
             ?assertEqual(Expectation, aws_lib:format_response(Response))
+        end},
+        {"201 Created is a success", fun() ->
+            Response =
+                {ok, {
+                    {"HTTP/1.1", 201, "Created"},
+                    [{<<"Content-Type">>, <<"text/xml">>}],
+                    "<test>Value</test>"
+                }},
+            Expectation = {ok, {[{<<"Content-Type">>, <<"text/xml">>}], [{"test", "Value"}]}},
+            ?assertEqual(Expectation, aws_lib:format_response(Response))
+        end},
+        {"204 No Content is a success", fun() ->
+            Response =
+                {ok, {
+                    {"HTTP/1.1", 204, "No Content"},
+                    [],
+                    <<>>
+                }},
+            Expectation = {ok, {[], <<>>}},
+            ?assertEqual(Expectation, aws_lib:format_response(Response))
+        end},
+        {"3xx redirect is an error (gun does not follow redirects)", fun() ->
+            Response =
+                {ok, {
+                    {"HTTP/1.1", 302, "Found"},
+                    [{<<"content-type">>, <<"text/plain">>}],
+                    <<"moved">>
+                }},
+            Expectation = {error, "Found", {[{<<"content-type">>, <<"text/plain">>}], <<"moved">>}},
+            ?assertEqual(Expectation, aws_lib:format_response(Response))
         end}
     ].
 


### PR DESCRIPTION
Fixes #83.

`format_response/1` only matched status codes 200, 206, and >= 400. A 201, 202, or 204 success (returned by S3 PUT, DynamoDB writes, and other AWS APIs), as well as any 3xx, fell through every clause and crashed the caller with a `function_clause` error.

This matches any 2xx as success with a range guard and treats every other status as an error. gun is not configured to follow redirects, so a 3xx is a request we could not complete and is correctly reported as an error.

Tests cover 201, 204, and a 3xx redirect in `format_response_test_`; they were confirmed to fail with `function_clause` against the previous code. `gmake eunit` and `gmake xref` are clean.
