### PR TITLE
Fix: Fail closed on the no-ARN branch instead of a default aws_state

### DIFF
--- a/src/aws_auth_validate_http.erl
+++ b/src/aws_auth_validate_http.erl
@@ -273,7 +273,21 @@ validate(Body) when is_map(Body) ->
 resolve_request_state(Params) ->
     case request_references_arn(Params) of
         false ->
-            {ok, Params#{aws_state => aws_lib:new()}};
+            %% No ARN is referenced, so this request resolves nothing and needs
+            %% no credentials. Do NOT hand out a usable aws_lib:new() state here:
+            %% that state carries undefined credentials, and aws_lib's credential
+            %% chain (ensure_credentials_valid/1 -> refresh_credentials/1) would
+            %% fall back to env/file/EC2 instance metadata if any ARN fetch were
+            %% ever attempted under it -- letting a customer request resolve an
+            %% ARN under the broker's ambient (over-privileged) instance role, the
+            %% exact confused-deputy breach the assume_role guardrail exists to
+            %% prevent. We instead store the sentinel `none', which
+            %% resolve_arn/2 refuses, so the instance role is unreachable BY
+            %% CONSTRUCTION rather than by an invariant spread across
+            %% request_references_arn/1 and build_client_ssl_opts/1. The
+            %% credential-free reachability probe is preserved: it resolves zero
+            %% ARNs, so it never reaches resolve_arn/2.
+            {ok, Params#{aws_state => none}};
         true ->
             case configured_assume_role_arn() of
                 none ->
@@ -1039,9 +1053,12 @@ params_for(<<"topic_path">>) ->
 build_client_ssl_opts(#{ssl_options := Map} = Params) ->
     %% aws_state was built once per request by resolve_request_state/1 (under the
     %% configured assume_role when any ARN is referenced) and is threaded into
-    %% every ARN fetch here. A request that references no ARN carries a default
-    %% state that is never used to resolve one.
-    State = maps:get(aws_state, Params, undefined),
+    %% every ARN fetch here. A request that references no ARN carries the `none'
+    %% sentinel, which resolve_arn/2 refuses -- so even if an ARN fetch were
+    %% reached on that path it fails closed instead of falling back to the
+    %% instance role. Default to `none' (never a usable state) if the key is
+    %% somehow absent, preserving the fail-closed contract.
+    State = maps:get(aws_state, Params, none),
     case resolve_cacerts(maps:get(<<"cacertfile_arn">>, Map, undefined), State) of
         {error, _, _} = Err ->
             Err;
@@ -1263,7 +1280,16 @@ is_nonempty_binary(B) -> is_binary(B) andalso byte_size(B) > 0.
 %% validation pipeline. The 3-tuple {ok, Data, State1} from
 %% aws_arn_util:resolve_arn/2 is adapted back to the {ok, Binary} contract the
 %% callers expect; the threaded state is request-scoped and discarded here.
--spec resolve_arn(binary(), aws_lib:aws_state()) -> {ok, binary()} | {error, term()}.
+-spec resolve_arn(binary(), aws_lib:aws_state() | none) -> {ok, binary()} | {error, term()}.
+%% Fail closed on the `none' sentinel: a request that referenced no ARN carries
+%% aws_state => none (resolve_request_state/1), and must never resolve an ARN --
+%% doing so under aws_lib's default credential chain could reach the broker's EC2
+%% instance role. `none' can only appear if a future code path tries to resolve
+%% an ARN on the no-ARN branch; refusing here turns that into a fixed-category
+%% error (never an instance-role fetch). A credentialed state is only ever
+%% produced by resolve_request_state/1's assume_role path.
+resolve_arn(_Arn, none) ->
+    {error, no_credentials_state};
 resolve_arn(Arn, State) when is_binary(Arn) ->
     case aws_arn_util:resolve_arn(binary_to_list(Arn), State) of
         {ok, Data, _State1} -> {ok, Data};

--- a/test/aws_auth_validate_http_tests.erl
+++ b/test/aws_auth_validate_http_tests.erl
@@ -488,6 +488,110 @@ http_arn_resolved_after_pure_pass_test_() ->
         end}.
 
 %%--------------------------------------------------------------------
+%% Option B: the broker's EC2 instance role must be unreachable by
+%% construction. A request that references no ARN carries aws_state => none;
+%% resolve_arn/2 refuses that sentinel, so an ARN can never be resolved under
+%% aws_lib's default credential chain (which would fall back to env/file/IMDS
+%% and thus the instance role). Credential-free reachability is preserved.
+%%--------------------------------------------------------------------
+
+%% A no-ARN reachability probe needs no credentials and no configured
+%% assume_role: it must succeed WITHOUT ever calling aws_arn_util:resolve_arn.
+%% arn_config is deliberately unset -- proving the credential-free path does not
+%% require (and never touches) the assume_role machinery.
+http_no_arn_request_resolves_nothing_test_() ->
+    {setup,
+        fun() ->
+            ok = meck:new(aws_arn_util, [passthrough]),
+            ok = meck:new(httpc, [unstick, passthrough]),
+            ok = meck:new(inets, [unstick, passthrough]),
+            application:unset_env(aws, arn_config),
+            meck:expect(aws_arn_util, resolve_arn, fun(_Arn, State) -> {ok, ?SECRET, State} end),
+            meck:expect(inets, start, fun(httpc, _) -> {ok, self()} end),
+            meck:expect(inets, stop, fun(httpc, _) -> ok end),
+            meck:expect(httpc, set_options, fun(_, _) -> ok end),
+            meck:expect(httpc, request, fun(_M, _R, _H, _O, _P) ->
+                {ok, {{"HTTP/1.1", 200, "OK"}, [], <<"allow">>}}
+            end),
+            ok
+        end,
+        fun(_) ->
+            meck:unload(inets),
+            meck:unload(httpc),
+            meck:unload(aws_arn_util)
+        end,
+        fun(_) ->
+            %% No ssl_options ARNs -> request_references_arn = false ->
+            %% aws_state => none. verify_none avoids needing a trust anchor.
+            Body = base_body(#{
+                <<"ssl_options">> => #{<<"verify">> => <<"verify_none">>}
+            }),
+            Result = aws_auth_validate_http:validate(Body),
+            [
+                ?_assertEqual(ok, Result),
+                ?_assertEqual(0, meck:num_calls(aws_arn_util, resolve_arn, '_'))
+            ]
+        end}.
+
+%% Direct fail-closed check: build_client_ssl_opts/1 with aws_state => none and a
+%% cacertfile_arn must refuse via resolve_arn's `none' clause -- mapping to the
+%% fixed input_invalid/ARN-resolve category -- and must NOT call the real ARN
+%% resolver (i.e. no env/file/IMDS credential lookup ever happens). This proves
+%% the instance role is unreachable even if a future code path reached ARN
+%% resolution on the no-ARN branch.
+http_resolve_arn_fails_closed_on_none_sentinel_test_() ->
+    {setup,
+        fun() ->
+            ok = meck:new(aws_arn_util, [passthrough]),
+            %% If this is ever called the sentinel would leak into a real
+            %% (potentially IMDS-backed) resolve; assert 0 calls below.
+            meck:expect(aws_arn_util, resolve_arn, fun(_Arn, State) -> {ok, ?SECRET, State} end),
+            ok
+        end,
+        fun(_) ->
+            meck:unload(aws_arn_util)
+        end,
+        fun(_) ->
+            Params = #{
+                ssl_options => #{<<"cacertfile_arn">> => <<"arn:aws:s3:::ca">>},
+                aws_state => none
+            },
+            Result = aws_auth_validate_http:build_client_ssl_opts(Params),
+            [
+                ?_assertEqual({error, input_invalid, <<"failed to resolve ARN">>}, Result),
+                ?_assertEqual(0, meck:num_calls(aws_arn_util, resolve_arn, '_'))
+            ]
+        end}.
+
+%% An ARN-referencing request with NO configured assume_role must be refused with
+%% config_conflict BEFORE any ARN fetch -- the guardrail that keeps the endpoint
+%% off the broker's ambient instance role. resolve_arn must never be called.
+http_arn_request_without_role_is_config_conflict_test_() ->
+    {setup,
+        fun() ->
+            ok = meck:new(aws_arn_util, [passthrough]),
+            application:unset_env(aws, arn_config),
+            meck:expect(aws_arn_util, resolve_arn, fun(_Arn, State) -> {ok, ?SECRET, State} end),
+            ok
+        end,
+        fun(_) ->
+            meck:unload(aws_arn_util)
+        end,
+        fun(_) ->
+            Body = base_body(#{
+                <<"ssl_options">> => #{
+                    <<"cacertfile_arn">> => <<"arn:aws:s3:::ca">>,
+                    <<"verify">> => <<"verify_peer">>
+                }
+            }),
+            Result = aws_auth_validate_http:validate(Body),
+            [
+                ?_assertMatch({error, config_conflict, _}, Result),
+                ?_assertEqual(0, meck:num_calls(aws_arn_util, resolve_arn, '_'))
+            ]
+        end}.
+
+%%--------------------------------------------------------------------
 %% R6: a resolved secret (CA/cert/key PEM) must never reach a result term,
 %% log, or crash report -- even when the probe raises with the secret in scope.
 %% Mirrors ldap_bind_raise_does_not_leak_password_test_.


### PR DESCRIPTION
  The HTTP validation backend handed the no-ARN branch a usable aws_lib:new() state. That state carries undefined credentials, and aws_lib's credential chain (ensure_credentials_valid/1 -> refresh_credentials/1) falls back to env/file/EC2 instance metadata if any ARN fetch were ever attempted under it -- which would let a customer request resolve an ARN under the broker's ambient, potentially over-privileged instance role (a confused-deputy breach). Today that path is never taken, but only by an invariant spread across request_references_arn/1 and build_client_ssl_opts/1 agreeing on the same ARN-key set; a future ARN-backed field or an unconditional resolve would silently route to IMDS.

Store the sentinel `none' on the no-ARN branch and refuse it in resolve_arn/2, so the instance role is unreachable by construction rather than by a cross-function invariant. build_client_ssl_opts/1 defaults a missing aws_state to `none' too, preserving the fail-closed contract. The credential-free reachability probe is unaffected: it resolves zero ARNs, so it never reaches resolve_arn/2. The `none' clause maps to the existing fixed input_invalid/ARN-resolve category, leaking nothing.

Add regression tests: a no-ARN probe succeeds resolving nothing, a build_client_ssl_opts/1 with `none' + a cacertfile_arn fails closed without calling the resolver, and an ARN request with no configured assume_role returns config_conflict before any fetch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
