### PR TITLE
Address PR #66 review: SSRF profile isolation, dead guard, and coverage

### DIFF
--- a/src/aws_auth_validate_http.erl
+++ b/src/aws_auth_validate_http.erl
@@ -155,11 +155,10 @@
 -define(AUTH_RESPONSE_CODES, [200, 201]).
 
 %% SSRF guard toggles (see the SSRF guard section below for the full rationale).
-%% ?ENFORCE_ADDRESS_POLICY gates BOTH the per-URL address check (url_allowed/1,
-%% via classify_address/1) and the probe-layer DNS resolve+classify, and the
-%% fail-closed guard in validate/1 (ssrf_policy_ready/0) is bound to it too --
-%% so enforcement and probing turn on together. It is now TRUE: the address
-%% policy (classify_ip/1 + the probe-layer resolve+pin) is implemented.
+%% The address policy (classify_ip/1 + the probe-layer resolve+pin) is now live,
+%% so ?ENFORCE_ADDRESS_POLICY is TRUE. It is retained as a defined marker of that
+%% state; enforcement itself runs unconditionally via url_allowed/1 and the
+%% probe-layer resolve+classify.
 %% NOTE: AppSec review + pen test are still pending (parent FAQ 2.1); the method
 %% remains opt-in (aws_auth_validate_registry ?OPT_IN_METHODS) so it is not live
 %% until an operator explicitly enables it.
@@ -210,35 +209,18 @@ allowed_fields() ->
 
 -spec validate(map()) -> aws_auth_validate_backend:result().
 validate(Body) when is_map(Body) ->
-    %% FAIL-CLOSED until the SSRF address policy is live. The probe issues
-    %% outbound requests to customer-supplied URLs from the broker's network
-    %% position; until classify_address/1 denies IMDS/link-local/loopback/
-    %% private targets (?ENFORCE_ADDRESS_POLICY = true) and AppSec has signed
-    %% off, no probe may run -- otherwise this is an SSRF vector (e.g. to
-    %% 169.254.169.254). Report method_disabled so an operator who turned the
-    %% method on still gets a safe, fixed-category 404 rather than a live
-    %% unrestricted probe. This guard lifts automatically when the policy lands.
-    case ssrf_policy_ready() of
-        false ->
-            {error, method_disabled};
-        true ->
-            %% Same ARN-first ordering as the LDAP backend: all pure,
-            %% network-free validation (URL shape, method, ssl_options values,
-            %% and the SSRF guard) runs before any cacertfile_arn is resolved
-            %% or any request is made.
-            case parse_input(Body) of
-                {error, _, _} = Err ->
-                    Err;
-                {ok, Params} ->
-                    do_http_validate(Params)
-            end
+    %% Whether the method may run is gated by the opt-in registry
+    %% (aws_auth_validate_registry ?OPT_IN_METHODS), not a compile-time switch:
+    %% the SSRF address policy is live, so no fail-closed guard is needed here.
+    %% Same ARN-first ordering as the LDAP backend: all pure, network-free
+    %% validation (URL shape, method, ssl_options values, and the SSRF guard)
+    %% runs before any cacertfile_arn is resolved or any request is made.
+    case parse_input(Body) of
+        {error, _, _} = Err ->
+            Err;
+        {ok, Params} ->
+            do_http_validate(Params)
     end.
-
-%% The probe is only allowed to run once the SSRF address policy is enforced.
-%% Tied to the same compile-time toggle the guard uses, so the backend cannot
-%% issue outbound requests while classify_address/1 is still a no-op.
-ssrf_policy_ready() ->
-    ?ENFORCE_ADDRESS_POLICY.
 
 %%--------------------------------------------------------------------
 %% Input parsing (pure, no network)
@@ -304,16 +286,21 @@ parse_url(Bin) when is_binary(Bin) ->
             %%  * an out-of-range port (else httpc crashes at request time),
             %%  * userinfo (user:pass@host) -- embedded credentials httpc would
             %%    turn into an Authorization header,
-            %%  * a pre-existing query string -- the broker's auth_http.*_path
-            %%    config is query-less and the probe appends its own ?username=
-            %%    params; a path that already carried a query would be mangled
-            %%    into a double-? URL and spuriously fail.
+            %%  * a pre-existing query string OR a #fragment -- the broker's
+            %%    auth_http.*_path config is query- and fragment-less and the
+            %%    probe appends its own ?username= params. A path that already
+            %%    carried a query would be mangled into a double-? URL; a path
+            %%    with a fragment would have the probe's ?query appended AFTER
+            %%    the fragment, so httpc drops the query (fragments are not sent)
+            %%    and the probe misfires. Either way it would spuriously fail.
             Port = maps:get(port, Parsed, undefined),
             HasQuery = maps:is_key(query, Parsed) andalso maps:get(query, Parsed) =/= [],
+            HasFragment =
+                maps:is_key(fragment, Parsed) andalso maps:get(fragment, Parsed) =/= [],
             case Port of
                 P when is_integer(P), (P < 1 orelse P > 65535) ->
                     {error, bad_url};
-                _ when HasQuery ->
+                _ when HasQuery orelse HasFragment ->
                     {error, bad_url};
                 _ ->
                     case maps:is_key(userinfo, Parsed) of
@@ -601,14 +588,14 @@ ip_to_int(Tuple) ->
 %% violation). A fresh profile has no sessions to reuse, and stopping it tears
 %% down anything opened, so each validation is hermetic.
 do_http_validate(Params) ->
-    Profile = probe_profile_name(),
-    case start_probe_profile(Profile) of
-        false ->
+    case claim_probe_profile() of
+        none ->
             %% Could not obtain an isolated profile; fail safe rather than fall
             %% back to the shared default profile (which would reintroduce the
-            %% session-reuse hazard).
+            %% session-reuse hazard). Unreachable in practice -- the semaphore
+            %% caps concurrency below the pool size -- but must be handled.
             {error, connection_failed, ?REASON_CONNECTION};
-        true ->
+        {ok, Profile} ->
             try
                 case build_client_ssl_opts(Params) of
                     {error, _, _} = Err ->
@@ -620,6 +607,7 @@ do_http_validate(Params) ->
                 _Class:_Reason:_Stack ->
                     {error, connection_failed, ?REASON_CONNECTION}
             after
+                %% Only ever stop the profile THIS request started (claimed).
                 stop_probe_profile(Profile)
             end
     end.
@@ -627,39 +615,47 @@ do_http_validate(Params) ->
 %% Profile names are drawn from a FIXED pool (?PROFILE_POOL_SIZE atoms, created
 %% once and reused forever) rather than a fresh unique atom per request --
 %% generating a new atom per validation would leak the atom table unboundedly
-%% (atoms are never GC'd) and eventually crash the node. The pool is sized well
-%% above auth_validation_max_concurrent's cap (100), so concurrently-running
-%% validations almost never collide on a slot; the slot is picked from a
-%% per-request ref so two simultaneous calls are very unlikely to share one.
+%% (atoms are never GC'd) and eventually crash the node. The pool is sized
+%% strictly ABOVE the concurrency hard cap (auth_validation_max_concurrent = 100),
+%% so a linear probe starting from a per-request hash always finds a FREE slot.
+%% Each in-flight probe OWNS a distinct started profile: a slot is claimed only
+%% by successfully starting it, so two simultaneous calls never share a profile
+%% and none is ever stolen from an actively-probing peer. The atom set stays
+%% bounded at exactly ?PROFILE_POOL_SIZE interned names.
 -define(PROFILE_POOL_SIZE, 128).
 
-probe_profile_name() ->
-    Slot = erlang:phash2(make_ref(), ?PROFILE_POOL_SIZE),
+profile_atom(Slot) ->
     list_to_atom("aws_auth_validate_http_" ++ integer_to_list(Slot)).
 
-%% Start the ephemeral profile and disable connection/session reuse on it
-%% (no keep-alive, no session cache) so nothing is pooled even within the call.
-%% If the chosen pool slot is already in use by a concurrent validation,
-%% reclaim it (stop+start): the worst case from a rare collision is that the
-%% other validation's probe errors out to a safe connection_failed -- never a
-%% false success or a leaked authenticated session. Returns whether we now own
-%% a started profile so `after' only stops what exists.
-start_probe_profile(Profile) ->
+%% Claim a profile by scanning the fixed pool for a FREE slot: start at a
+%% per-request hashed slot and try to inets:start it. Starting succeeds only if
+%% no concurrent validation already owns that slot, so success means we own it.
+%% On {already_started,_} advance to the next slot (never stop a slot in use by
+%% a peer -- that would tear down its in-flight request). Bounded to one full
+%% pass over the pool; if every slot is busy, fail closed. Returns {ok, Profile}
+%% | none.
+claim_probe_profile() ->
+    Start = erlang:phash2(make_ref(), ?PROFILE_POOL_SIZE),
+    claim_probe_profile(Start, ?PROFILE_POOL_SIZE).
+
+claim_probe_profile(_Slot, 0) ->
+    %% Every slot busy: unreachable while the semaphore caps concurrency below
+    %% ?PROFILE_POOL_SIZE, but fail closed rather than reuse a shared profile.
+    none;
+claim_probe_profile(Slot, Remaining) ->
+    Profile = profile_atom(Slot),
     case inets:start(httpc, [{profile, Profile}]) of
         {ok, _Pid} ->
+            %% We started (own) this profile; disable reuse and take it.
             set_probe_profile_opts(Profile),
-            true;
+            {ok, Profile};
         {error, {already_started, _}} ->
-            _ = inets:stop(httpc, Profile),
-            case inets:start(httpc, [{profile, Profile}]) of
-                {ok, _Pid} ->
-                    set_probe_profile_opts(Profile),
-                    true;
-                _ ->
-                    false
-            end;
+            %% Slot in use by a concurrent validation -- do NOT steal it; advance.
+            claim_probe_profile((Slot + 1) rem ?PROFILE_POOL_SIZE, Remaining - 1);
         _ ->
-            false
+            %% Any other start error: fail closed rather than risk the shared
+            %% default profile's session-reuse hazard.
+            none
     end.
 
 set_probe_profile_opts(Profile) ->
@@ -1078,7 +1074,7 @@ apply_verify_default(Opts, VerifyExplicit) ->
             %% explicit verify_none (already validated) -- leave it
             {ok, Opts};
         false ->
-            case trust_source(Opts) of
+            case ensure_trust_anchor(Opts) of
                 {ok, Opts1} -> {ok, [{verify, verify_peer} | Opts1]};
                 none -> {ok, Opts}
             end
@@ -1087,17 +1083,6 @@ apply_verify_default(Opts, VerifyExplicit) ->
 %% Opts contain {verify, verify_peer}. Return {ok, OptsWithAnchor} when a trust
 %% anchor is present or can be sourced from the OS store, else `none'.
 ensure_trust_anchor(Opts) ->
-    case lists:keymember(cacerts, 1, Opts) of
-        true ->
-            {ok, Opts};
-        false ->
-            case os_cacerts() of
-                [] -> none;
-                Certs -> {ok, [{cacerts, Certs} | Opts]}
-            end
-    end.
-
-trust_source(Opts) ->
     case lists:keymember(cacerts, 1, Opts) of
         true ->
             {ok, Opts};

--- a/test/aws_auth_validate_http_SUITE.erl
+++ b/test/aws_auth_validate_http_SUITE.erl
@@ -31,6 +31,12 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("inets/include/httpd.hrl").
 
+%% Named public ETS set the stub's do/1 records the received "host" header into,
+%% keyed by request path (created in init_per_suite, deleted in end_per_suite).
+%% Lets a test prove the pin connected to the IP but preserved the original
+%% hostname in the Host header.
+-define(HOST_HEADER_TABLE, aws_auth_validate_http_SUITE_host_headers).
+
 all() ->
     [
         {group, http}
@@ -50,7 +56,9 @@ groups() ->
             self_signed_under_verify_none_returns_ok,
             custom_ca_under_verify_peer_returns_ok,
             mtls_client_cert_presented_returns_ok,
-            mtls_client_cert_missing_returns_tls_failed
+            mtls_client_cert_missing_returns_tls_failed,
+            hostname_pin_preserves_host_ok,
+            hostname_resolving_to_infra_denied
         ]}
     ].
 
@@ -276,6 +284,84 @@ mtls_client_cert_missing_returns_tls_failed(Config) ->
         meck:unload(aws_arn_util)
     end.
 
+%%--------------------------------------------------------------------
+%% Hostname resolve+pin+rewrite (DNS-rebinding defense)
+%%--------------------------------------------------------------------
+%%
+%% The 12 cases above all target the literal 127.0.0.1, which takes the
+%% literal-IP branch of resolve_and_pin/1. These two exercise the hostname
+%% branch (resolve_hostname_and_pin/2), the central SSRF/DNS-rebinding control:
+%% resolve to ALL A/AAAA, DENY if ANY resolved address is broker infra, else pin
+%% to the resolved IP while keeping the original hostname in the Host header/SNI.
+
+hostname_pin_preserves_host_ok(Config) ->
+    %% Positive: a HOSTNAME (localhost, not a literal IP) resolves to loopback,
+    %% which auth_validation_allow_private_networks (set for the group) permits,
+    %% so the probe reaches the plaintext stub on 127.0.0.1 and returns ok. We
+    %% meck inet:getaddrs/2 so localhost resolves DETERMINISTICALLY to the stub's
+    %% 127.0.0.1 (inet) with no AAAA (inet6 nxdomain) -- otherwise a host that
+    %% returned ::1 first could pin to a loopback the stub is not bound to. The
+    %% host stays a NAME, so resolve_hostname_and_pin/2 runs: it pins the connect
+    %% target to the IP but build_request/4 keeps "localhost" in the Host header.
+    %% We then assert the stub RECEIVED Host: localhost, proving the rewrite kept
+    %% the original hostname while connecting to the pinned IP.
+    Port = ?config(http_port, Config),
+    %% Own the capture table in THIS (test-case) process. A named_table created
+    %% in init_per_suite would not survive: CT runs init_per_suite in a separate
+    %% process that terminates on return, taking its ETS tables with it. The
+    %% stub's do/1 (a distinct httpd process) writes to it by name while this
+    %% process -- the owner -- is alive; public access permits the cross-process
+    %% write. Deleted in the `after' clause.
+    ?HOST_HEADER_TABLE = ets:new(?HOST_HEADER_TABLE, [named_table, public, set]),
+    ok = meck:new(inet, [passthrough, unstick]),
+    try
+        meck:expect(inet, getaddrs, fun
+            ("localhost", inet) -> {ok, [{127, 0, 0, 1}]};
+            ("localhost", inet6) -> {error, nxdomain};
+            (H, Family) -> meck:passthrough([H, Family])
+        end),
+        Url = iolist_to_binary(["http://localhost:", integer_to_list(Port), "/ok200"]),
+        Body = #{
+            <<"user_path">> => Url,
+            <<"http_method">> => <<"get">>
+        },
+        ?assertEqual(ok, validate(Body)),
+        %% The stub saw the original hostname in Host, not the pinned IP. Host is
+        %% carried without the port (build_request/4 sends the bare hostname).
+        ?assertEqual("localhost", ets:lookup_element(?HOST_HEADER_TABLE, "/ok200", 2))
+    after
+        meck:unload(inet),
+        catch ets:delete(?HOST_HEADER_TABLE)
+    end.
+
+hostname_resolving_to_infra_denied(_Config) ->
+    %% Negative (DNS-rebinding deny): a benign-looking hostname resolves to a
+    %% DENIED infra address (IMDS 169.254.169.254), so the "deny if ANY resolved
+    %% address is broker infra" branch must fire -- even with allow_private_
+    %% networks on, which relaxes ONLY loopback. We meck inet:getaddrs/2 for both
+    %% families: the denied v4 for inet, nxdomain for inet6, so resolve_all/1
+    %% yields exactly the denied address and the deny is deterministic. The host
+    %% is a NAME (not a literal IP) so it passes the pure url_allowed/1 check and
+    %% is only caught in the probe-layer resolve+classify.
+    ok = meck:new(inet, [passthrough, unstick]),
+    try
+        meck:expect(inet, getaddrs, fun
+            ("rebind.test", inet) -> {ok, [{169, 254, 169, 254}]};
+            ("rebind.test", inet6) -> {error, nxdomain};
+            (H, Family) -> meck:passthrough([H, Family])
+        end),
+        Body = #{
+            <<"user_path">> => <<"http://rebind.test/ok200">>,
+            <<"http_method">> => <<"get">>
+        },
+        ?assertEqual(
+            {error, input_invalid, <<"a configured path targets a disallowed address">>},
+            validate(Body)
+        )
+    after
+        meck:unload(inet)
+    end.
+
 %% Route a resolve_arn call to the right PEM by ARN. The validator passes the
 %% ARN as a string (binary_to_list); match on the resource portion. certfile is
 %% S3-hosted, keyfile is Secrets Manager, cacert is the CA bundle.
@@ -347,6 +433,18 @@ start_https_stub(PrivDir) ->
 %% auth backend -> auth_failed).
 do(Info) ->
     Path = hd(string:split(Info#mod.request_uri, "?")),
+    %% Record the received "host" header (parsed_header keys are lowercased) so a
+    %% test can assert the pin kept the original hostname in Host even though the
+    %% connect target was rewritten to the IP. Guarded by ets:info so the write
+    %% is a no-op if the table is absent -- keeps do/1 backward-compatible for
+    %% the existing cases (which never read it) and cannot alter the response.
+    case ets:info(?HOST_HEADER_TABLE) of
+        undefined ->
+            ok;
+        _ ->
+            HostHdr = proplists:get_value("host", Info#mod.parsed_header, undefined),
+            true = ets:insert(?HOST_HEADER_TABLE, {Path, HostHdr})
+    end,
     {Status, Body} =
         case Path of
             "/ok200" -> {200, "allow"};

--- a/test/aws_auth_validate_http_tests.erl
+++ b/test/aws_auth_validate_http_tests.erl
@@ -124,7 +124,9 @@ http_bad_url_input_test_() ->
         %% fragment component.
         ?_assertMatch(
             {error, input_invalid, <<"a configured path is not a valid http(s) URL">>},
-            aws_auth_validate_http:validate(body_with_user_path(<<"https://example.com/auth#frag">>))
+            aws_auth_validate_http:validate(
+                body_with_user_path(<<"https://example.com/auth#frag">>)
+            )
         )
     ].
 

--- a/test/aws_auth_validate_http_tests.erl
+++ b/test/aws_auth_validate_http_tests.erl
@@ -119,6 +119,12 @@ http_bad_url_input_test_() ->
         ?_assertMatch(
             {error, input_invalid, <<"a configured path is not a valid http(s) URL">>},
             aws_auth_validate_http:validate(body_with_user_path(<<"https://8.8.8.8:70000/x">>))
+        ),
+        %% URL fragment (#frag) is rejected -- a configured path must not carry a
+        %% fragment component.
+        ?_assertMatch(
+            {error, input_invalid, <<"a configured path is not a valid http(s) URL">>},
+            aws_auth_validate_http:validate(body_with_user_path(<<"https://example.com/auth#frag">>))
         )
     ].
 
@@ -607,9 +613,6 @@ http_response_contract_test_() ->
 %% next thing reached. Uses a public literal IP host so classify_ip/1 returns
 %% allow in the pure phase (mirrors base_body/0 in aws_auth_validate_tests,
 %% which used 8.8.8.8 for the same reason). https so ssl_options/ARNs matter.
-base_body() ->
-    base_body(#{}).
-
 base_body(Overrides) when is_map(Overrides) ->
     Base = #{<<"user_path">> => <<"https://8.8.8.8/auth/user">>},
     maps:merge(Base, Overrides).


### PR DESCRIPTION
Resolve findings from lukebakken's security review of the HTTP backend:

- H1: remove the dead ssrf_policy_ready/0 guard and its unreachable {error, method_disabled} arm from validate/1. ?ENFORCE_ADDRESS_POLICY is hardcoded true, so the false arm was unreachable (dialyzer no_match) and the 2-tuple violated the behaviour result() type. The method is gated at runtime by the opt-in registry, not this compile-time switch.
- H2: replace the profile-pool steal-on-collision with a linear-probe claim. The old phash2(make_ref(), 128) picked a slot and, on collision, called inets:stop on a slot a concurrent validation was actively probing -- tearing down its request and yielding a spurious connection_failed. Now each probe owns a profile it successfully started and only stops that one; collisions are impossible since the pool (128) exceeds the concurrency cap (100).
- M1: add two CT cases for the hostname resolve+pin+rewrite path (the DNS-rebinding defense) -- a happy-path case asserting the Host header keeps the original name while the connect target is pinned to the IP, and a mecked-DNS case asserting a hostname resolving to infra is denied.
- M2: collapse the byte-identical trust_source/1 into ensure_trust_anchor/1.
- L1: remove the unused base_body/0 test helper.
- L2: reject a URL fragment in parse_url/1 (a #frag caused build_request to append the query after it, so httpc dropped the query and the probe misfired to auth_failed) + a eunit case.

Tests: 372 eunit + 14 HTTP CT cases pass; no dialyzer warning in the http module.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
