### PR TITLE
Handle `gun:await_body` errors during credential loading

### DIFF
--- a/src/aws_lib_config.erl
+++ b/src/aws_lib_config.erl
@@ -765,8 +765,13 @@ perform_http_get_with_conn(ConnPid, Path, Config) ->
         {response, fin, Status, RespHeaders} ->
             {ok, {{http_version, Status, aws_lib:status_text(Status)}, RespHeaders, <<>>}, Config1};
         {response, nofin, Status, RespHeaders} ->
-            {ok, Body} = gun:await_body(ConnPid, StreamRef, ?DEFAULT_HTTP_TIMEOUT),
-            {ok, {{http_version, Status, aws_lib:status_text(Status)}, RespHeaders, Body}, Config1};
+            case gun:await_body(ConnPid, StreamRef, ?DEFAULT_HTTP_TIMEOUT) of
+                {ok, Body} ->
+                    {ok, {{http_version, Status, aws_lib:status_text(Status)}, RespHeaders, Body},
+                        Config1};
+                {error, Reason} ->
+                    {error, Reason}
+            end;
         {error, Reason} ->
             {error, Reason}
     end.
@@ -867,16 +872,22 @@ perform_http_get_instance_metadata(URL, Config) ->
                                     },
                                     Config1};
                             {response, nofin, Status, RespHeaders} ->
-                                {ok, Body} = gun:await_body(
-                                    ConnPid, StreamRef, ?DEFAULT_HTTP_TIMEOUT
-                                ),
-                                {ok,
-                                    {
-                                        {http_version, Status, aws_lib:status_text(Status)},
-                                        RespHeaders,
-                                        Body
-                                    },
-                                    Config1};
+                                case
+                                    gun:await_body(
+                                        ConnPid, StreamRef, ?DEFAULT_HTTP_TIMEOUT
+                                    )
+                                of
+                                    {ok, Body} ->
+                                        {ok,
+                                            {
+                                                {http_version, Status, aws_lib:status_text(Status)},
+                                                RespHeaders,
+                                                Body
+                                            },
+                                            Config1};
+                                    {error, Reason} ->
+                                        {error, Reason}
+                                end;
                             {error, Reason} ->
                                 {error, Reason}
                         end,
@@ -968,11 +979,24 @@ load_imdsv2_token() ->
                                 % Empty body for fin response
                                 <<>>;
                             {response, nofin, 200, _RespHeaders} ->
-                                {ok, Body} = gun:await_body(
-                                    ConnPid, StreamRef, ?DEFAULT_HTTP_TIMEOUT
-                                ),
-                                ?LOG_DEBUG("Successfully obtained EC2 IMDSv2 token."),
-                                binary_to_list(Body);
+                                case
+                                    gun:await_body(
+                                        ConnPid, StreamRef, ?DEFAULT_HTTP_TIMEOUT
+                                    )
+                                of
+                                    {ok, Body} ->
+                                        ?LOG_DEBUG("Successfully obtained EC2 IMDSv2 token."),
+                                        binary_to_list(Body);
+                                    {error, Reason} ->
+                                        ?LOG_WARNING(
+                                            get_instruction_on_instance_metadata_error(
+                                                "Failed to read EC2 IMDSv2 token body: ~tp. "
+                                                "Falling back to EC2 IMDSv1 for now. It is recommended to use EC2 IMDSv2."
+                                            ),
+                                            [Reason]
+                                        ),
+                                        undefined
+                                end;
                             {response, _, 400, _RespHeaders} ->
                                 ?LOG_WARNING(
                                     "Failed to obtain EC2 IMDSv2 token: Missing or Invalid Parameters – The PUT request is not valid."

--- a/test/aws_lib_config_tests.erl
+++ b/test/aws_lib_config_tests.erl
@@ -379,6 +379,19 @@ credentials_test_() ->
                     ]
                 ),
                 ?assertEqual({error, undefined}, aws_lib_config:credentials(S))
+            end},
+            {"with instance metadata body read timeout", fun() ->
+                %% Headers arrive (200) but the body read times out. This must
+                %% surface as {error, timeout}, not crash with a badmatch.
+                S = #aws_config{},
+                meck:expect(aws_lib, ensure_imdsv2_token_valid, 1, {ok, undefined, S}),
+                meck:expect(gun, open, fun(_, _, _) -> {ok, pid} end),
+                meck:expect(gun, close, fun(_) -> ok end),
+                meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
+                meck:expect(gun, get, fun(_, _, _) -> stream_ref end),
+                meck:expect(gun, await, fun(_, _, _) -> {response, nofin, 200, headers} end),
+                meck:expect(gun, await_body, fun(_, _, _) -> {error, timeout} end),
+                ?assertEqual({error, timeout}, aws_lib_config:credentials(S))
             end}
         ]
     }.
@@ -643,6 +656,17 @@ load_imdsv2_token_test_() ->
                 meck:expect(gun, await_body, fun(_, _, _) ->
                     {ok, <<"Missing or Invalid Parameters – The PUT request is not valid.">>}
                 end),
+                ?assertEqual(undefined, aws_lib_config:load_imdsv2_token())
+            end},
+            {"fail to get imdsv2 token - body read timeout", fun() ->
+                %% The 200 response headers arrive but the body read times out;
+                %% this must fall back to undefined, not crash with a badmatch.
+                meck:expect(gun, open, fun(_, _, _) -> {ok, pid} end),
+                meck:expect(gun, close, fun(_) -> ok end),
+                meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
+                meck:expect(gun, put, fun(_, _, _, _) -> stream_ref end),
+                meck:expect(gun, await, fun(_, _, _) -> {response, nofin, 200, headers} end),
+                meck:expect(gun, await_body, fun(_, _, _) -> {error, timeout} end),
                 ?assertEqual(undefined, aws_lib_config:load_imdsv2_token())
             end},
             {"successfully get imdsv2 token from instance metadata service", fun() ->


### PR DESCRIPTION
Fixes #90.

Three call sites in `aws_lib_config` matched the body read with `{ok, Body} = gun:await_body(...)`. `gun:await_body/3` can return `{error, timeout}` (or another `{error, Reason}`) when body delivery stalls after the response headers arrive, so a slow EC2 Instance Metadata Service response crashed credential loading with a badmatch instead of failing gracefully.

Each site now matches `await_body/3` explicitly and propagates the error per the function's contract:

- `perform_http_get_with_conn/3` returns `{error, Reason}`
- `perform_http_get_instance_metadata/2` returns `{error, Reason}`
- `load_imdsv2_token/0` logs and returns `undefined`, so it still falls back to IMDSv1 (this function is spec'd to return a token or `undefined`, not an error tuple)

Tests cover the body-read-timeout path for the metadata-credentials and IMDSv2-token requests; both were confirmed to fail with `{badmatch, {error, timeout}}` against the previous code. `gmake eunit` and `gmake xref` are clean.
