### PR TITLE
Refactor: Extract shared ssl/net/httpc modules from the validation backends

### DIFF
--- a/src/aws_auth_validate_http.erl
+++ b/src/aws_auth_validate_http.erl
@@ -86,6 +86,11 @@
 %% is unset. Matches the LDAP backend's default.
 -define(DEFAULT_TIMEOUT_MS, 5_000).
 
+%% Ephemeral httpc profile-name prefix for this backend's pool (shared pool
+%% machinery in aws_auth_validate_httpc). Disjoint from the oauth prefix so the
+%% two backends' pools never collide.
+-define(PROFILE_PREFIX, "aws_auth_validate_http_").
+
 %% The four request paths a rabbit_auth_backend_http config can define. Each is
 %% an absolute URL. user_path is required (the broker always issues a user
 %% check); the other three are optional and validated/probed only when present.
@@ -124,14 +129,6 @@
     <<"versions">>,
     <<"sni">>
 ]).
--define(SSL_VERIFY_VALUES, [<<"verify_peer">>, <<"verify_none">>]).
--define(SSL_VERSION_VALUES, [
-    <<"tlsv1.3">>,
-    <<"tlsv1.2">>,
-    <<"tlsv1.1">>,
-    <<"tlsv1">>
-]).
-
 %% Fixed, hardcoded reason strings (R4): no URL, host, or raw error echoed.
 -define(REASON_BAD_PATHS, <<"at least user_path must be a non-empty URL string">>).
 -define(REASON_BAD_PATH_VALUE, <<"each path must be a non-empty URL string">>).
@@ -153,13 +150,9 @@
 -define(REASON_CLIENT_CERT_INCOMPLETE,
     <<"ssl_options.certfile_arn and keyfile_arn must be supplied together">>
 ).
--define(REASON_NO_TRUST_ANCHOR,
-    <<"verify_peer requested but no CA trust anchor is available; supply cacertfile_arn">>
-).
 -define(REASON_CONNECTION, <<"could not connect to HTTP auth server">>).
 -define(REASON_TLS_HANDSHAKE, <<"TLS handshake failed">>).
 -define(REASON_ENDPOINT, <<"HTTP auth server did not return a usable response">>).
--define(REASON_ARN_RESOLVE, <<"failed to resolve ARN">>).
 -define(REASON_ASSUME_ROLE, <<"failed to assume the configured role">>).
 -define(REASON_NO_ASSUME_ROLE, <<
     "auth validation requires an assume_role to be configured; "
@@ -208,6 +201,44 @@
     %% unspecified ::/128
     {{0, 0, 0, 0, 0, 0, 0, 0}, 128}
 ]).
+
+%% Per-backend surface passed to the shared aws_auth_validate_ssl helpers: which
+%% ssl_options keys reference an ARN, the full allowed-key set, the customer SNI
+%% key spelling, whether the mTLS client-cert pair is accepted, and this
+%% backend's fixed R4 reason strings (kept here so wording/tests are unchanged).
+ssl_opts() ->
+    #{
+        arn_keys => [<<"cacertfile_arn">>, <<"certfile_arn">>, <<"keyfile_arn">>],
+        ssl_option_keys => ?SSL_OPTION_KEYS,
+        sni_key => <<"sni">>,
+        client_cert => true,
+        reasons => #{
+            no_assume_role => ?REASON_NO_ASSUME_ROLE,
+            assume_role => ?REASON_ASSUME_ROLE,
+            unknown_ssl_option => ?REASON_UNKNOWN_SSL_OPTION,
+            client_cert_incomplete => ?REASON_CLIENT_CERT_INCOMPLETE,
+            bad_ssl_options => ?REASON_BAD_SSL_OPTIONS,
+            bad_ssl_verify => ?REASON_BAD_SSL_VERIFY,
+            bad_ssl_depth => ?REASON_BAD_SSL_DEPTH,
+            bad_ssl_versions => ?REASON_BAD_SSL_VERSIONS,
+            bad_ssl_sni => ?REASON_BAD_SSL_SNI,
+            bad_ssl_cacert_arn => ?REASON_BAD_SSL_CACERT_ARN,
+            bad_ssl_cert_arn => ?REASON_BAD_SSL_CERT_ARN,
+            bad_ssl_key_arn => ?REASON_BAD_SSL_KEY_ARN
+        }
+    }.
+
+%% SSRF policy passed to the shared aws_auth_validate_net guard: this backend's
+%% infra denylists, its scheme allowlist (http+https), and the fixed reason
+%% strings for a disallowed target / an unreachable host.
+net_policy() ->
+    #{
+        denied_v4 => ?DENIED_V4_CIDRS,
+        denied_v6 => ?DENIED_V6_CIDRS,
+        allowed_schemes => ?ALLOWED_SCHEMES,
+        reason_not_allowed => ?REASON_URL_NOT_ALLOWED,
+        reason_connection => ?REASON_CONNECTION
+    }.
 
 %%--------------------------------------------------------------------
 %% Behaviour callbacks
@@ -271,47 +302,7 @@ validate(Body) when is_map(Body) ->
 %% no AWS call, so it needs no role and gets a default state that is never used
 %% to resolve an ARN -- preserving the credential-free reachability check.
 resolve_request_state(Params) ->
-    case request_references_arn(Params) of
-        false ->
-            {ok, Params#{aws_state => aws_lib:new()}};
-        true ->
-            case configured_assume_role_arn() of
-                none ->
-                    {error, config_conflict, ?REASON_NO_ASSUME_ROLE};
-                RoleArn ->
-                    case aws_iam:assume_role(RoleArn, aws_lib:new()) of
-                        {ok, State} -> {ok, Params#{aws_state => State}};
-                        {error, _} -> {error, input_invalid, ?REASON_ASSUME_ROLE}
-                    end
-            end
-    end.
-
-%% True when the request references any ARN-backed TLS material, i.e. resolving
-%% the request will make at least one AWS call. The ARN keys live under
-%% ssl_options (cacertfile_arn / certfile_arn / keyfile_arn); parse_ssl_options
-%% guaranteed cert/key are supplied together, so any one key means an AWS fetch.
-request_references_arn(#{ssl_options := Map}) ->
-    lists:any(
-        fun(K) -> maps:is_key(K, Map) end,
-        [<<"cacertfile_arn">>, <<"certfile_arn">>, <<"keyfile_arn">>]
-    ).
-
-%% The operator-configured boot-time assume role (aws.arns.assume_role_arn),
-%% read from the same `aws, arn_config' env the boot sequence uses
-%% (aws_arn_config:maybe_assume_role/1). Returns the role ARN string, or `none'
-%% when unset. Mirrors aws_auth_validate_ldap:configured_assume_role_arn/0.
-configured_assume_role_arn() ->
-    case application:get_env(aws, arn_config) of
-        {ok, ArnConfig} when is_list(ArnConfig) ->
-            case proplists:get_value(assume_role_arn, ArnConfig) of
-                undefined -> none;
-                Arn when is_list(Arn) -> Arn;
-                Arn when is_binary(Arn) -> binary_to_list(Arn);
-                _ -> none
-            end;
-        _ ->
-            none
-    end.
+    aws_auth_validate_ssl:resolve_request_state(Params, ssl_opts()).
 
 %%--------------------------------------------------------------------
 %% Input parsing (pure, no network)
@@ -421,76 +412,12 @@ parse_http_method(Body, Acc) ->
             {error, input_invalid, ?REASON_BAD_HTTP_METHOD}
     end.
 
-%% ssl_options parsing is identical to the LDAP backend's: validate both keys
-%% and values in the pure phase so a mis-typed value cannot be silently dropped
-%% and re-defaulted.
+%% ssl_options parsing (keys + values, mTLS pairing) is shared across backends;
+%% delegate to aws_auth_validate_ssl with this backend's surface (ssl_opts/0).
 parse_ssl_options(Body, Acc) ->
-    case maps:get(<<"ssl_options">>, Body, undefined) of
-        undefined ->
-            {ok, Acc#{ssl_options => #{}}};
-        Map when is_map(Map) ->
-            case [K || K <- maps:keys(Map), not lists:member(K, ?SSL_OPTION_KEYS)] of
-                [_ | _] ->
-                    {error, input_invalid, ?REASON_UNKNOWN_SSL_OPTION};
-                [] ->
-                    %% Client cert + key are an inseparable pair: one without
-                    %% the other cannot build an mTLS identity. Reject in the
-                    %% pure phase before resolving either ARN.
-                    HasCert = maps:is_key(<<"certfile_arn">>, Map),
-                    HasKey = maps:is_key(<<"keyfile_arn">>, Map),
-                    case HasCert =:= HasKey of
-                        false -> {error, input_invalid, ?REASON_CLIENT_CERT_INCOMPLETE};
-                        true -> validate_ssl_values(maps:to_list(Map), Acc, Map)
-                    end
-            end;
-        _ ->
-            {error, input_invalid, ?REASON_BAD_SSL_OPTIONS}
-    end.
-
-validate_ssl_values([], Acc, Map) ->
-    {ok, Acc#{ssl_options => Map}};
-validate_ssl_values([{Key, Value} | Rest], Acc, Map) ->
-    case valid_ssl_value(Key, Value) of
-        ok -> validate_ssl_values(Rest, Acc, Map);
-        {error, _, _} = Err -> Err
-    end.
-
-valid_ssl_value(<<"verify">>, V) ->
-    case lists:member(V, ?SSL_VERIFY_VALUES) of
-        true -> ok;
-        false -> {error, input_invalid, ?REASON_BAD_SSL_VERIFY}
-    end;
-valid_ssl_value(<<"depth">>, V) when is_integer(V), V >= 0 ->
-    ok;
-valid_ssl_value(<<"depth">>, _) ->
-    {error, input_invalid, ?REASON_BAD_SSL_DEPTH};
-valid_ssl_value(<<"versions">>, V) when is_list(V), V =/= [] ->
-    case lists:all(fun(Ver) -> lists:member(Ver, ?SSL_VERSION_VALUES) end, V) of
-        true -> ok;
-        false -> {error, input_invalid, ?REASON_BAD_SSL_VERSIONS}
-    end;
-valid_ssl_value(<<"versions">>, _) ->
-    {error, input_invalid, ?REASON_BAD_SSL_VERSIONS};
-valid_ssl_value(<<"sni">>, V) ->
-    case is_nonempty_binary(V) of
-        true -> ok;
-        false -> {error, input_invalid, ?REASON_BAD_SSL_SNI}
-    end;
-valid_ssl_value(<<"cacertfile_arn">>, V) ->
-    case is_nonempty_binary(V) of
-        true -> ok;
-        false -> {error, input_invalid, ?REASON_BAD_SSL_CACERT_ARN}
-    end;
-valid_ssl_value(<<"certfile_arn">>, V) ->
-    case is_nonempty_binary(V) of
-        true -> ok;
-        false -> {error, input_invalid, ?REASON_BAD_SSL_CERT_ARN}
-    end;
-valid_ssl_value(<<"keyfile_arn">>, V) ->
-    case is_nonempty_binary(V) of
-        true -> ok;
-        false -> {error, input_invalid, ?REASON_BAD_SSL_KEY_ARN}
-    end.
+    aws_auth_validate_ssl:parse_ssl_options(
+        maps:get(<<"ssl_options">>, Body, undefined), Acc, ssl_opts()
+    ).
 
 %%--------------------------------------------------------------------
 %% SSRF guard
@@ -528,123 +455,23 @@ guard_urls(_Body, #{paths := Paths} = Acc) ->
 check_urls([]) ->
     ok;
 check_urls([{_Key, Url} | Rest]) ->
-    case url_allowed(Url) of
+    case aws_auth_validate_net:url_allowed(Url, net_policy()) of
         ok -> check_urls(Rest);
         {error, _, _} = Err -> Err
     end.
 
-%% Pure per-URL policy check: scheme allowlist + literal-IP classification.
-%% Hostnames pass here (allow) and are re-checked after DNS in the probe layer.
-url_allowed(#{scheme := Scheme} = Url) ->
-    case lists:member(Scheme, ?ALLOWED_SCHEMES) of
-        false ->
-            {error, input_invalid, ?REASON_URL_NOT_ALLOWED};
-        true ->
-            case classify_address(Url) of
-                allow -> ok;
-                deny -> {error, input_invalid, ?REASON_URL_NOT_ALLOWED}
-            end
-    end.
-
-%% Classify a URL's host in the pure phase. A literal IP is classified directly
-%% against the infra denylist. A hostname cannot be classified without DNS, so
-%% it is allowed here and resolved+classified in the probe layer.
-classify_address(#{host := Host}) ->
-    case inet:parse_address(Host) of
-        {ok, IP} -> classify_ip(IP);
-        {error, _} -> allow
-    end.
-
-%% classify_ip/1: allow | deny for a parsed IP tuple. Denies the broker-infra
-%% ranges only. Several IPv6 notations embed a v4 address; each must be
-%% unwrapped to its v4 form and re-classified, otherwise the v6 encoding
-%% smuggles a denied v4 address (e.g. 169.254.169.254) past the v4 denylist.
-%% Covered: IPv4-mapped ::ffff:a.b.c.d, IPv4-compatible ::a.b.c.d, NAT64
-%% 64:ff9b::/96, and 6to4 2002:WWXX:YYZZ::/48. The unwrap clauses come BEFORE
-%% the generic 8-tuple clause so they win.
-classify_ip({0, 0, 0, 0, 0, 16#ffff, W1, W2}) ->
-    %% IPv4-mapped ::ffff:a.b.c.d
-    classify_ip(v4_from_words(W1, W2));
-classify_ip({0, 0, 0, 0, 0, 0, W1, W2}) when {W1, W2} =/= {0, 0}, {W1, W2} =/= {0, 1} ->
-    %% IPv4-compatible ::a.b.c.d (RFC4291-deprecated). The guard lets the
-    %% unspecified :: and loopback ::1 fall through to the v6 denylist instead
-    %% (::1 must be matched as v6 loopback, not as v4 0.0.0.1).
-    classify_ip(v4_from_words(W1, W2));
-classify_ip({16#64, 16#ff9b, 0, 0, 0, 0, W1, W2}) ->
-    %% NAT64 well-known prefix 64:ff9b::/96 -> embedded v4 in the low 32 bits.
-    classify_ip(v4_from_words(W1, W2));
-classify_ip({16#2002, W1, W2, _, _, _, _, _}) ->
-    %% 6to4 2002::/16 -> embedded v4 in segments 2-3.
-    classify_ip(v4_from_words(W1, W2));
-classify_ip({_, _, _, _} = V4) ->
-    case in_any_cidr(V4, ?DENIED_V4_CIDRS) of
-        true -> classify_denied(V4);
-        false -> allow
-    end;
-classify_ip({_, _, _, _, _, _, _, _} = V6) ->
-    case in_any_cidr(V6, ?DENIED_V6_CIDRS) of
-        true -> classify_denied(V6);
-        false -> allow
-    end.
-
-%% A denied address is normally `deny'. The ONE exception is loopback when
-%% auth_validation_allow_private_networks is set: that flag (default false, off
-%% in production) lets the HTTP integration suite probe a local stub server on
-%% 127.0.0.1/::1. It is the HTTP analogue of the same flag the LDAP backend
-%% honours for local-slapd tests. It relaxes ONLY loopback -- IMDS, link-local,
-%% and unspecified stay denied even with the flag on, so it cannot be used to
-%% reach instance metadata.
-classify_denied(IP) ->
-    case is_loopback(IP) andalso allow_private_networks() of
-        true -> allow;
-        false -> deny
-    end.
-
-is_loopback({127, _, _, _}) -> true;
-is_loopback({0, 0, 0, 0, 0, 0, 0, 1}) -> true;
-is_loopback(_) -> false.
-
-allow_private_networks() ->
-    application:get_env(aws, auth_validation_allow_private_networks, false) =:= true.
-
-%% Two 16-bit words -> a v4 4-tuple {a,b,c,d}.
-v4_from_words(W1, W2) ->
-    {W1 bsr 8, W1 band 16#ff, W2 bsr 8, W2 band 16#ff}.
-
-in_any_cidr(IP, Cidrs) ->
-    lists:any(fun(Cidr) -> in_cidr(IP, Cidr) end, Cidrs).
-
-%% in_cidr/2: is IP within {Network, PrefixBits}? Same address family only
-%% (a v4 IP never matches a v6 CIDR and vice-versa). Converts both to a single
-%% integer, drops the host bits below the prefix, and compares the network bits.
-in_cidr({_, _, _, _} = IP, {{_, _, _, _} = Net, Prefix}) when
-    Prefix >= 0, Prefix =< 32
-->
-    same_prefix(ip_to_int(IP), ip_to_int(Net), 32, Prefix);
-in_cidr({_, _, _, _, _, _, _, _} = IP, {{_, _, _, _, _, _, _, _} = Net, Prefix}) when
-    Prefix >= 0, Prefix =< 128
-->
-    same_prefix(ip_to_int(IP), ip_to_int(Net), 128, Prefix);
-in_cidr(_IP, _Cidr) ->
-    %% Cross-family (e.g. v4 IP vs v6 CIDR): never matches.
-    false.
-
-same_prefix(IpInt, NetInt, TotalBits, Prefix) ->
-    HostBits = TotalBits - Prefix,
-    (IpInt bsr HostBits) =:= (NetInt bsr HostBits).
-
-%% Fold an IP tuple into a single unsigned integer (v4: 32-bit, v6: 128-bit).
-ip_to_int(Tuple) ->
-    BitsPerElem =
-        case tuple_size(Tuple) of
-            4 -> 8;
-            8 -> 16
-        end,
-    lists:foldl(
-        fun(Elem, Acc) -> (Acc bsl BitsPerElem) bor Elem end,
-        0,
-        tuple_to_list(Tuple)
-    ).
+-ifdef(TEST).
+%% TEST-only wrappers exposing the shared SSRF guard under this backend's policy,
+%% so the module's -ifdef(TEST) export contract stays stable. Production code
+%% calls aws_auth_validate_net directly.
+url_allowed(Url) -> aws_auth_validate_net:url_allowed(Url, net_policy()).
+classify_address(Url) -> aws_auth_validate_net:classify_address(Url, net_policy()).
+classify_ip(IP) -> aws_auth_validate_net:classify_ip(IP, net_policy()).
+in_cidr(IP, Cidr) -> aws_auth_validate_net:in_cidr(IP, Cidr).
+in_any_cidr(IP, Cidrs) -> aws_auth_validate_net:in_any_cidr(IP, Cidrs).
+resolve_and_pin(Url) -> aws_auth_validate_net:resolve_and_pin(Url, net_policy()).
+pin_url(Url, Host) -> aws_auth_validate_net:pin_url(Url, Host).
+-endif.
 
 %%--------------------------------------------------------------------
 %% Reachability probe (network)
@@ -679,7 +506,7 @@ ip_to_int(Tuple) ->
 %% violation). A fresh profile has no sessions to reuse, and stopping it tears
 %% down anything opened, so each validation is hermetic.
 do_http_validate(Params) ->
-    case claim_probe_profile() of
+    case aws_auth_validate_httpc:claim_probe_profile(?PROFILE_PREFIX) of
         none ->
             %% Could not obtain an isolated profile; fail safe rather than fall
             %% back to the shared default profile (which would reintroduce the
@@ -699,80 +526,9 @@ do_http_validate(Params) ->
                     {error, connection_failed, ?REASON_CONNECTION}
             after
                 %% Only ever stop the profile THIS request started (claimed).
-                stop_probe_profile(Profile)
+                aws_auth_validate_httpc:stop_probe_profile(Profile)
             end
     end.
-
-%% This profile machinery exists ONLY because httpc pools sessions on a global,
-%% named-profile basis; see the HTTP client rationale in the module header for
-%% why httpc is nonetheless the right client here.
-%%
-%% Profile names are drawn from a FIXED pool (?PROFILE_POOL_SIZE atoms, created
-%% once and reused forever) rather than a fresh unique atom per request --
-%% generating a new atom per validation would leak the atom table unboundedly
-%% (atoms are never GC'd) and eventually crash the node. The pool is sized
-%% strictly ABOVE the concurrency hard cap (auth_validation_max_concurrent = 100),
-%% so a linear probe starting from a per-request hash always finds a FREE slot.
-%% Each in-flight probe OWNS a distinct started profile: a slot is claimed only
-%% by successfully starting it, so two simultaneous calls never share a profile
-%% and none is ever stolen from an actively-probing peer. The atom set stays
-%% bounded at exactly ?PROFILE_POOL_SIZE interned names.
--define(PROFILE_POOL_SIZE, 128).
-
-profile_atom(Slot) ->
-    list_to_atom("aws_auth_validate_http_" ++ integer_to_list(Slot)).
-
-%% Claim a profile by scanning the fixed pool for a FREE slot: start at a
-%% per-request hashed slot and try to inets:start it. Starting succeeds only if
-%% no concurrent validation already owns that slot, so success means we own it.
-%% On {already_started,_} (slot running) or already_present (slot mid-teardown)
-%% advance to the next slot -- never stop a slot in use by a peer, that would
-%% tear down its in-flight request. Bounded to one full pass over the pool; if
-%% every slot is busy, fail closed. Returns {ok, Profile} | none.
-claim_probe_profile() ->
-    Start = erlang:phash2(make_ref(), ?PROFILE_POOL_SIZE),
-    claim_probe_profile(Start, ?PROFILE_POOL_SIZE).
-
-claim_probe_profile(_Slot, 0) ->
-    %% Every slot busy: unreachable while the semaphore caps concurrency below
-    %% ?PROFILE_POOL_SIZE, but fail closed rather than reuse a shared profile.
-    none;
-claim_probe_profile(Slot, Remaining) ->
-    Profile = profile_atom(Slot),
-    case inets:start(httpc, [{profile, Profile}]) of
-        {ok, _Pid} ->
-            %% We started (own) this profile; disable reuse and take it.
-            set_probe_profile_opts(Profile),
-            {ok, Profile};
-        {error, {already_started, _}} ->
-            %% Slot in use by a concurrent validation -- do NOT steal it; advance.
-            claim_probe_profile((Slot + 1) rem ?PROFILE_POOL_SIZE, Remaining - 1);
-        {error, already_present} ->
-            %% Slot mid-teardown by a concurrent validation. inets:stop/2 runs
-            %% terminate_child THEN delete_child as two separate supervisor
-            %% calls; a permanent child (the httpc profile) keeps its spec with
-            %% pid=undefined between them, so a start landing in that window sees
-            %% already_present rather than already_started. Not cleanly free --
-            %% advance like the already_started case rather than fail this
-            %% request closed. The pool size exceeds the concurrency cap, so the
-            %% scan still lands on a genuinely free slot within one pass.
-            claim_probe_profile((Slot + 1) rem ?PROFILE_POOL_SIZE, Remaining - 1);
-        _ ->
-            %% Any other start error: fail closed rather than risk the shared
-            %% default profile's session-reuse hazard.
-            none
-    end.
-
-set_probe_profile_opts(Profile) ->
-    _ = httpc:set_options(
-        [{max_sessions, 0}, {max_keep_alive_length, 0}, {keep_alive_timeout, 0}],
-        Profile
-    ),
-    ok.
-
-stop_probe_profile(Profile) ->
-    _ = inets:stop(httpc, Profile),
-    ok.
 
 %% Probe each configured path in turn; the first non-ok outcome wins (mirrors
 %% the LDAP backend's check_dns/2 short-circuit).
@@ -789,7 +545,7 @@ probe_one(Key, Url, #{http_method := Method, timeout := Timeout}, SslOpts, Profi
     %% denylist BEFORE connecting, then connect to the pinned IP so httpc cannot
     %% re-resolve to a different (possibly denied) address (DNS-rebinding /
     %% TOCTOU defense). For a literal-IP host this is a no-op pin to that IP.
-    case resolve_and_pin(Url) of
+    case aws_auth_validate_net:resolve_and_pin(Url, net_policy()) of
         {error, _, _} = Err ->
             Err;
         {ok, PinnedUrl, Host} ->
@@ -821,100 +577,21 @@ probe_one(Key, Url, #{http_method := Method, timeout := Timeout}, SslOpts, Profi
             end
     end.
 
-%% Resolve the URL's host to all addresses, deny if ANY is a blocked infra
-%% address, and return the URL rewritten to connect to a single pinned IP plus
-%% the original host (for the Host header / SNI). A literal-IP host is pinned to
-%% itself (already classified in the pure phase, re-checked here defensively).
-%% A resolution failure is a reachability fact -> connection_failed.
-resolve_and_pin(#{host := Host} = Url) ->
-    case inet:parse_address(Host) of
-        {ok, IP} ->
-            %% Literal IP: re-classify defensively, pin to itself.
-            case classify_ip(IP) of
-                deny -> {error, input_invalid, ?REASON_URL_NOT_ALLOWED};
-                allow -> {ok, pin_url(Url, Host), Host}
-            end;
-        {error, _} ->
-            resolve_hostname_and_pin(Url, Host)
-    end.
-
-resolve_hostname_and_pin(Url, Host) ->
-    Addrs = resolve_all(Host),
-    case Addrs of
-        [] ->
-            {error, connection_failed, ?REASON_CONNECTION};
-        _ ->
-            case lists:any(fun(IP) -> classify_ip(IP) =:= deny end, Addrs) of
-                true ->
-                    %% At least one resolved address is blocked infra. Deny the
-                    %% whole request -- never connect to a host that resolves
-                    %% (even partly) to IMDS/loopback/link-local.
-                    {error, input_invalid, ?REASON_URL_NOT_ALLOWED};
-                false ->
-                    %% All addresses allowed: pin to the first and connect there.
-                    PinIP = inet:ntoa(hd(Addrs)),
-                    {ok, pin_url(Url, PinIP), Host}
-            end
-    end.
-
-%% Resolve a hostname to all IPv4 + IPv6 addresses (best-effort per family).
-resolve_all(Host) ->
-    V4 =
-        case inet:getaddrs(Host, inet) of
-            {ok, A4} -> A4;
-            {error, _} -> []
-        end,
-    V6 =
-        case inet:getaddrs(Host, inet6) of
-            {ok, A6} -> A6;
-            {error, _} -> []
-        end,
-    V4 ++ V6.
-
-%% Rewrite the URL to connect to the pinned IP, keeping scheme/port/path/query.
-%% uri_string:recompose brackets an IPv6 host on its own. The original hostname
-%% is carried separately (build_request adds the Host header, ssl_http_opt sets
-%% SNI) so vhost routing and cert hostname verification still target the real
-%% name, not the pinned IP.
-pin_url(Url, PinHost) ->
-    Rebuilt = uri_string:recompose(maps:without([url_string], Url#{host => PinHost})),
-    Url#{url_string => Rebuilt}.
-
-%% Map an httpc transport error to a fixed category. A TLS/cert failure is
-%% reported as tls_failed; everything else (refused, DNS, timeout, closed) is
-%% connection_failed. We never echo the raw reason (R4).
+%% Map an httpc transport error to a fixed category (shared classifier). A
+%% TLS/cert failure -> tls_failed; everything else -> connection_failed. The raw
+%% reason is never echoed (R4).
 classify_http_error(Reason) ->
-    case is_tls_error(Reason) of
-        true -> {error, tls_failed, ?REASON_TLS_HANDSHAKE};
-        false -> {error, connection_failed, ?REASON_CONNECTION}
-    end.
+    aws_auth_validate_ssl:classify_http_error(
+        Reason, ?REASON_TLS_HANDSHAKE, ?REASON_CONNECTION
+    ).
 
-%% Recursively scan an httpc error term for the markers of a TLS-layer failure
-%% (tls_alert, or a certificate/handshake atom). httpc wraps these as
-%% {failed_connect, [..., {inet, [inet], {tls_alert, _}}]} and similar.
-is_tls_error(Term) when is_tuple(Term) ->
-    case element(1, Term) of
-        tls_alert -> true;
-        Other when is_atom(Other) -> is_tls_atom(Other) orelse is_tls_error(tuple_to_list(Term));
-        _ -> is_tls_error(tuple_to_list(Term))
-    end;
-is_tls_error([H | T]) ->
-    is_tls_error(H) orelse is_tls_error(T);
-is_tls_error(Atom) when is_atom(Atom) ->
-    is_tls_atom(Atom);
-is_tls_error(_) ->
-    false.
-
-is_tls_atom(A) ->
-    lists:member(A, [
-        tls_alert,
-        certificate_expired,
-        bad_certificate,
-        unknown_ca,
-        handshake_failure,
-        certificate_unknown,
-        no_peercert
-    ]).
+-ifdef(TEST).
+%% TEST-only re-export delegating to the shared TLS-error scanner (the module's
+%% -ifdef(TEST) export block exposes it; production code calls the shared module
+%% directly via classify_http_error/1).
+is_tls_error(Term) ->
+    aws_auth_validate_ssl:is_tls_error(Term).
+-endif.
 
 %% Response-contract check: the status code proved the server answered, this
 %% proves it answered like rabbit_auth_backend_http. A `deny' (or a `deny'-
@@ -1036,242 +713,36 @@ params_for(<<"topic_path">>) ->
 %% proplist for httpc. ARN resolution happens here, in the network phase, after
 %% all pure validation has passed (ARN-first ordering). Any resolution failure
 %% maps to input_invalid, matching the LDAP backend.
+%% Resolve the ARN-backed TLS material (CA bundle + optional mTLS client cert)
+%% and translate the validated ssl_options into an ssl proplist for httpc. The
+%% resolution, decoding, and verify-default policy are shared
+%% (aws_auth_validate_ssl); only the SNI key spelling (<<"sni">>) is
+%% backend-specific.
 build_client_ssl_opts(#{ssl_options := Map} = Params) ->
     %% aws_state was built once per request by resolve_request_state/1 (under the
     %% configured assume_role when any ARN is referenced) and is threaded into
     %% every ARN fetch here. A request that references no ARN carries a default
     %% state that is never used to resolve one.
-    State = maps:get(aws_state, Params, undefined),
-    case resolve_cacerts(maps:get(<<"cacertfile_arn">>, Map, undefined), State) of
+    State = maps:get(aws_state, Params, none),
+    case
+        aws_auth_validate_ssl:resolve_cacerts(maps:get(<<"cacertfile_arn">>, Map, undefined), State)
+    of
         {error, _, _} = Err ->
             Err;
         {ok, CacertOpts} ->
-            case resolve_client_cert(Map, State) of
+            case aws_auth_validate_ssl:resolve_client_cert(Map, State) of
                 {error, _, _} = Err ->
                     Err;
                 {ok, ClientOpts} ->
-                    Opts = CacertOpts ++ ClientOpts ++ translate_ssl_opts(Map),
+                    Opts =
+                        CacertOpts ++ ClientOpts ++
+                            aws_auth_validate_ssl:translate_ssl_opts(Map, <<"sni">>),
                     %% Whether the caller set verify explicitly governs the
                     %% no-trust-anchor policy (fail vs silent default).
                     VerifyExplicit = maps:is_key(<<"verify">>, Map),
-                    apply_verify_default(Opts, VerifyExplicit)
+                    aws_auth_validate_ssl:apply_verify_default(Opts, VerifyExplicit)
             end
-    end.
-
-resolve_cacerts(undefined, _State) ->
-    {ok, []};
-resolve_cacerts(Arn, State) when is_binary(Arn) ->
-    case resolve_arn(Arn, State) of
-        {ok, Pem} ->
-            case decode_pem_cacerts(Pem) of
-                skip -> {ok, []};
-                Certs -> {ok, [{cacerts, Certs}]}
-            end;
-        {error, _} ->
-            {error, input_invalid, ?REASON_ARN_RESOLVE}
-    end.
-
-%% Resolve the client certificate + private key for mutual TLS. parse_ssl_options
-%% already guaranteed both are present or both absent, so here we either resolve
-%% the pair or return no client-auth options.
-resolve_client_cert(#{<<"certfile_arn">> := CertArn, <<"keyfile_arn">> := KeyArn}, State) when
-    is_binary(CertArn), is_binary(KeyArn)
-->
-    case resolve_arn(CertArn, State) of
-        {ok, CertPem} ->
-            case decode_client_cert(CertPem) of
-                {error, _, _} = Err ->
-                    Err;
-                {ok, CertOpt} ->
-                    case resolve_arn(KeyArn, State) of
-                        {ok, KeyPem} ->
-                            case decode_client_key(KeyPem) of
-                                {error, _, _} = Err -> Err;
-                                {ok, KeyOpt} -> {ok, [CertOpt, KeyOpt]}
-                            end;
-                        {error, _} ->
-                            {error, input_invalid, ?REASON_ARN_RESOLVE}
-                    end
-            end;
-        {error, _} ->
-            {error, input_invalid, ?REASON_ARN_RESOLVE}
-    end;
-resolve_client_cert(_Map, _State) ->
-    {ok, []}.
-
-%% Decode a client-certificate PEM into an ssl {cert, DER} option. The first
-%% 'Certificate' entry is the leaf; we pass the raw DER (ssl accepts a single
-%% DER binary or a list). A PEM with no certificate entry is a resolution-shaped
-%% failure (the secret content is wrong), reported as the fixed ARN category so
-%% no PEM content leaks.
-decode_client_cert(Pem) when is_binary(Pem) ->
-    case [Der || {'Certificate', Der, not_encrypted} <- public_key:pem_decode(Pem)] of
-        [] -> {error, input_invalid, ?REASON_ARN_RESOLVE};
-        Ders -> {ok, {cert, Ders}}
-    end.
-
-%% Decode a private-key PEM into an ssl {key, {Asn1Type, DER}} option. Accepts
-%% the common unencrypted key entry types. An encrypted or absent key is a
-%% fixed ARN-category failure (we never prompt for a passphrase or echo detail).
-decode_client_key(Pem) when is_binary(Pem) ->
-    KeyEntries = [
-        {Type, Der}
-     || {Type, Der, not_encrypted} <- public_key:pem_decode(Pem),
-        lists:member(Type, [
-            'PrivateKeyInfo', 'RSAPrivateKey', 'ECPrivateKey', 'DSAPrivateKey'
-        ])
-    ],
-    case KeyEntries of
-        [{Type, Der} | _] -> {ok, {key, {Type, Der}}};
-        [] -> {error, input_invalid, ?REASON_ARN_RESOLVE}
-    end.
-
-%% Translate the non-cacert ssl_options keys. `sni' is the customer-facing
-%% config key; ssl expects `server_name_indication', so translate it here.
-translate_ssl_opts(Map) ->
-    Pairs = [
-        {verify, <<"verify">>, fun to_verify/1},
-        {depth, <<"depth">>, fun to_integer/1},
-        {versions, <<"versions">>, fun to_versions/1},
-        {server_name_indication, <<"sni">>, fun to_list/1}
-    ],
-    lists:foldl(
-        fun({SslKey, JsonKey, Fun}, Acc) ->
-            case maps:get(JsonKey, Map, undefined) of
-                undefined -> Acc;
-                Value -> [{SslKey, Fun(Value)} | Acc]
-            end
-        end,
-        [],
-        Pairs
-    ).
-
-%% Ensure verify_peer always has a trust anchor, whether the caller set
-%% verify_peer EXPLICITLY or we are about to default it on. Without this, an
-%% explicit `verify: verify_peer' with no cacertfile_arn produced
-%% [{verify, verify_peer}] with no `cacerts', which OTP ssl rejects as
-%% {options, incompatible, [{verify,verify_peer},{cacerts,undefined}]} -- httpc
-%% surfaces that as a generic failed_connect (no tls_alert), so the probe
-%% mis-reported connection_failed and an explicit verify_peer could never
-%% succeed. Policy:
-%% The no-trust-anchor policy DEPENDS on whether the caller asked for
-%% verify_peer EXPLICITLY:
-%%   * EXPLICIT verify_peer + no cacerts -> attach OS trust store if available;
-%%     if none, FAIL with tls_failed. Silently downgrading an explicit
-%%     verify_peer to verify_none would report a passing handshake that never
-%%     verified the peer -- the exact false-positive this endpoint exists to
-%%     prevent, so we surface it instead.
-%%   * DEFAULTED verify (caller omitted it) -> verify_peer when a trust anchor
-%%     exists, else leave verify unset (broker-parity verify_none); this is a
-%%     host-environment artifact, not a customer config error, so no failure.
-%%   * explicit verify_none -> untouched.
-%% Returns {ok, Opts} | {error, Category, Reason}.
-apply_verify_default(Opts, VerifyExplicit) ->
-    case lists:keyfind(verify, 1, Opts) of
-        {verify, verify_peer} when VerifyExplicit ->
-            case ensure_trust_anchor(Opts) of
-                {ok, _} = Ok -> Ok;
-                none -> {error, tls_failed, ?REASON_NO_TRUST_ANCHOR}
-            end;
-        {verify, verify_peer} ->
-            %% verify_peer that we defaulted on (not caller-supplied): if the
-            %% anchor vanished, fall back rather than fail.
-            case ensure_trust_anchor(Opts) of
-                {ok, Opts1} -> {ok, Opts1};
-                none -> {ok, lists:keyreplace(verify, 1, Opts, {verify, verify_none})}
-            end;
-        {verify, _Other} ->
-            %% explicit verify_none (already validated) -- leave it
-            {ok, Opts};
-        false ->
-            case ensure_trust_anchor(Opts) of
-                {ok, Opts1} -> {ok, [{verify, verify_peer} | Opts1]};
-                none -> {ok, Opts}
-            end
-    end.
-
-%% Opts contain {verify, verify_peer}. Return {ok, OptsWithAnchor} when a trust
-%% anchor is present or can be sourced from the OS store, else `none'.
-ensure_trust_anchor(Opts) ->
-    case lists:keymember(cacerts, 1, Opts) of
-        true ->
-            {ok, Opts};
-        false ->
-            case os_cacerts() of
-                [] -> none;
-                Certs -> {ok, [{cacerts, Certs} | Opts]}
-            end
-    end.
-
-os_cacerts() ->
-    try
-        public_key:cacerts_get()
-    catch
-        _:_ -> []
-    end.
-
-%% Decode a CA-bundle PEM into the raw DER binaries ssl's {cacerts, _} option
-%% expects. Passing decoded #'OTPCertificate'{} records (pem_entry_decode/1
-%% output) makes ssl silently ignore the trust anchor -> unknown_ca -> a
-%% spurious tls_failed (see the custom_ca_under_verify_peer_returns_ok
-%% regression guard). Mirror decode_client_cert/1: take only the 'Certificate'
-%% entries, as raw DER. A PEM with no certificate entry yields no anchor (skip),
-%% same as an empty bundle. The LDAP backend's identically named helper does the
-%% same thing for the same reason -- eldap forwards sslopts to this same ssl.
-decode_pem_cacerts(B) when is_binary(B) ->
-    case [Der || {'Certificate', Der, not_encrypted} <- public_key:pem_decode(B)] of
-        [] -> skip;
-        Ders -> Ders
-    end.
-
-to_list(B) when is_binary(B) -> binary_to_list(B);
-to_list(L) when is_list(L) -> L.
-
-to_integer(I) when is_integer(I) -> I.
-
-%% Explicit value->atom tables (mirrors aws_auth_validate_ldap). Using fixed
-%% clauses rather than binary_to_existing_atom avoids depending on the verify/
-%% version atoms already existing in the table, and is safe because the values
-%% were allowlisted in the pure phase (valid_ssl_value/2).
-to_verify(<<"verify_peer">>) -> verify_peer;
-to_verify(<<"verify_none">>) -> verify_none.
-
-to_versions(L) when is_list(L) ->
-    [to_version(V) || V <- L].
-
-to_version(<<"tlsv1.3">>) -> 'tlsv1.3';
-to_version(<<"tlsv1.2">>) -> 'tlsv1.2';
-to_version(<<"tlsv1.1">>) -> 'tlsv1.1';
-to_version(<<"tlsv1">>) -> tlsv1.
-
-%%--------------------------------------------------------------------
-%% Shared helpers (mirror the LDAP backend)
-%%--------------------------------------------------------------------
-
-is_nonempty_binary(B) -> is_binary(B) andalso byte_size(B) > 0.
-
-%% Resolve an ARN using the request's threaded aws_state(). The state is built
-%% once per request by resolve_request_state/1 -- under the operator-configured
-%% assume_role (a request that references an ARN with no role configured is
-%% refused before reaching here) -- and passed to every ARN fetch in the
-%% request. This is the guardrail: aws_lib threads credentials per call, so the
-%% assumed role's credentials are visible only to this request's resolutions and
-%% the endpoint never resolves an ARN under the broker's ambient EC2 instance
-%% role. R6 is preserved -- resolution runs in the caller process and the
-%% resolved secret is neither logged nor returned (only adapted to the caller's
-%% {ok, Binary} contract). R3 is preserved -- this still runs only after the pure
-%% validation pipeline. The 3-tuple {ok, Data, State1} from
-%% aws_arn_util:resolve_arn/2 is adapted back to the {ok, Binary} contract the
-%% callers expect; the threaded state is request-scoped and discarded here.
--spec resolve_arn(binary(), aws_lib:aws_state()) -> {ok, binary()} | {error, term()}.
-resolve_arn(Arn, State) when is_binary(Arn) ->
-    case aws_arn_util:resolve_arn(binary_to_list(Arn), State) of
-        {ok, Data, _State1} -> {ok, Data};
-        {error, _} = Error -> Error
     end.
 
 connection_timeout_ms() ->
-    case application:get_env(aws, auth_validation_connection_timeout_ms) of
-        {ok, Ms} when is_integer(Ms), Ms > 0 -> Ms;
-        _ -> ?DEFAULT_TIMEOUT_MS
-    end.
+    aws_auth_validate_ssl:connection_timeout_ms(#{default => ?DEFAULT_TIMEOUT_MS, max => 60_000}).

--- a/src/aws_auth_validate_httpc.erl
+++ b/src/aws_auth_validate_httpc.erl
@@ -1,0 +1,89 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% Shared ephemeral-httpc-profile pool for the http and oauth validation
+%% backends. (The ldap backend uses eldap, not httpc, so it does not use this.)
+%%
+%% This machinery exists ONLY because httpc pools TLS sessions on a global,
+%% named-profile basis: the shared default profile would let a prior request's
+%% authenticated (e.g. mTLS) session be reused by a later request -- a false
+%% success and a cross-request connection leak (R3 violation). Each in-flight
+%% probe therefore OWNS a distinct started profile drawn from a FIXED pool of
+%% ?PROFILE_POOL_SIZE interned atoms (a fresh atom per request would leak the
+%% atom table). A slot is claimed only by successfully starting it, so two
+%% simultaneous calls never share a profile and none is ever stolen from an
+%% actively-probing peer. The pool is sized strictly above the concurrency cap
+%% (auth_validation_max_concurrent = 100) so the scan always finds a free slot.
+%%
+%% Both backends carried a byte-identical copy of this before; the only
+%% difference was the profile-name prefix (kept per-backend so the two pools
+%% never collide), which is now a parameter.
+-module(aws_auth_validate_httpc).
+
+-export([
+    claim_probe_profile/1,
+    set_probe_profile_opts/1,
+    stop_probe_profile/1
+]).
+
+-define(PROFILE_POOL_SIZE, 128).
+
+profile_atom(Prefix, Slot) ->
+    list_to_atom(Prefix ++ integer_to_list(Slot)).
+
+%% Claim a profile by scanning the fixed pool for a FREE slot: start at a
+%% per-request hashed slot and try to inets:start it. Starting succeeds only if
+%% no concurrent validation already owns that slot, so success means we own it.
+%% On {already_started,_} (slot running) or already_present (slot mid-teardown)
+%% advance to the next slot -- never stop a slot in use by a peer, that would
+%% tear down its in-flight request. Bounded to one full pass over the pool; if
+%% every slot is busy, fail closed. Returns {ok, Profile} | none.
+%%
+%% Prefix disambiguates the http and oauth pools so their atoms never collide.
+-spec claim_probe_profile(string()) -> {ok, atom()} | none.
+claim_probe_profile(Prefix) ->
+    Start = erlang:phash2(make_ref(), ?PROFILE_POOL_SIZE),
+    claim_probe_profile(Prefix, Start, ?PROFILE_POOL_SIZE).
+
+claim_probe_profile(_Prefix, _Slot, 0) ->
+    %% Every slot busy: unreachable while the semaphore caps concurrency below
+    %% ?PROFILE_POOL_SIZE, but fail closed rather than reuse a shared profile.
+    none;
+claim_probe_profile(Prefix, Slot, Remaining) ->
+    Profile = profile_atom(Prefix, Slot),
+    case inets:start(httpc, [{profile, Profile}]) of
+        {ok, _Pid} ->
+            %% We started (own) this profile; disable reuse and take it.
+            set_probe_profile_opts(Profile),
+            {ok, Profile};
+        {error, {already_started, _}} ->
+            %% Slot in use by a concurrent validation -- do NOT steal it; advance.
+            claim_probe_profile(Prefix, (Slot + 1) rem ?PROFILE_POOL_SIZE, Remaining - 1);
+        {error, already_present} ->
+            %% Slot mid-teardown by a concurrent validation. inets:stop/2 runs
+            %% terminate_child THEN delete_child as two separate supervisor
+            %% calls; a permanent child (the httpc profile) keeps its spec with
+            %% pid=undefined between them, so a start landing in that window sees
+            %% already_present rather than already_started. Not cleanly free --
+            %% advance like the already_started case rather than fail this
+            %% request closed. The pool size exceeds the concurrency cap, so the
+            %% scan still lands on a genuinely free slot within one pass.
+            claim_probe_profile(Prefix, (Slot + 1) rem ?PROFILE_POOL_SIZE, Remaining - 1);
+        _ ->
+            %% Any other start error: fail closed rather than risk the shared
+            %% default profile's session-reuse hazard.
+            none
+    end.
+
+set_probe_profile_opts(Profile) ->
+    _ = httpc:set_options(
+        [{max_sessions, 0}, {max_keep_alive_length, 0}, {keep_alive_timeout, 0}],
+        Profile
+    ),
+    ok.
+
+stop_probe_profile(Profile) ->
+    _ = inets:stop(httpc, Profile),
+    ok.

--- a/src/aws_auth_validate_ldap.erl
+++ b/src/aws_auth_validate_ldap.erl
@@ -229,22 +229,9 @@ resolve_request_state(Params) ->
             end
     end.
 
-%% The operator-configured boot-time assume role (aws.arns.assume_role_arn),
-%% read from the same `aws, arn_config' env the boot sequence uses
-%% (aws_arn_config:maybe_assume_role/1). Returns the role ARN string, or `none'
-%% when unset.
+%% The operator-configured boot-time assume role (shared helper).
 configured_assume_role_arn() ->
-    case application:get_env(aws, arn_config) of
-        {ok, ArnConfig} when is_list(ArnConfig) ->
-            case proplists:get_value(assume_role_arn, ArnConfig) of
-                undefined -> none;
-                Arn when is_list(Arn) -> Arn;
-                Arn when is_binary(Arn) -> binary_to_list(Arn);
-                _ -> none
-            end;
-        _ ->
-            none
-    end.
+    aws_auth_validate_ssl:configured_assume_role_arn().
 
 %%--------------------------------------------------------------------
 %% Input parsing
@@ -352,7 +339,7 @@ resolve_cacert(#{ssl_options := SslOpts, aws_state := State} = Params) ->
                     %% certless PEM returns `skip'. Both mean the ARN does not
                     %% hold a usable CA cert -- report input_invalid rather than
                     %% degrading the trust anchor.
-                    try decode_pem_cacerts(PemData) of
+                    try aws_auth_validate_ssl:decode_pem_cacerts(PemData) of
                         skip -> {error, input_invalid, ?REASON_CACERT_PEM_INVALID};
                         Certs -> {ok, Params#{ssl_options => SslOpts#{cacerts => Certs}}}
                     catch
@@ -1008,10 +995,10 @@ maybe_start_tls(Handle, true, SslOpts, Timeout) ->
 build_ssl_opts(Map) when is_map(Map) ->
     Pairs = [
         {cacerts, cacerts, fun(Certs) -> Certs end},
-        {verify, <<"verify">>, fun to_verify/1},
-        {depth, <<"depth">>, fun to_integer/1},
-        {versions, <<"versions">>, fun to_versions/1},
-        {server_name_indication, <<"server_name_indication">>, fun to_list/1}
+        {verify, <<"verify">>, fun aws_auth_validate_ssl:to_verify/1},
+        {depth, <<"depth">>, fun aws_auth_validate_ssl:to_integer/1},
+        {versions, <<"versions">>, fun aws_auth_validate_ssl:to_versions/1},
+        {server_name_indication, <<"server_name_indication">>, fun aws_auth_validate_ssl:to_list/1}
     ],
     Translated = lists:foldl(
         fun({SslKey, JsonKey, Fun}, Acc) ->
@@ -1042,101 +1029,30 @@ add_ssl_opt(SslKey, Fun, Value, Acc) ->
 %% config error, breaking decision parity. With no trust source we therefore
 %% leave `verify' unset (broker-parity verify_none). An explicit `verify'
 %% from the caller is always left untouched (verify_none stays opt-in).
+%% OTP's ssl defaults `verify' to verify_none. When the caller did not specify
+%% `verify', prefer verify_peer -- but only when a trust anchor is available (the
+%% caller's cacertfile_arn, or the host OS store). trust_source/1 is shared with
+%% the http/oauth backends (aws_auth_validate_ssl). An explicit `verify' is left
+%% untouched.
 apply_verify_default(Opts) ->
     case lists:keymember(verify, 1, Opts) of
         true ->
             Opts;
         false ->
-            case trust_source(Opts) of
+            case aws_auth_validate_ssl:trust_source(Opts) of
                 {ok, Opts1} -> [{verify, verify_peer} | Opts1];
                 none -> Opts
             end
     end.
 
-%% Returns {ok, OptsWithCacerts} when a trust anchor is available (either the
-%% caller already supplied cacerts, or the OS trust store is non-empty, in
-%% which case it is added), or `none' when nothing can verify the peer.
-trust_source(Opts) ->
-    case lists:keymember(cacerts, 1, Opts) of
-        true ->
-            {ok, Opts};
-        false ->
-            case os_cacerts() of
-                [] -> none;
-                Certs -> {ok, [{cacerts, Certs} | Opts]}
-            end
-    end.
-
-os_cacerts() ->
-    try
-        public_key:cacerts_get()
-    catch
-        _:_ -> []
-    end.
-
-to_list(B) when is_binary(B) -> binary_to_list(B);
-to_list(L) when is_list(L) -> L.
-
-%% Map the validated `verify' binary to its ssl atom via an explicit table,
-%% NOT binary_to_existing_atom: those atoms (verify_peer/verify_none) only
-%% exist once the ssl app has been loaded, and build_ssl_opts runs while
-%% assembling eldap:open options -- before ssl is guaranteed loaded -- so
-%% binary_to_existing_atom would raise badarg on a perfectly valid request.
-%% parse_ssl_options/2 has already constrained the value to this domain.
-to_verify(<<"verify_peer">>) -> verify_peer;
-to_verify(<<"verify_none">>) -> verify_none.
-
-to_integer(I) when is_integer(I) -> I.
-
-%% Map each validated TLS version binary to its ssl atom via an explicit
-%% table, for the same reason as to_verify/1 (the version atoms are not
-%% guaranteed to exist when build_ssl_opts runs). parse_ssl_options/2 has
-%% already constrained every element to this domain.
-to_versions(L) when is_list(L) ->
-    [to_version(V) || V <- L].
-
-to_version(<<"tlsv1.3">>) -> 'tlsv1.3';
-to_version(<<"tlsv1.2">>) -> 'tlsv1.2';
-to_version(<<"tlsv1.1">>) -> 'tlsv1.1';
-to_version(<<"tlsv1">>) -> tlsv1.
-
-%% Decode a CA-bundle PEM into the raw DER binaries ssl's `cacerts' option
-%% expects. eldap has NO special cacerts contract: build_ssl_opts/1's proplist
-%% is handed to eldap:open/2 as {sslopts, _} and to eldap:start_tls/3, both of
-%% which forward it straight to the `ssl' module -- the same ssl httpc uses. ssl
-%% silently ignores decoded #'OTPCertificate'{} records (pem_entry_decode/1
-%% output) as a trust anchor -> unknown_ca -> a spurious tls_failed. So pass raw
-%% DER, exactly as the HTTP backend's decode_pem_cacerts/1 now does. Returns
-%% `skip' when the data holds no certificate entries (so resolve_cacert/1 can
-%% reject it as input_invalid rather than proceeding with an empty trust set).
-decode_pem_cacerts(B) when is_binary(B) ->
-    case [Der || {'Certificate', Der, not_encrypted} <- public_key:pem_decode(B)] of
-        [] -> skip;
-        Ders -> Ders
-    end.
-
 %%--------------------------------------------------------------------
 
-%% Resolve an ARN using the request's threaded aws_state(). The state is built
-%% once per request by resolve_request_state/1 with the operator-configured
-%% assume_role assumed (a request with no configured role is refused before
-%% reaching here) and passed to every ARN fetch in the request. Region and
-%% credentials live in that value, not a shared singleton, so concurrent
-%% validations cannot clobber each other. R6 is preserved -- resolution runs in
-%% the caller process and the
-%% resolved secret is neither logged nor returned (only adapted to the caller's
-%% {ok, Binary} contract). R3 is preserved -- this still runs only after the pure
-%% validation pipeline. The 3-tuple {ok, Data, State1} from
-%% aws_arn_util:resolve_arn/2 is adapted back to the {ok, Binary} contract the
-%% callers expect; the returned state is request-scoped and discarded here.
+%% Resolve an ARN using the request's threaded aws_state() (shared helper). The
+%% state is built once per request by resolve_request_state/1 under the
+%% operator-configured assume_role. R6: the resolved secret is neither logged nor
+%% returned; R3: this runs only after the pure validation pipeline.
 resolve_arn(Arn, State) when is_binary(Arn) ->
-    case aws_arn_util:resolve_arn(binary_to_list(Arn), State) of
-        {ok, Data, _State1} -> {ok, Data};
-        {error, _} = Error -> Error
-    end.
+    aws_auth_validate_ssl:resolve_arn(Arn, State).
 
 connection_timeout_ms() ->
-    case application:get_env(aws, auth_validation_connection_timeout_ms) of
-        {ok, Ms} when is_integer(Ms), Ms > 0, Ms =< 60_000 -> Ms;
-        _ -> ?DEFAULT_TIMEOUT_MS
-    end.
+    aws_auth_validate_ssl:connection_timeout_ms(#{default => ?DEFAULT_TIMEOUT_MS, max => 60_000}).

--- a/src/aws_auth_validate_net.erl
+++ b/src/aws_auth_validate_net.erl
@@ -1,0 +1,230 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% Shared SSRF / DNS-rebinding network guard for the http and oauth validation
+%% backends. (The ldap backend enforces a DIFFERENT, stricter address policy --
+%% it denies ALL private/RFC1918/CGNAT ranges, not just broker infra -- so it
+%% deliberately does NOT share this module. See aws_auth_validate_ldap's
+%% is_private_ip/1.)
+%%
+%% The validator issues outbound requests to customer-supplied URLs from the
+%% broker's network position -- a textbook SSRF / confused-deputy surface.
+%% Defense is two-phase and IDENTICAL for http and oauth; only the scheme
+%% allowlist (oauth is https-only; http allows http+https) and the fixed R4
+%% reason strings differ, so those are parameters (a policy() map):
+%%
+%%   * PURE phase (url_allowed/2): scheme allowlist + literal-IP classification
+%%     against the always-denied infra ranges. Deterministic, no DNS. Catches
+%%     https://169.254.169.254/... and https://[::1]/... up front. A hostname
+%%     passes here (cannot classify without DNS) and is re-checked below.
+%%
+%%   * NETWORK phase (resolve_and_pin/2): resolve the host to ALL A/AAAA, deny
+%%     if ANY is blocked infra, then connect to the PINNED resolved IP (the
+%%     caller preserves Host header + SNI) so httpc cannot re-resolve to a
+%%     different address (DNS-rebinding / TOCTOU defense).
+%%
+%% Policy: deny the broker's own infra only (IMDS, loopback, link-local,
+%% unspecified). RFC1918 / unique-local are NOT denied -- a customer auth server
+%% or IdP normally lives in their VPC. The test-only
+%% auth_validation_allow_private_networks flag relaxes ONLY loopback so an
+%% integration suite can reach a local stub; IMDS/link-local stay denied.
+-module(aws_auth_validate_net).
+
+-export([
+    url_allowed/2,
+    classify_address/2,
+    classify_ip/2,
+    resolve_and_pin/2,
+    pin_url/2,
+    in_cidr/2,
+    in_any_cidr/2
+]).
+
+%% policy() carries the per-backend surface: the infra denylists, the scheme
+%% allowlist, and the fixed reason strings for a disallowed target / an
+%% unreachable host.
+-type policy() :: #{
+    denied_v4 := [{tuple(), non_neg_integer()}],
+    denied_v6 := [{tuple(), non_neg_integer()}],
+    allowed_schemes := [string()],
+    reason_not_allowed := binary(),
+    reason_connection := binary()
+}.
+
+-export_type([policy/0]).
+
+%%--------------------------------------------------------------------
+%% Pure phase: scheme allowlist + literal-IP classification
+%%--------------------------------------------------------------------
+
+%% Pure per-URL policy check: scheme allowlist + literal-IP classification.
+%% Hostnames pass here (allow) and are re-checked after DNS in resolve_and_pin/2.
+-spec url_allowed(map(), policy()) ->
+    ok | {error, input_invalid, binary()}.
+url_allowed(#{scheme := Scheme} = Url, Policy) ->
+    case lists:member(Scheme, maps:get(allowed_schemes, Policy)) of
+        false ->
+            {error, input_invalid, maps:get(reason_not_allowed, Policy)};
+        true ->
+            case classify_address(Url, Policy) of
+                allow -> ok;
+                deny -> {error, input_invalid, maps:get(reason_not_allowed, Policy)}
+            end
+    end.
+
+%% Classify a URL's host in the pure phase. A literal IP is classified directly
+%% against the infra denylist; a hostname cannot be classified without DNS, so
+%% it is allowed here and resolved+classified in the network phase.
+-spec classify_address(map(), policy()) -> allow | deny.
+classify_address(#{host := Host}, Policy) ->
+    case inet:parse_address(Host) of
+        {ok, IP} -> classify_ip(IP, Policy);
+        {error, _} -> allow
+    end.
+
+%% classify_ip/2: allow | deny for a parsed IP tuple. Denies the broker-infra
+%% ranges only. Several IPv6 notations embed a v4 address; each is unwrapped to
+%% its v4 form and re-classified, otherwise the v6 encoding smuggles a denied v4
+%% address (e.g. 169.254.169.254) past the v4 denylist. Covered: IPv4-mapped
+%% ::ffff:a.b.c.d, IPv4-compatible ::a.b.c.d, NAT64 64:ff9b::/96, 6to4 2002::/16.
+-spec classify_ip(tuple(), policy()) -> allow | deny.
+classify_ip({0, 0, 0, 0, 0, 16#ffff, W1, W2}, Policy) ->
+    %% IPv4-mapped ::ffff:a.b.c.d
+    classify_ip(v4_from_words(W1, W2), Policy);
+classify_ip({0, 0, 0, 0, 0, 0, W1, W2}, Policy) when {W1, W2} =/= {0, 0}, {W1, W2} =/= {0, 1} ->
+    %% IPv4-compatible ::a.b.c.d (RFC4291-deprecated). The guard lets the
+    %% unspecified :: and loopback ::1 fall through to the v6 denylist instead
+    %% (::1 must be matched as v6 loopback, not as v4 0.0.0.1).
+    classify_ip(v4_from_words(W1, W2), Policy);
+classify_ip({16#64, 16#ff9b, 0, 0, 0, 0, W1, W2}, Policy) ->
+    %% NAT64 well-known prefix 64:ff9b::/96 -> embedded v4 in the low 32 bits.
+    classify_ip(v4_from_words(W1, W2), Policy);
+classify_ip({16#2002, W1, W2, _, _, _, _, _}, Policy) ->
+    %% 6to4 2002::/16 -> embedded v4 in segments 2-3.
+    classify_ip(v4_from_words(W1, W2), Policy);
+classify_ip({_, _, _, _} = V4, Policy) ->
+    case in_any_cidr(V4, maps:get(denied_v4, Policy)) of
+        true -> classify_denied(V4);
+        false -> allow
+    end;
+classify_ip({_, _, _, _, _, _, _, _} = V6, Policy) ->
+    case in_any_cidr(V6, maps:get(denied_v6, Policy)) of
+        true -> classify_denied(V6);
+        false -> allow
+    end.
+
+%% A denied address is normally `deny'. The ONE exception is loopback when
+%% auth_validation_allow_private_networks is set (test-only, default false): that
+%% lets an integration suite probe a local stub on 127.0.0.1/::1. It relaxes ONLY
+%% loopback -- IMDS, link-local, and unspecified stay denied even with the flag
+%% on, so it cannot be used to reach instance metadata.
+classify_denied(IP) ->
+    case is_loopback(IP) andalso allow_private_networks() of
+        true -> allow;
+        false -> deny
+    end.
+
+is_loopback({127, _, _, _}) -> true;
+is_loopback({0, 0, 0, 0, 0, 0, 0, 1}) -> true;
+is_loopback(_) -> false.
+
+allow_private_networks() ->
+    application:get_env(aws, auth_validation_allow_private_networks, false) =:= true.
+
+%% Two 16-bit words -> a v4 4-tuple {a,b,c,d}.
+v4_from_words(W1, W2) ->
+    {W1 bsr 8, W1 band 16#ff, W2 bsr 8, W2 band 16#ff}.
+
+in_any_cidr(IP, Cidrs) ->
+    lists:any(fun(Cidr) -> in_cidr(IP, Cidr) end, Cidrs).
+
+%% in_cidr/2: is IP within {Network, PrefixBits}? Same address family only.
+in_cidr({_, _, _, _} = IP, {{_, _, _, _} = Net, Prefix}) when
+    Prefix >= 0, Prefix =< 32
+->
+    same_prefix(ip_to_int(IP), ip_to_int(Net), 32, Prefix);
+in_cidr({_, _, _, _, _, _, _, _} = IP, {{_, _, _, _, _, _, _, _} = Net, Prefix}) when
+    Prefix >= 0, Prefix =< 128
+->
+    same_prefix(ip_to_int(IP), ip_to_int(Net), 128, Prefix);
+in_cidr(_IP, _Cidr) ->
+    %% Cross-family (e.g. v4 IP vs v6 CIDR): never matches.
+    false.
+
+same_prefix(IpInt, NetInt, TotalBits, Prefix) ->
+    HostBits = TotalBits - Prefix,
+    (IpInt bsr HostBits) =:= (NetInt bsr HostBits).
+
+ip_to_int(Tuple) ->
+    BitsPerElem =
+        case tuple_size(Tuple) of
+            4 -> 8;
+            8 -> 16
+        end,
+    lists:foldl(
+        fun(Elem, Acc) -> (Acc bsl BitsPerElem) bor Elem end,
+        0,
+        tuple_to_list(Tuple)
+    ).
+
+%%--------------------------------------------------------------------
+%% Network phase: DNS resolve-and-pin (DNS-rebinding / TOCTOU defense)
+%%--------------------------------------------------------------------
+
+%% Resolve the URL's host to all addresses, deny if ANY is a blocked infra
+%% address, and return the URL rewritten to connect to a single pinned IP plus
+%% the original host (for the Host header / SNI). A literal-IP host is pinned to
+%% itself (re-classified here defensively). A resolution failure is a
+%% reachability fact -> connection_failed.
+-spec resolve_and_pin(map(), policy()) ->
+    {ok, map(), string()} | {error, input_invalid | connection_failed, binary()}.
+resolve_and_pin(#{host := Host} = Url, Policy) ->
+    case inet:parse_address(Host) of
+        {ok, IP} ->
+            case classify_ip(IP, Policy) of
+                deny -> {error, input_invalid, maps:get(reason_not_allowed, Policy)};
+                allow -> {ok, pin_url(Url, Host), Host}
+            end;
+        {error, _} ->
+            resolve_hostname_and_pin(Url, Host, Policy)
+    end.
+
+resolve_hostname_and_pin(Url, Host, Policy) ->
+    case resolve_all(Host) of
+        [] ->
+            {error, connection_failed, maps:get(reason_connection, Policy)};
+        Addrs ->
+            case lists:any(fun(IP) -> classify_ip(IP, Policy) =:= deny end, Addrs) of
+                true ->
+                    %% At least one resolved address is blocked infra: deny the
+                    %% whole request rather than connect to a host that resolves
+                    %% (even partly) to IMDS/loopback/link-local.
+                    {error, input_invalid, maps:get(reason_not_allowed, Policy)};
+                false ->
+                    PinIP = inet:ntoa(hd(Addrs)),
+                    {ok, pin_url(Url, PinIP), Host}
+            end
+    end.
+
+%% Resolve a hostname to all IPv4 + IPv6 addresses (best-effort per family).
+resolve_all(Host) ->
+    V4 =
+        case inet:getaddrs(Host, inet) of
+            {ok, A4} -> A4;
+            {error, _} -> []
+        end,
+    V6 =
+        case inet:getaddrs(Host, inet6) of
+            {ok, A6} -> A6;
+            {error, _} -> []
+        end,
+    V4 ++ V6.
+
+%% Rewrite the URL to connect to the pinned IP, keeping scheme/port/path/query.
+%% The original hostname is carried separately by the caller (Host header + SNI)
+%% so vhost routing and cert hostname verification still target the real name.
+pin_url(Url, PinHost) ->
+    Rebuilt = uri_string:recompose(maps:without([url_string], Url#{host => PinHost})),
+    Url#{url_string => Rebuilt}.

--- a/src/aws_auth_validate_oauth.erl
+++ b/src/aws_auth_validate_oauth.erl
@@ -78,13 +78,6 @@
     <<"versions">>,
     <<"sni">>
 ]).
--define(SSL_VERIFY_VALUES, [<<"verify_peer">>, <<"verify_none">>]).
--define(SSL_VERSION_VALUES, [
-    <<"tlsv1.3">>,
-    <<"tlsv1.2">>,
-    <<"tlsv1.1">>,
-    <<"tlsv1">>
-]).
 
 %% Fixed, hardcoded reason strings (R4): no URL, host, or raw error echoed.
 -define(REASON_MISSING_URL, <<"at least one of jwks_uri or issuer must be present">>).
@@ -106,14 +99,10 @@
 -define(REASON_CLIENT_CERT_INCOMPLETE,
     <<"ssl_options.certfile_arn and keyfile_arn must be supplied together">>
 ).
--define(REASON_NO_TRUST_ANCHOR,
-    <<"verify_peer requested but no CA trust anchor is available; supply cacertfile_arn">>
-).
 -define(REASON_CONNECTION, <<"could not connect to OAuth endpoint">>).
 -define(REASON_TLS_HANDSHAKE, <<"TLS handshake failed">>).
 -define(REASON_ENDPOINT, <<"endpoint did not return a valid JWKS document">>).
 -define(REASON_DISCOVERY, <<"issuer discovery did not return a valid OpenID configuration">>).
--define(REASON_ARN_RESOLVE, <<"failed to resolve ARN">>).
 -define(REASON_ASSUME_ROLE, <<"failed to assume the configured role">>).
 -define(REASON_NO_ASSUME_ROLE, <<
     "auth validation requires an assume_role to be configured; "
@@ -145,8 +134,48 @@
     {{0, 0, 0, 0, 0, 0, 0, 0}, 128}
 ]).
 
-%% Profile pool for ephemeral httpc profiles (same sizing rationale as HTTP backend).
--define(PROFILE_POOL_SIZE, 128).
+%% Ephemeral httpc profile-name prefix for this backend's pool (shared pool
+%% machinery in aws_auth_validate_httpc). Disjoint from the http prefix so the
+%% two backends' pools never collide.
+-define(PROFILE_PREFIX, "aws_auth_validate_oauth_").
+
+%% Per-backend surface passed to the shared aws_auth_validate_ssl helpers.
+%% Identical shape to the HTTP backend's (both accept the mTLS pair and use the
+%% <<"sni">> key); only this backend's fixed R4 reason strings differ, kept here.
+ssl_opts() ->
+    #{
+        arn_keys => [<<"cacertfile_arn">>, <<"certfile_arn">>, <<"keyfile_arn">>],
+        ssl_option_keys => ?SSL_OPTION_KEYS,
+        sni_key => <<"sni">>,
+        client_cert => true,
+        reasons => #{
+            no_assume_role => ?REASON_NO_ASSUME_ROLE,
+            assume_role => ?REASON_ASSUME_ROLE,
+            unknown_ssl_option => ?REASON_UNKNOWN_SSL_OPTION,
+            client_cert_incomplete => ?REASON_CLIENT_CERT_INCOMPLETE,
+            bad_ssl_options => ?REASON_BAD_SSL_OPTIONS,
+            bad_ssl_verify => ?REASON_BAD_SSL_VERIFY,
+            bad_ssl_depth => ?REASON_BAD_SSL_DEPTH,
+            bad_ssl_versions => ?REASON_BAD_SSL_VERSIONS,
+            bad_ssl_sni => ?REASON_BAD_SSL_SNI,
+            bad_ssl_cacert_arn => ?REASON_BAD_SSL_CACERT_ARN,
+            bad_ssl_cert_arn => ?REASON_BAD_SSL_CERT_ARN,
+            bad_ssl_key_arn => ?REASON_BAD_SSL_KEY_ARN
+        }
+    }.
+
+%% SSRF policy passed to the shared aws_auth_validate_net guard: this backend's
+%% infra denylists, its scheme allowlist (https-only -- stricter than the HTTP
+%% backend), and the fixed reason strings for a disallowed target / an
+%% unreachable host.
+net_policy() ->
+    #{
+        denied_v4 => ?DENIED_V4_CIDRS,
+        denied_v6 => ?DENIED_V6_CIDRS,
+        allowed_schemes => ?ALLOWED_SCHEMES,
+        reason_not_allowed => ?REASON_URL_NOT_ALLOWED,
+        reason_connection => ?REASON_CONNECTION
+    }.
 
 %%--------------------------------------------------------------------
 %% Behaviour callbacks
@@ -202,47 +231,7 @@ validate(Body) when is_map(Body) ->
 %% needs no role and gets a default state that is never used to resolve an ARN --
 %% preserving the credential-free JWKS reachability check.
 resolve_request_state(Params) ->
-    case request_references_arn(Params) of
-        false ->
-            {ok, Params#{aws_state => aws_lib:new()}};
-        true ->
-            case configured_assume_role_arn() of
-                none ->
-                    {error, config_conflict, ?REASON_NO_ASSUME_ROLE};
-                RoleArn ->
-                    case aws_iam:assume_role(RoleArn, aws_lib:new()) of
-                        {ok, State} -> {ok, Params#{aws_state => State}};
-                        {error, _} -> {error, input_invalid, ?REASON_ASSUME_ROLE}
-                    end
-            end
-    end.
-
-%% True when the request references any ARN-backed TLS material, i.e. resolving
-%% the request will make at least one AWS call. The ARN keys live under
-%% ssl_options (cacertfile_arn / certfile_arn / keyfile_arn); parse_ssl_options
-%% guaranteed cert/key are supplied together, so any one key means an AWS fetch.
-request_references_arn(#{ssl_options := Map}) ->
-    lists:any(
-        fun(K) -> maps:is_key(K, Map) end,
-        [<<"cacertfile_arn">>, <<"certfile_arn">>, <<"keyfile_arn">>]
-    ).
-
-%% The operator-configured boot-time assume role (aws.arns.assume_role_arn),
-%% read from the same `aws, arn_config' env the boot sequence uses
-%% (aws_arn_config:maybe_assume_role/1). Returns the role ARN string, or `none'
-%% when unset. Mirrors aws_auth_validate_http:configured_assume_role_arn/0.
-configured_assume_role_arn() ->
-    case application:get_env(aws, arn_config) of
-        {ok, ArnConfig} when is_list(ArnConfig) ->
-            case proplists:get_value(assume_role_arn, ArnConfig) of
-                undefined -> none;
-                Arn when is_list(Arn) -> Arn;
-                Arn when is_binary(Arn) -> binary_to_list(Arn);
-                _ -> none
-            end;
-        _ ->
-            none
-    end.
+    aws_auth_validate_ssl:resolve_request_state(Params, ssl_opts()).
 
 %%--------------------------------------------------------------------
 %% Input parsing (pure, no network)
@@ -339,75 +328,12 @@ parse_resource_server_id(Body, Acc) ->
             {error, input_invalid, ?REASON_BAD_RESOURCE_SERVER_ID}
     end.
 
-%% ssl_options parsing: validate both keys and values in the pure phase so a
-%% mis-typed value cannot be silently dropped and re-defaulted.
+%% ssl_options parsing (keys + values, mTLS pairing) is shared across backends;
+%% delegate to aws_auth_validate_ssl with this backend's surface (ssl_opts/0).
 parse_ssl_options(Body, Acc) ->
-    case maps:get(<<"ssl_options">>, Body, undefined) of
-        undefined ->
-            {ok, Acc#{ssl_options => #{}}};
-        Map when is_map(Map) ->
-            case [K || K <- maps:keys(Map), not lists:member(K, ?SSL_OPTION_KEYS)] of
-                [_ | _] ->
-                    {error, input_invalid, ?REASON_UNKNOWN_SSL_OPTION};
-                [] ->
-                    %% Client cert + key are an inseparable pair: one without
-                    %% the other cannot build an mTLS identity. Reject in the
-                    %% pure phase before resolving either ARN.
-                    HasCert = maps:is_key(<<"certfile_arn">>, Map),
-                    HasKey = maps:is_key(<<"keyfile_arn">>, Map),
-                    case HasCert =:= HasKey of
-                        false -> {error, input_invalid, ?REASON_CLIENT_CERT_INCOMPLETE};
-                        true -> validate_ssl_values(maps:to_list(Map), Acc, Map)
-                    end
-            end;
-        _ ->
-            {error, input_invalid, ?REASON_BAD_SSL_OPTIONS}
-    end.
-
-validate_ssl_values([], Acc, Map) ->
-    {ok, Acc#{ssl_options => Map}};
-validate_ssl_values([{Key, Value} | Rest], Acc, Map) ->
-    case valid_ssl_value(Key, Value) of
-        ok -> validate_ssl_values(Rest, Acc, Map);
-        {error, _, _} = Err -> Err
-    end.
-
-valid_ssl_value(<<"verify">>, V) ->
-    case lists:member(V, ?SSL_VERIFY_VALUES) of
-        true -> ok;
-        false -> {error, input_invalid, ?REASON_BAD_SSL_VERIFY}
-    end;
-valid_ssl_value(<<"depth">>, V) when is_integer(V), V >= 0 ->
-    ok;
-valid_ssl_value(<<"depth">>, _) ->
-    {error, input_invalid, ?REASON_BAD_SSL_DEPTH};
-valid_ssl_value(<<"versions">>, V) when is_list(V), V =/= [] ->
-    case lists:all(fun(Ver) -> lists:member(Ver, ?SSL_VERSION_VALUES) end, V) of
-        true -> ok;
-        false -> {error, input_invalid, ?REASON_BAD_SSL_VERSIONS}
-    end;
-valid_ssl_value(<<"versions">>, _) ->
-    {error, input_invalid, ?REASON_BAD_SSL_VERSIONS};
-valid_ssl_value(<<"sni">>, V) ->
-    case is_nonempty_binary(V) of
-        true -> ok;
-        false -> {error, input_invalid, ?REASON_BAD_SSL_SNI}
-    end;
-valid_ssl_value(<<"cacertfile_arn">>, V) ->
-    case is_nonempty_binary(V) of
-        true -> ok;
-        false -> {error, input_invalid, ?REASON_BAD_SSL_CACERT_ARN}
-    end;
-valid_ssl_value(<<"certfile_arn">>, V) ->
-    case is_nonempty_binary(V) of
-        true -> ok;
-        false -> {error, input_invalid, ?REASON_BAD_SSL_CERT_ARN}
-    end;
-valid_ssl_value(<<"keyfile_arn">>, V) ->
-    case is_nonempty_binary(V) of
-        true -> ok;
-        false -> {error, input_invalid, ?REASON_BAD_SSL_KEY_ARN}
-    end.
+    aws_auth_validate_ssl:parse_ssl_options(
+        maps:get(<<"ssl_options">>, Body, undefined), Acc, ssl_opts()
+    ).
 
 %%--------------------------------------------------------------------
 %% SSRF guard
@@ -439,114 +365,19 @@ collect_guard_urls(#{jwks_uri := JwksUrl, issuer := IssuerUrl}) ->
 check_urls([]) ->
     ok;
 check_urls([Url | Rest]) ->
-    case url_allowed(Url) of
+    case aws_auth_validate_net:url_allowed(Url, net_policy()) of
         ok -> check_urls(Rest);
         {error, _, _} = Err -> Err
     end.
 
-%% Pure per-URL policy check: scheme allowlist + literal-IP classification.
-%% Hostnames pass here (allow) and are re-checked after DNS in the probe layer.
-url_allowed(#{scheme := Scheme} = Url) ->
-    case lists:member(Scheme, ?ALLOWED_SCHEMES) of
-        false ->
-            {error, input_invalid, ?REASON_URL_NOT_ALLOWED};
-        true ->
-            case classify_address(Url) of
-                allow -> ok;
-                deny -> {error, input_invalid, ?REASON_URL_NOT_ALLOWED}
-            end
-    end.
-
-%% Classify a URL's host in the pure phase. A literal IP is classified directly
-%% against the infra denylist. A hostname cannot be classified without DNS, so
-%% it is allowed here and resolved+classified in the probe layer.
-classify_address(#{host := Host}) ->
-    case inet:parse_address(Host) of
-        {ok, IP} -> classify_ip(IP);
-        {error, _} -> allow
-    end.
-
-%% classify_ip/1: allow | deny for a parsed IP tuple. Denies the broker-infra
-%% ranges only. IPv6 notations that embed a v4 address are unwrapped and
-%% re-classified (DNS-rebinding defense via v6-encoded addresses).
-classify_ip({0, 0, 0, 0, 0, 16#ffff, W1, W2}) ->
-    %% IPv4-mapped ::ffff:a.b.c.d
-    classify_ip(v4_from_words(W1, W2));
-classify_ip({0, 0, 0, 0, 0, 0, W1, W2}) when {W1, W2} =/= {0, 0}, {W1, W2} =/= {0, 1} ->
-    %% IPv4-compatible ::a.b.c.d (RFC4291-deprecated). Guard lets :: and ::1
-    %% fall through to the v6 denylist.
-    classify_ip(v4_from_words(W1, W2));
-classify_ip({16#64, 16#ff9b, 0, 0, 0, 0, W1, W2}) ->
-    %% NAT64 well-known prefix 64:ff9b::/96 -> embedded v4 in the low 32 bits.
-    classify_ip(v4_from_words(W1, W2));
-classify_ip({16#2002, W1, W2, _, _, _, _, _}) ->
-    %% 6to4 2002::/16 -> embedded v4 in segments 2-3.
-    classify_ip(v4_from_words(W1, W2));
-classify_ip({_, _, _, _} = V4) ->
-    case in_any_cidr(V4, ?DENIED_V4_CIDRS) of
-        true -> classify_denied(V4);
-        false -> allow
-    end;
-classify_ip({_, _, _, _, _, _, _, _} = V6) ->
-    case in_any_cidr(V6, ?DENIED_V6_CIDRS) of
-        true -> classify_denied(V6);
-        false -> allow
-    end.
-
-%% A denied address is normally `deny'. The ONE exception is loopback when
-%% auth_validation_allow_private_networks is set: that flag (default false, off
-%% in production) lets the OAuth integration suite probe a local stub IdP on
-%% 127.0.0.1/::1. It is the OAuth analogue of the same flag the LDAP and HTTP
-%% backends honour for local-server tests. It relaxes ONLY loopback -- IMDS,
-%% link-local, and unspecified stay denied even with the flag on, so it cannot
-%% be used to reach instance metadata.
-classify_denied(IP) ->
-    case is_loopback(IP) andalso allow_private_networks() of
-        true -> allow;
-        false -> deny
-    end.
-
-is_loopback({127, _, _, _}) -> true;
-is_loopback({0, 0, 0, 0, 0, 0, 0, 1}) -> true;
-is_loopback(_) -> false.
-
-allow_private_networks() ->
-    application:get_env(aws, auth_validation_allow_private_networks, false) =:= true.
-
-%% Two 16-bit words -> a v4 4-tuple {a,b,c,d}.
-v4_from_words(W1, W2) ->
-    {W1 bsr 8, W1 band 16#ff, W2 bsr 8, W2 band 16#ff}.
-
-in_any_cidr(IP, Cidrs) ->
-    lists:any(fun(Cidr) -> in_cidr(IP, Cidr) end, Cidrs).
-
-in_cidr({_, _, _, _} = IP, {{_, _, _, _} = Net, Prefix}) when
-    Prefix >= 0, Prefix =< 32
-->
-    same_prefix(ip_to_int(IP), ip_to_int(Net), 32, Prefix);
-in_cidr({_, _, _, _, _, _, _, _} = IP, {{_, _, _, _, _, _, _, _} = Net, Prefix}) when
-    Prefix >= 0, Prefix =< 128
-->
-    same_prefix(ip_to_int(IP), ip_to_int(Net), 128, Prefix);
-in_cidr(_IP, _Cidr) ->
-    %% Cross-family (e.g. v4 IP vs v6 CIDR): never matches.
-    false.
-
-same_prefix(IpInt, NetInt, TotalBits, Prefix) ->
-    HostBits = TotalBits - Prefix,
-    (IpInt bsr HostBits) =:= (NetInt bsr HostBits).
-
-ip_to_int(Tuple) ->
-    BitsPerElem =
-        case tuple_size(Tuple) of
-            4 -> 8;
-            8 -> 16
-        end,
-    lists:foldl(
-        fun(Elem, Acc) -> (Acc bsl BitsPerElem) bor Elem end,
-        0,
-        tuple_to_list(Tuple)
-    ).
+-ifdef(TEST).
+%% TEST-only wrappers exposing the shared SSRF guard under this backend's policy,
+%% so the module's -ifdef(TEST) export contract stays stable. Production code
+%% calls aws_auth_validate_net directly.
+url_allowed(Url) -> aws_auth_validate_net:url_allowed(Url, net_policy()).
+classify_ip(IP) -> aws_auth_validate_net:classify_ip(IP, net_policy()).
+in_cidr(IP, Cidr) -> aws_auth_validate_net:in_cidr(IP, Cidr).
+-endif.
 
 %%--------------------------------------------------------------------
 %% Network phase: fetch JWKS (and optionally discover via issuer)
@@ -557,7 +388,7 @@ ip_to_int(Tuple) ->
 %% All probe requests run on a dedicated ephemeral httpc profile (R3).
 
 do_oauth_validate(Params) ->
-    case claim_probe_profile() of
+    case aws_auth_validate_httpc:claim_probe_profile(?PROFILE_PREFIX) of
         none ->
             %% Could not obtain an isolated profile; fail safe rather than fall
             %% back to the shared default profile (which would reintroduce the
@@ -577,7 +408,7 @@ do_oauth_validate(Params) ->
                     {error, connection_failed, ?REASON_CONNECTION}
             after
                 %% Only ever stop the profile THIS request started (claimed).
-                stop_probe_profile(Profile)
+                aws_auth_validate_httpc:stop_probe_profile(Profile)
             end
     end.
 
@@ -595,7 +426,7 @@ do_fetch_jwks(#{jwks_uri := undefined, issuer := IssuerUrl, timeout := Timeout},
             Err;
         {ok, DerivedUrl} ->
             %% SSRF-guard + resolve_and_pin the derived URL before fetching it.
-            case url_allowed(DerivedUrl) of
+            case aws_auth_validate_net:url_allowed(DerivedUrl, net_policy()) of
                 {error, _, _} = Err ->
                     Err;
                 ok ->
@@ -611,7 +442,7 @@ discover_jwks_uri(IssuerUrl, SslOpts, Timeout, Profile) ->
     DiscoveryUrlStr =
         strip_trailing_slash(maps:get(url_string, IssuerUrl)) ++
             "/.well-known/openid-configuration",
-    case resolve_and_pin(IssuerUrl) of
+    case aws_auth_validate_net:resolve_and_pin(IssuerUrl, net_policy()) of
         {error, _, _} = Err ->
             Err;
         {ok, PinnedUrl, Host} ->
@@ -654,7 +485,7 @@ parse_discovery_doc(Body, _DiscoveryUrlStr) ->
 
 %% Fetch the JWKS endpoint and validate the response is a well-formed JWKS.
 fetch_and_validate_jwks(JwksUrl, SslOpts, Timeout, Profile) ->
-    case resolve_and_pin(JwksUrl) of
+    case aws_auth_validate_net:resolve_and_pin(JwksUrl, net_policy()) of
         {error, _, _} = Err ->
             Err;
         {ok, PinnedUrl, Host} ->
@@ -692,59 +523,6 @@ is_valid_jwks(Body) when is_binary(Body) ->
             false
     end.
 
-%%--------------------------------------------------------------------
-%% DNS resolve-and-pin (SSRF network-phase defense)
-%%--------------------------------------------------------------------
-
-%% Resolve the URL's host to all addresses, deny if ANY is a blocked infra
-%% address, and return the URL rewritten to connect to a single pinned IP plus
-%% the original host (for the Host header / SNI).
-resolve_and_pin(#{host := Host} = Url) ->
-    case inet:parse_address(Host) of
-        {ok, IP} ->
-            %% Literal IP: re-classify defensively, pin to itself.
-            case classify_ip(IP) of
-                deny -> {error, input_invalid, ?REASON_URL_NOT_ALLOWED};
-                allow -> {ok, pin_url(Url, Host), Host}
-            end;
-        {error, _} ->
-            resolve_hostname_and_pin(Url, Host)
-    end.
-
-resolve_hostname_and_pin(Url, Host) ->
-    Addrs = resolve_all(Host),
-    case Addrs of
-        [] ->
-            {error, connection_failed, ?REASON_CONNECTION};
-        _ ->
-            case lists:any(fun(IP) -> classify_ip(IP) =:= deny end, Addrs) of
-                true ->
-                    {error, input_invalid, ?REASON_URL_NOT_ALLOWED};
-                false ->
-                    PinIP = inet:ntoa(hd(Addrs)),
-                    {ok, pin_url(Url, PinIP), Host}
-            end
-    end.
-
-%% Resolve a hostname to all IPv4 + IPv6 addresses (best-effort per family).
-resolve_all(Host) ->
-    V4 =
-        case inet:getaddrs(Host, inet) of
-            {ok, A4} -> A4;
-            {error, _} -> []
-        end,
-    V6 =
-        case inet:getaddrs(Host, inet6) of
-            {ok, A6} -> A6;
-            {error, _} -> []
-        end,
-    V4 ++ V6.
-
-%% Rewrite the URL to connect to the pinned IP, keeping scheme/port/path/query.
-pin_url(Url, PinHost) ->
-    Rebuilt = uri_string:recompose(maps:without([url_string], Url#{host => PinHost})),
-    Url#{url_string => Rebuilt}.
-
 %% Strip a single trailing slash from a URL string to avoid producing
 %% double-slash paths when appending "/.well-known/..." to an issuer URL
 %% that already ends with "/".
@@ -758,99 +536,12 @@ strip_trailing_slash(S) ->
 %% httpc error classification
 %%--------------------------------------------------------------------
 
+%% Shared classifier: TLS/cert failure -> tls_failed, else connection_failed.
+%% The raw reason is never echoed (R4).
 classify_http_error(Reason) ->
-    case is_tls_error(Reason) of
-        true -> {error, tls_failed, ?REASON_TLS_HANDSHAKE};
-        false -> {error, connection_failed, ?REASON_CONNECTION}
-    end.
-
-is_tls_error(Term) when is_tuple(Term) ->
-    case element(1, Term) of
-        tls_alert -> true;
-        Other when is_atom(Other) -> is_tls_atom(Other) orelse is_tls_error(tuple_to_list(Term));
-        _ -> is_tls_error(tuple_to_list(Term))
-    end;
-is_tls_error([H | T]) ->
-    is_tls_error(H) orelse is_tls_error(T);
-is_tls_error(Atom) when is_atom(Atom) ->
-    is_tls_atom(Atom);
-is_tls_error(_) ->
-    false.
-
-is_tls_atom(A) ->
-    lists:member(A, [
-        tls_alert,
-        certificate_expired,
-        bad_certificate,
-        unknown_ca,
-        handshake_failure,
-        certificate_unknown,
-        no_peercert
-    ]).
-
-%%--------------------------------------------------------------------
-%% Ephemeral httpc profile management
-%%--------------------------------------------------------------------
-
-%% Each in-flight probe OWNS a distinct started profile: a slot is claimed only
-%% by successfully starting it, so two simultaneous calls never share a profile
-%% and none is ever stolen from an actively-probing peer. The atom set stays
-%% bounded at exactly ?PROFILE_POOL_SIZE interned names. The "oauth" prefix keeps
-%% these names disjoint from the HTTP backend's pool so the two never collide.
-profile_atom(Slot) ->
-    list_to_atom("aws_auth_validate_oauth_" ++ integer_to_list(Slot)).
-
-%% Claim a profile by scanning the fixed pool for a FREE slot: start at a
-%% per-request hashed slot and try to inets:start it. Starting succeeds only if
-%% no concurrent validation already owns that slot, so success means we own it.
-%% On {already_started,_} (slot running) or already_present (slot mid-teardown)
-%% advance to the next slot -- never stop a slot in use by a peer, that would
-%% tear down its in-flight request. Bounded to one full pass over the pool; if
-%% every slot is busy, fail closed. Returns {ok, Profile} | none.
-claim_probe_profile() ->
-    Start = erlang:phash2(make_ref(), ?PROFILE_POOL_SIZE),
-    claim_probe_profile(Start, ?PROFILE_POOL_SIZE).
-
-claim_probe_profile(_Slot, 0) ->
-    %% Every slot busy: unreachable while the semaphore caps concurrency below
-    %% ?PROFILE_POOL_SIZE, but fail closed rather than reuse a shared profile.
-    none;
-claim_probe_profile(Slot, Remaining) ->
-    Profile = profile_atom(Slot),
-    case inets:start(httpc, [{profile, Profile}]) of
-        {ok, _Pid} ->
-            %% We started (own) this profile; disable reuse and take it.
-            set_probe_profile_opts(Profile),
-            {ok, Profile};
-        {error, {already_started, _}} ->
-            %% Slot in use by a concurrent validation -- do NOT steal it; advance.
-            claim_probe_profile((Slot + 1) rem ?PROFILE_POOL_SIZE, Remaining - 1);
-        {error, already_present} ->
-            %% Slot mid-teardown by a concurrent validation. inets:stop/2 runs
-            %% terminate_child THEN delete_child as two separate supervisor
-            %% calls; a permanent child (the httpc profile) keeps its spec with
-            %% pid=undefined between them, so a start landing in that window sees
-            %% already_present rather than already_started. Not cleanly free --
-            %% advance like the already_started case rather than fail this
-            %% request closed. The pool size exceeds the concurrency cap, so the
-            %% scan still lands on a genuinely free slot within one pass.
-            claim_probe_profile((Slot + 1) rem ?PROFILE_POOL_SIZE, Remaining - 1);
-        _ ->
-            %% Any other start error: fail closed rather than risk the shared
-            %% default profile's session-reuse hazard.
-            none
-    end.
-
-set_probe_profile_opts(Profile) ->
-    _ = httpc:set_options(
-        [{max_sessions, 0}, {max_keep_alive_length, 0}, {keep_alive_timeout, 0}],
-        Profile
-    ),
-    ok.
-
-stop_probe_profile(Profile) ->
-    _ = inets:stop(httpc, Profile),
-    ok.
+    aws_auth_validate_ssl:classify_http_error(
+        Reason, ?REASON_TLS_HANDSHAKE, ?REASON_CONNECTION
+    ).
 
 %%--------------------------------------------------------------------
 %% TLS option shaping (mirrors the HTTP backend's resolution, for httpc)
@@ -869,205 +560,34 @@ with_default_sni(SslOpts, Host) ->
         false -> [{server_name_indication, Host} | SslOpts]
     end.
 
-%% Resolve the ARN-backed TLS material (CA bundle, and the client cert+key for
-%% mTLS) and translate the validated ssl_options map into an Erlang ssl
-%% proplist for httpc. ARN resolution happens here, in the network phase, after
-%% all pure validation has passed (ARN-first ordering).
+%% Resolve the ARN-backed TLS material (CA bundle + optional mTLS client cert)
+%% and translate the validated ssl_options into an ssl proplist for httpc. The
+%% resolution, decoding, and verify-default policy are shared
+%% (aws_auth_validate_ssl); only the SNI key spelling (<<"sni">>) is
+%% backend-specific.
 build_client_ssl_opts(#{ssl_options := Map} = Params) ->
     %% aws_state was built once per request by resolve_request_state/1 (under the
     %% configured assume_role when any ARN is referenced) and is threaded into
     %% every ARN fetch here. A request that references no ARN carries a default
     %% state that is never used to resolve one.
-    State = maps:get(aws_state, Params, undefined),
-    case resolve_cacerts(maps:get(<<"cacertfile_arn">>, Map, undefined), State) of
+    State = maps:get(aws_state, Params, none),
+    case
+        aws_auth_validate_ssl:resolve_cacerts(maps:get(<<"cacertfile_arn">>, Map, undefined), State)
+    of
         {error, _, _} = Err ->
             Err;
         {ok, CacertOpts} ->
-            case resolve_client_cert(Map, State) of
+            case aws_auth_validate_ssl:resolve_client_cert(Map, State) of
                 {error, _, _} = Err ->
                     Err;
                 {ok, ClientOpts} ->
-                    Opts = CacertOpts ++ ClientOpts ++ translate_ssl_opts(Map),
+                    Opts =
+                        CacertOpts ++ ClientOpts ++
+                            aws_auth_validate_ssl:translate_ssl_opts(Map, <<"sni">>),
                     VerifyExplicit = maps:is_key(<<"verify">>, Map),
-                    apply_verify_default(Opts, VerifyExplicit)
+                    aws_auth_validate_ssl:apply_verify_default(Opts, VerifyExplicit)
             end
-    end.
-
-resolve_cacerts(undefined, _State) ->
-    {ok, []};
-resolve_cacerts(Arn, State) when is_binary(Arn) ->
-    case resolve_arn(Arn, State) of
-        {ok, Pem} ->
-            case decode_pem_cacerts(Pem) of
-                skip -> {ok, []};
-                Certs -> {ok, [{cacerts, Certs}]}
-            end;
-        {error, _} ->
-            {error, input_invalid, ?REASON_ARN_RESOLVE}
-    end.
-
-resolve_client_cert(#{<<"certfile_arn">> := CertArn, <<"keyfile_arn">> := KeyArn}, State) when
-    is_binary(CertArn), is_binary(KeyArn)
-->
-    case resolve_arn(CertArn, State) of
-        {ok, CertPem} ->
-            case decode_client_cert(CertPem) of
-                {error, _, _} = Err ->
-                    Err;
-                {ok, CertOpt} ->
-                    case resolve_arn(KeyArn, State) of
-                        {ok, KeyPem} ->
-                            case decode_client_key(KeyPem) of
-                                {error, _, _} = Err -> Err;
-                                {ok, KeyOpt} -> {ok, [CertOpt, KeyOpt]}
-                            end;
-                        {error, _} ->
-                            {error, input_invalid, ?REASON_ARN_RESOLVE}
-                    end
-            end;
-        {error, _} ->
-            {error, input_invalid, ?REASON_ARN_RESOLVE}
-    end;
-resolve_client_cert(_Map, _State) ->
-    {ok, []}.
-
-decode_client_cert(Pem) when is_binary(Pem) ->
-    case [Der || {'Certificate', Der, not_encrypted} <- public_key:pem_decode(Pem)] of
-        [] -> {error, input_invalid, ?REASON_ARN_RESOLVE};
-        Ders -> {ok, {cert, Ders}}
-    end.
-
-decode_client_key(Pem) when is_binary(Pem) ->
-    KeyEntries = [
-        {Type, Der}
-     || {Type, Der, not_encrypted} <- public_key:pem_decode(Pem),
-        lists:member(Type, [
-            'PrivateKeyInfo', 'RSAPrivateKey', 'ECPrivateKey', 'DSAPrivateKey'
-        ])
-    ],
-    case KeyEntries of
-        [{Type, Der} | _] -> {ok, {key, {Type, Der}}};
-        [] -> {error, input_invalid, ?REASON_ARN_RESOLVE}
-    end.
-
-translate_ssl_opts(Map) ->
-    Pairs = [
-        {verify, <<"verify">>, fun to_verify/1},
-        {depth, <<"depth">>, fun to_integer/1},
-        {versions, <<"versions">>, fun to_versions/1},
-        {server_name_indication, <<"sni">>, fun to_list/1}
-    ],
-    lists:foldl(
-        fun({SslKey, JsonKey, Fun}, Acc) ->
-            case maps:get(JsonKey, Map, undefined) of
-                undefined -> Acc;
-                Value -> [{SslKey, Fun(Value)} | Acc]
-            end
-        end,
-        [],
-        Pairs
-    ).
-
-%% Ensure verify_peer always has a trust anchor. Policy mirrors the HTTP backend:
-%%   * EXPLICIT verify_peer + no cacerts -> OS store or FAIL.
-%%   * DEFAULTED verify (caller omitted) -> verify_peer when anchor exists, else
-%%     leave unset (broker-parity verify_none).
-%%   * Explicit verify_none -> untouched.
-apply_verify_default(Opts, VerifyExplicit) ->
-    case lists:keyfind(verify, 1, Opts) of
-        {verify, verify_peer} when VerifyExplicit ->
-            case ensure_trust_anchor(Opts) of
-                {ok, _} = Ok -> Ok;
-                none -> {error, tls_failed, ?REASON_NO_TRUST_ANCHOR}
-            end;
-        {verify, verify_peer} ->
-            case ensure_trust_anchor(Opts) of
-                {ok, Opts1} -> {ok, Opts1};
-                none -> {ok, lists:keyreplace(verify, 1, Opts, {verify, verify_none})}
-            end;
-        {verify, _Other} ->
-            {ok, Opts};
-        false ->
-            case trust_source(Opts) of
-                {ok, Opts1} -> {ok, [{verify, verify_peer} | Opts1]};
-                none -> {ok, Opts}
-            end
-    end.
-
-ensure_trust_anchor(Opts) ->
-    case lists:keymember(cacerts, 1, Opts) of
-        true ->
-            {ok, Opts};
-        false ->
-            case os_cacerts() of
-                [] -> none;
-                Certs -> {ok, [{cacerts, Certs} | Opts]}
-            end
-    end.
-
-trust_source(Opts) ->
-    case lists:keymember(cacerts, 1, Opts) of
-        true ->
-            {ok, Opts};
-        false ->
-            case os_cacerts() of
-                [] -> none;
-                Certs -> {ok, [{cacerts, Certs} | Opts]}
-            end
-    end.
-
-os_cacerts() ->
-    try
-        public_key:cacerts_get()
-    catch
-        _:_ -> []
-    end.
-
-%% Return raw 'Certificate' DER binaries, NOT pem_entry_decode/1 records: ssl
-%% silently ignores #'OTPCertificate'{} records under {cacerts, _}, which
-%% surfaces as unknown_ca -> a spurious tls_failed on the verify_peer +
-%% cacertfile_arn path. Matches the HTTP/LDAP backends' decode_pem_cacerts/1.
-decode_pem_cacerts(B) when is_binary(B) ->
-    case [Der || {'Certificate', Der, not_encrypted} <- public_key:pem_decode(B)] of
-        [] -> skip;
-        Ders -> Ders
-    end.
-
-to_list(B) when is_binary(B) -> binary_to_list(B);
-to_list(L) when is_list(L) -> L.
-
-to_integer(I) when is_integer(I) -> I.
-
-to_verify(<<"verify_peer">>) -> verify_peer;
-to_verify(<<"verify_none">>) -> verify_none.
-
-to_versions(L) when is_list(L) ->
-    [to_version(V) || V <- L].
-
-to_version(<<"tlsv1.3">>) -> 'tlsv1.3';
-to_version(<<"tlsv1.2">>) -> 'tlsv1.2';
-to_version(<<"tlsv1.1">>) -> 'tlsv1.1';
-to_version(<<"tlsv1">>) -> tlsv1.
-
-%%--------------------------------------------------------------------
-%% Shared helpers
-%%--------------------------------------------------------------------
-
-is_nonempty_binary(B) -> is_binary(B) andalso byte_size(B) > 0.
-
-%% Resolve an ARN using the request's threaded aws_state(). The state is built
-%% once per request by resolve_request_state/1 -- under the operator-configured
-%% assume_role when any ARN is referenced -- so no global singleton is mutated.
-%% See the HTTP backend's identical resolve_arn/2 for the full rationale (R3, R6).
--spec resolve_arn(binary(), aws_lib:aws_state()) -> {ok, binary()} | {error, term()}.
-resolve_arn(Arn, State) when is_binary(Arn) ->
-    case aws_arn_util:resolve_arn(binary_to_list(Arn), State) of
-        {ok, Data, _State1} -> {ok, Data};
-        {error, _} = Error -> Error
     end.
 
 connection_timeout_ms() ->
-    case application:get_env(aws, auth_validation_connection_timeout_ms) of
-        {ok, Ms} when is_integer(Ms), Ms > 0 -> Ms;
-        _ -> ?DEFAULT_TIMEOUT_MS
-    end.
+    aws_auth_validate_ssl:connection_timeout_ms(#{default => ?DEFAULT_TIMEOUT_MS, max => 60_000}).

--- a/src/aws_auth_validate_ssl.erl
+++ b/src/aws_auth_validate_ssl.erl
@@ -1,0 +1,508 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% Shared TLS-material, ARN-resolution, and assume-role helpers for the auth
+%% validation backends (ldap / http / oauth).
+%%
+%% Before this module each backend carried its own byte-identical copy of the
+%% ARN resolver, the assume-role guardrail, the cacert/client-cert PEM decoders,
+%% the ssl_options value validators, and the verify/version/depth translators.
+%% Three separate copies meant a security fix (e.g. the cacerts-DER fix, the
+%% assume_role guardrail) had to be applied three times or silently drift. This
+%% module is the single home for that logic; each backend now delegates.
+%%
+%% Backend-specific surface differences (LDAP has no client cert and uses the
+%% `server_name_indication' key; HTTP/OAuth carry the mTLS pair and the `sni'
+%% key) are absorbed by an options map passed to the parsing entry points, so
+%% the behaviour is identical where the backends agree and explicit where they
+%% differ.
+%%
+%% Security invariants preserved verbatim from the original copies:
+%%   * R6 -- a resolved secret (password / PEM) is never logged or returned;
+%%     resolve_arn/2 adapts aws_arn_util's 3-tuple to {ok, Binary} and discards
+%%     the threaded state.
+%%   * assume_role guardrail -- resolving any ARN requires a configured
+%%     aws.arns.assume_role_arn; the broker instance role is never used.
+%%   * cacerts DER -- decode_pem_cacerts/1 returns raw 'Certificate' DER, not
+%%     pem_entry_decode/1 records (ssl silently ignores the latter under
+%%     {cacerts,_} -> unknown_ca -> spurious tls_failed).
+-module(aws_auth_validate_ssl).
+
+-export([
+    %% assume-role / request state
+    configured_assume_role_arn/0,
+    resolve_request_state/2,
+    resolve_arn/2,
+    %% ssl_options parsing (pure phase)
+    parse_ssl_options/3,
+    valid_ssl_value/3,
+    %% TLS-material resolution + translation (network phase)
+    resolve_cacerts/2,
+    resolve_client_cert/2,
+    decode_pem_cacerts/1,
+    decode_client_cert/1,
+    decode_client_key/1,
+    translate_ssl_opts/2,
+    apply_verify_default/2,
+    ensure_trust_anchor/1,
+    trust_source/1,
+    os_cacerts/0,
+    %% value translators (shared by all three backends)
+    to_verify/1,
+    to_version/1,
+    to_versions/1,
+    to_integer/1,
+    to_list/1,
+    %% httpc error classification
+    classify_http_error/3,
+    is_tls_error/1,
+    %% misc shared helpers
+    connection_timeout_ms/1,
+    is_nonempty_binary/1
+]).
+
+%% Accepted values for `verify' and `versions', shared by all backends.
+-define(SSL_VERIFY_VALUES, [<<"verify_peer">>, <<"verify_none">>]).
+-define(SSL_VERSION_VALUES, [
+    <<"tlsv1.3">>,
+    <<"tlsv1.2">>,
+    <<"tlsv1.1">>,
+    <<"tlsv1">>
+]).
+
+%% opts() is the per-backend surface description supplied by the caller. Fields:
+%%   arn_keys   :: [binary()] -- ssl_options keys that reference an ARN (a
+%%                 request touching any of these must assume a role).
+%%   sni_key    :: binary()   -- the customer-facing SNI key (<<"sni">> for
+%%                 http/oauth, <<"server_name_indication">> for ldap).
+%%   client_cert :: boolean() -- whether the mTLS cert/key pair is accepted.
+%%   reasons    :: map()      -- backend-specific fixed reason binaries, keyed by
+%%                 the atoms below (so each backend keeps its own wording/R4
+%%                 contract). See reason/2.
+-type opts() :: #{
+    arn_keys := [binary()],
+    ssl_option_keys := [binary()],
+    sni_key := binary(),
+    client_cert := boolean(),
+    reasons := map()
+}.
+
+-export_type([opts/0]).
+
+%%--------------------------------------------------------------------
+%% assume-role / request state
+%%--------------------------------------------------------------------
+
+%% The operator-configured boot-time assume role (aws.arns.assume_role_arn),
+%% read from the same `aws, arn_config' env the boot sequence uses
+%% (aws_arn_config:maybe_assume_role/1). Returns the role ARN string, or `none'
+%% when unset.
+-spec configured_assume_role_arn() -> string() | none.
+configured_assume_role_arn() ->
+    case application:get_env(aws, arn_config) of
+        {ok, ArnConfig} when is_list(ArnConfig) ->
+            case proplists:get_value(assume_role_arn, ArnConfig) of
+                undefined -> none;
+                Arn when is_list(Arn) -> Arn;
+                Arn when is_binary(Arn) -> binary_to_list(Arn);
+                _ -> none
+            end;
+        _ ->
+            none
+    end.
+
+%% Build the per-request aws_lib state used for every ARN fetch in this request,
+%% and thread it into Params under `aws_state'. MustAssume indicates whether the
+%% request references any ARN (true = a fetch will occur, so a role is required).
+%%
+%% When a role is required and configured, we assume it into a request-local
+%% aws_lib state -- the SAME role the plugin assumes at boot -- and resolve ARNs
+%% under it. This is operator config, not caller input, so no confused-deputy.
+%% When required but NOT configured, refuse with config_conflict rather than fall
+%% back to the broker's ambient EC2 instance role (a least-privilege pitfall).
+%% When not required (no ARN referenced), thread a default state that is never
+%% used to resolve an ARN, preserving the credential-free reachability check.
+-spec resolve_request_state(map(), opts()) ->
+    {ok, map()} | {error, aws_auth_validate_backend:error_category(), binary()}.
+resolve_request_state(Params, Opts) ->
+    case request_references_arn(Params, Opts) of
+        false ->
+            {ok, Params#{aws_state => aws_lib:new()}};
+        true ->
+            case configured_assume_role_arn() of
+                none ->
+                    {error, config_conflict, reason(no_assume_role, Opts)};
+                RoleArn ->
+                    case aws_iam:assume_role(RoleArn, aws_lib:new()) of
+                        {ok, State} -> {ok, Params#{aws_state => State}};
+                        {error, _} -> {error, input_invalid, reason(assume_role, Opts)}
+                    end
+            end
+    end.
+
+%% True when the request references any ARN-backed TLS material under
+%% ssl_options, i.e. resolving the request will make at least one AWS call.
+request_references_arn(#{ssl_options := Map}, #{arn_keys := Keys}) ->
+    lists:any(fun(K) -> maps:is_key(K, Map) end, Keys);
+request_references_arn(_Params, _Opts) ->
+    false.
+
+%% Resolve an ARN using the request's threaded aws_state(). The 3-tuple
+%% {ok, Data, State1} from aws_arn_util:resolve_arn/2 is adapted back to the
+%% {ok, Binary} contract callers expect; the threaded state is request-scoped
+%% and discarded here. R6: the resolved secret is neither logged nor returned.
+%%
+%% Fail closed on the `none' sentinel: a request that referenced no ARN carries
+%% aws_state => none (a no-ARN branch), and must never resolve an ARN -- doing so
+%% under aws_lib's default credential chain could reach the broker's EC2 instance
+%% role. Refusing here turns any such path into a fixed-category error rather than
+%% an instance-role fetch. A credentialed state is only ever produced by
+%% resolve_request_state/2's assume_role path.
+-spec resolve_arn(binary(), aws_lib:aws_state() | none) -> {ok, binary()} | {error, term()}.
+resolve_arn(_Arn, none) ->
+    {error, no_credentials_state};
+resolve_arn(Arn, State) when is_binary(Arn) ->
+    case aws_arn_util:resolve_arn(binary_to_list(Arn), State) of
+        {ok, Data, _State1} -> {ok, Data};
+        {error, _} = Error -> Error
+    end.
+
+%%--------------------------------------------------------------------
+%% ssl_options parsing (pure phase)
+%%--------------------------------------------------------------------
+
+%% Validate the ssl_options object: unknown-key rejection, the mTLS both-or-
+%% neither pairing (when client_cert is enabled), and every value's shape/domain.
+%% Stores the original map unchanged under `ssl_options' (translation happens
+%% later). SslOptionKeys is the allowed-key list for this backend.
+-spec parse_ssl_options(term(), map(), opts()) ->
+    {ok, map()} | {error, aws_auth_validate_backend:error_category(), binary()}.
+parse_ssl_options(undefined, Acc, _Opts) ->
+    {ok, Acc#{ssl_options => #{}}};
+parse_ssl_options(Map, Acc, #{ssl_option_keys := Keys} = Opts) when is_map(Map) ->
+    case [K || K <- maps:keys(Map), not lists:member(K, Keys)] of
+        [_ | _] ->
+            {error, input_invalid, reason(unknown_ssl_option, Opts)};
+        [] ->
+            case client_cert_pairing_ok(Map, Opts) of
+                false -> {error, input_invalid, reason(client_cert_incomplete, Opts)};
+                true -> validate_ssl_values(maps:to_list(Map), Acc, Map, Opts)
+            end
+    end;
+parse_ssl_options(_Other, _Acc, Opts) ->
+    {error, input_invalid, reason(bad_ssl_options, Opts)}.
+
+%% Client cert + key are an inseparable pair: one without the other cannot build
+%% an mTLS identity. Only enforced for backends that accept client certs.
+client_cert_pairing_ok(Map, #{client_cert := true}) ->
+    maps:is_key(<<"certfile_arn">>, Map) =:= maps:is_key(<<"keyfile_arn">>, Map);
+client_cert_pairing_ok(_Map, _Opts) ->
+    true.
+
+validate_ssl_values([], Acc, Map, _Opts) ->
+    {ok, Acc#{ssl_options => Map}};
+validate_ssl_values([{Key, Value} | Rest], Acc, Map, Opts) ->
+    case valid_ssl_value(Key, Value, Opts) of
+        ok -> validate_ssl_values(Rest, Acc, Map, Opts);
+        {error, _, _} = Err -> Err
+    end.
+
+%% Validate one ssl_options value for shape/domain. The `sni' key is spelled
+%% differently per backend (Opts.sni_key), so it is matched dynamically.
+-spec valid_ssl_value(binary(), term(), opts()) ->
+    ok | {error, aws_auth_validate_backend:error_category(), binary()}.
+valid_ssl_value(<<"verify">>, V, Opts) ->
+    case lists:member(V, ?SSL_VERIFY_VALUES) of
+        true -> ok;
+        false -> {error, input_invalid, reason(bad_ssl_verify, Opts)}
+    end;
+valid_ssl_value(<<"depth">>, V, _Opts) when is_integer(V), V >= 0 ->
+    ok;
+valid_ssl_value(<<"depth">>, _V, Opts) ->
+    {error, input_invalid, reason(bad_ssl_depth, Opts)};
+valid_ssl_value(<<"versions">>, V, Opts) when is_list(V), V =/= [] ->
+    case lists:all(fun(Ver) -> lists:member(Ver, ?SSL_VERSION_VALUES) end, V) of
+        true -> ok;
+        false -> {error, input_invalid, reason(bad_ssl_versions, Opts)}
+    end;
+valid_ssl_value(<<"versions">>, _V, Opts) ->
+    {error, input_invalid, reason(bad_ssl_versions, Opts)};
+valid_ssl_value(<<"cacertfile_arn">>, V, Opts) ->
+    nonempty_or(V, bad_ssl_cacert_arn, Opts);
+valid_ssl_value(<<"certfile_arn">>, V, Opts) ->
+    nonempty_or(V, bad_ssl_cert_arn, Opts);
+valid_ssl_value(<<"keyfile_arn">>, V, Opts) ->
+    nonempty_or(V, bad_ssl_key_arn, Opts);
+valid_ssl_value(Key, V, #{sni_key := Key} = Opts) ->
+    %% The SNI key (backend-specific spelling): a non-empty string.
+    nonempty_or(V, bad_ssl_sni, Opts).
+
+nonempty_or(V, ReasonKey, Opts) ->
+    case is_nonempty_binary(V) of
+        true -> ok;
+        false -> {error, input_invalid, reason(ReasonKey, Opts)}
+    end.
+
+%%--------------------------------------------------------------------
+%% TLS-material resolution (network phase)
+%%--------------------------------------------------------------------
+
+%% Resolve ssl_options.cacertfile_arn to the raw-DER cacerts ssl option (or [] if
+%% absent / no cert entries). Any resolve failure -> input_invalid (fixed reason).
+-spec resolve_cacerts(term(), aws_lib:aws_state()) ->
+    {ok, list()} | {error, aws_auth_validate_backend:error_category(), binary()}.
+resolve_cacerts(undefined, _State) ->
+    {ok, []};
+resolve_cacerts(Arn, State) when is_binary(Arn) ->
+    case resolve_arn(Arn, State) of
+        {ok, Pem} ->
+            case decode_pem_cacerts(Pem) of
+                skip -> {ok, []};
+                Certs -> {ok, [{cacerts, Certs}]}
+            end;
+        {error, _} ->
+            {error, input_invalid, generic_arn_resolve()}
+    end.
+
+%% Resolve the client certificate + private key for mutual TLS. parse_ssl_options
+%% already guaranteed both are present or both absent, so here we either resolve
+%% the pair or return no client-auth options.
+-spec resolve_client_cert(map(), aws_lib:aws_state()) ->
+    {ok, list()} | {error, aws_auth_validate_backend:error_category(), binary()}.
+resolve_client_cert(#{<<"certfile_arn">> := CertArn, <<"keyfile_arn">> := KeyArn}, State) when
+    is_binary(CertArn), is_binary(KeyArn)
+->
+    case resolve_arn(CertArn, State) of
+        {ok, CertPem} ->
+            case decode_client_cert(CertPem) of
+                {error, _, _} = Err ->
+                    Err;
+                {ok, CertOpt} ->
+                    case resolve_arn(KeyArn, State) of
+                        {ok, KeyPem} ->
+                            case decode_client_key(KeyPem) of
+                                {error, _, _} = Err -> Err;
+                                {ok, KeyOpt} -> {ok, [CertOpt, KeyOpt]}
+                            end;
+                        {error, _} ->
+                            {error, input_invalid, generic_arn_resolve()}
+                    end
+            end;
+        {error, _} ->
+            {error, input_invalid, generic_arn_resolve()}
+    end;
+resolve_client_cert(_Map, _State) ->
+    {ok, []}.
+
+%% Decode a CA-bundle PEM into the raw 'Certificate' DER binaries ssl's
+%% {cacerts,_} expects. Passing pem_entry_decode/1 records makes ssl silently
+%% ignore the anchor -> unknown_ca -> spurious tls_failed. `skip' when the data
+%% holds no certificate entries.
+-spec decode_pem_cacerts(binary()) -> skip | [binary()].
+decode_pem_cacerts(B) when is_binary(B) ->
+    case [Der || {'Certificate', Der, not_encrypted} <- public_key:pem_decode(B)] of
+        [] -> skip;
+        Ders -> Ders
+    end.
+
+%% Decode a client-certificate PEM into an ssl {cert, [DER]} option. A PEM with
+%% no certificate entry is a resolution-shaped failure (fixed ARN category).
+-spec decode_client_cert(binary()) ->
+    {ok, {cert, [binary()]}} | {error, aws_auth_validate_backend:error_category(), binary()}.
+decode_client_cert(Pem) when is_binary(Pem) ->
+    case [Der || {'Certificate', Der, not_encrypted} <- public_key:pem_decode(Pem)] of
+        [] -> {error, input_invalid, generic_arn_resolve()};
+        Ders -> {ok, {cert, Ders}}
+    end.
+
+%% Decode a private-key PEM into an ssl {key, {Asn1Type, DER}} option. An
+%% encrypted or absent key is a fixed ARN-category failure.
+-spec decode_client_key(binary()) ->
+    {ok, {key, {atom(), binary()}}}
+    | {error, aws_auth_validate_backend:error_category(), binary()}.
+decode_client_key(Pem) when is_binary(Pem) ->
+    KeyEntries = [
+        {Type, Der}
+     || {Type, Der, not_encrypted} <- public_key:pem_decode(Pem),
+        lists:member(Type, [
+            'PrivateKeyInfo', 'RSAPrivateKey', 'ECPrivateKey', 'DSAPrivateKey'
+        ])
+    ],
+    case KeyEntries of
+        [{Type, Der} | _] -> {ok, {key, {Type, Der}}};
+        [] -> {error, input_invalid, generic_arn_resolve()}
+    end.
+
+%% Translate the non-cacert ssl_options keys into an ssl proplist. SniKey is the
+%% backend's customer-facing SNI key spelling; it always maps to the ssl
+%% `server_name_indication' atom.
+-spec translate_ssl_opts(map(), binary()) -> list().
+translate_ssl_opts(Map, SniKey) ->
+    Pairs = [
+        {verify, <<"verify">>, fun to_verify/1},
+        {depth, <<"depth">>, fun to_integer/1},
+        {versions, <<"versions">>, fun to_versions/1},
+        {server_name_indication, SniKey, fun to_list/1}
+    ],
+    lists:foldl(
+        fun({SslKey, JsonKey, Fun}, Acc) ->
+            case maps:get(JsonKey, Map, undefined) of
+                undefined -> Acc;
+                Value -> [{SslKey, Fun(Value)} | Acc]
+            end
+        end,
+        [],
+        Pairs
+    ).
+
+%% Ensure verify_peer always has a trust anchor. VerifyExplicit governs the
+%% no-anchor policy: an EXPLICIT verify_peer with no anchor FAILS (never silently
+%% downgraded -- the false-positive this endpoint exists to prevent); a DEFAULTED
+%% verify falls back to verify_none; an explicit verify_none is untouched; and
+%% when verify is absent we default to verify_peer only if an anchor exists.
+-spec apply_verify_default(list(), boolean()) ->
+    {ok, list()} | {error, aws_auth_validate_backend:error_category(), binary()}.
+apply_verify_default(Opts, VerifyExplicit) ->
+    case lists:keyfind(verify, 1, Opts) of
+        {verify, verify_peer} when VerifyExplicit ->
+            case ensure_trust_anchor(Opts) of
+                {ok, _} = Ok -> Ok;
+                none -> {error, tls_failed, no_trust_anchor()}
+            end;
+        {verify, verify_peer} ->
+            case ensure_trust_anchor(Opts) of
+                {ok, Opts1} -> {ok, Opts1};
+                none -> {ok, lists:keyreplace(verify, 1, Opts, {verify, verify_none})}
+            end;
+        {verify, _Other} ->
+            {ok, Opts};
+        false ->
+            case ensure_trust_anchor(Opts) of
+                {ok, Opts1} -> {ok, [{verify, verify_peer} | Opts1]};
+                none -> {ok, Opts}
+            end
+    end.
+
+%% Return {ok, OptsWithAnchor} when a trust anchor is present or can be sourced
+%% from the OS store, else `none'. (trust_source/1 is the historical LDAP name
+%% for the same behaviour; kept as an alias for that backend's call site.)
+-spec ensure_trust_anchor(list()) -> {ok, list()} | none.
+ensure_trust_anchor(Opts) ->
+    case lists:keymember(cacerts, 1, Opts) of
+        true ->
+            {ok, Opts};
+        false ->
+            case os_cacerts() of
+                [] -> none;
+                Certs -> {ok, [{cacerts, Certs} | Opts]}
+            end
+    end.
+
+-spec trust_source(list()) -> {ok, list()} | none.
+trust_source(Opts) ->
+    ensure_trust_anchor(Opts).
+
+os_cacerts() ->
+    try
+        public_key:cacerts_get()
+    catch
+        _:_ -> []
+    end.
+
+%%--------------------------------------------------------------------
+%% httpc error classification
+%%--------------------------------------------------------------------
+
+%% Map an httpc transport error to a fixed category: a TLS/cert failure is
+%% tls_failed (with TlsReason), everything else connection_failed (ConnReason).
+%% The raw reason is never echoed (R4).
+-spec classify_http_error(term(), binary(), binary()) ->
+    {error, tls_failed | connection_failed, binary()}.
+classify_http_error(Reason, TlsReason, ConnReason) ->
+    case is_tls_error(Reason) of
+        true -> {error, tls_failed, TlsReason};
+        false -> {error, connection_failed, ConnReason}
+    end.
+
+%% Recursively scan an httpc error term for the markers of a TLS-layer failure.
+-spec is_tls_error(term()) -> boolean().
+is_tls_error(Term) when is_tuple(Term) ->
+    case element(1, Term) of
+        tls_alert -> true;
+        Other when is_atom(Other) -> is_tls_atom(Other) orelse is_tls_error(tuple_to_list(Term));
+        _ -> is_tls_error(tuple_to_list(Term))
+    end;
+is_tls_error([H | T]) ->
+    is_tls_error(H) orelse is_tls_error(T);
+is_tls_error(Atom) when is_atom(Atom) ->
+    is_tls_atom(Atom);
+is_tls_error(_) ->
+    false.
+
+is_tls_atom(A) ->
+    lists:member(A, [
+        tls_alert,
+        certificate_expired,
+        bad_certificate,
+        unknown_ca,
+        handshake_failure,
+        certificate_unknown,
+        no_peercert
+    ]).
+
+%%--------------------------------------------------------------------
+%% Value translators (total over the pure-phase-validated domain)
+%%--------------------------------------------------------------------
+
+to_list(B) when is_binary(B) -> binary_to_list(B);
+to_list(L) when is_list(L) -> L.
+
+to_integer(I) when is_integer(I) -> I.
+
+to_verify(<<"verify_peer">>) -> verify_peer;
+to_verify(<<"verify_none">>) -> verify_none.
+
+to_versions(L) when is_list(L) ->
+    [to_version(V) || V <- L].
+
+to_version(<<"tlsv1.3">>) -> 'tlsv1.3';
+to_version(<<"tlsv1.2">>) -> 'tlsv1.2';
+to_version(<<"tlsv1.1">>) -> 'tlsv1.1';
+to_version(<<"tlsv1">>) -> tlsv1.
+
+%%--------------------------------------------------------------------
+%% Misc shared helpers
+%%--------------------------------------------------------------------
+
+is_nonempty_binary(B) -> is_binary(B) andalso byte_size(B) > 0.
+
+%% Per-request connection timeout (ms), read from aws env. Bounded to
+%% (0, MaxMs]; anything out of range falls back to Default. A shared cap
+%% prevents an operator-set timeout from pinning a semaphore slot indefinitely.
+-spec connection_timeout_ms(#{default := pos_integer(), max := pos_integer()}) -> pos_integer().
+connection_timeout_ms(#{default := Default, max := Max}) ->
+    case application:get_env(aws, auth_validation_connection_timeout_ms) of
+        {ok, Ms} when is_integer(Ms), Ms > 0, Ms =< Max -> Ms;
+        _ -> Default
+    end.
+
+%%--------------------------------------------------------------------
+%% Reason lookup
+%%--------------------------------------------------------------------
+
+%% Fetch a backend-specific fixed reason binary. Each backend supplies its own
+%% wording (preserving its R4 response contract and existing tests) via the
+%% reasons map in opts().
+reason(Key, #{reasons := Reasons}) ->
+    maps:get(Key, Reasons).
+
+%% The generic ARN-resolve reason. resolve_cacerts/2, resolve_client_cert/2, and
+%% the PEM decoders all report the same fixed string across backends (all three
+%% originals used <<"failed to resolve ARN">> in these paths).
+generic_arn_resolve() ->
+    <<"failed to resolve ARN">>.
+
+no_trust_anchor() ->
+    <<"verify_peer requested but no CA trust anchor is available; supply cacertfile_arn">>.

--- a/test/aws_auth_validate_shared_tests.erl
+++ b/test/aws_auth_validate_shared_tests.erl
@@ -1,0 +1,171 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% Cross-backend equivalence tests for the shared validation modules
+%% (aws_auth_validate_ssl / aws_auth_validate_net / aws_auth_validate_httpc).
+%%
+%% These lock in the property that the http and oauth backends behave
+%% IDENTICALLY where they share code -- the whole point of the extraction. If a
+%% future change makes one backend diverge from the shared helper (the drift
+%% these modules exist to prevent), one of these fails.
+-module(aws_auth_validate_shared_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%%--------------------------------------------------------------------
+%% aws_auth_validate_ssl: value translators (backend-independent)
+%%--------------------------------------------------------------------
+
+to_verify_test() ->
+    ?assertEqual(verify_peer, aws_auth_validate_ssl:to_verify(<<"verify_peer">>)),
+    ?assertEqual(verify_none, aws_auth_validate_ssl:to_verify(<<"verify_none">>)).
+
+to_versions_test() ->
+    ?assertEqual(
+        ['tlsv1.3', 'tlsv1.2', 'tlsv1.1', tlsv1],
+        aws_auth_validate_ssl:to_versions([
+            <<"tlsv1.3">>, <<"tlsv1.2">>, <<"tlsv1.1">>, <<"tlsv1">>
+        ])
+    ).
+
+%% decode_pem_cacerts/1 must return raw DER (or skip), never pem_entry_decode
+%% records -- the cacerts-DER contract the three backends depend on.
+decode_pem_cacerts_skip_on_non_pem_test() ->
+    ?assertEqual(skip, aws_auth_validate_ssl:decode_pem_cacerts(<<"not-a-pem">>)).
+
+%% resolve_arn/2 fails closed on the `none' credential sentinel: it must NOT call
+%% out to AWS. (aws_arn_util is not even loaded here; a call would error.)
+resolve_arn_fails_closed_on_none_test() ->
+    ?assertEqual(
+        {error, no_credentials_state}, aws_auth_validate_ssl:resolve_arn(<<"arn:x">>, none)
+    ).
+
+%% connection_timeout_ms/1 caps at the supplied max and floors invalid values to
+%% the default -- shared by all three backends.
+connection_timeout_bounds_test() ->
+    application:unset_env(aws, auth_validation_connection_timeout_ms),
+    ?assertEqual(
+        5000, aws_auth_validate_ssl:connection_timeout_ms(#{default => 5000, max => 60000})
+    ),
+    application:set_env(aws, auth_validation_connection_timeout_ms, 7000),
+    ?assertEqual(
+        7000, aws_auth_validate_ssl:connection_timeout_ms(#{default => 5000, max => 60000})
+    ),
+    %% Over the cap -> default.
+    application:set_env(aws, auth_validation_connection_timeout_ms, 999999),
+    ?assertEqual(
+        5000, aws_auth_validate_ssl:connection_timeout_ms(#{default => 5000, max => 60000})
+    ),
+    application:unset_env(aws, auth_validation_connection_timeout_ms).
+
+%%--------------------------------------------------------------------
+%% aws_auth_validate_net: the SSRF classifier is identical for the http and
+%% oauth policies (same infra denylist). Assert both backends' TEST wrappers
+%% agree with each other and with the shared module for the full v4/v6 matrix.
+%%--------------------------------------------------------------------
+
+%% The infra addresses both backends must DENY, and the public address both must
+%% ALLOW. classify_ip/1 on each backend delegates to the shared net module with
+%% that backend's policy; the denylists are identical, so the verdicts must match.
+ssrf_classify_ip_parity_test() ->
+    application:unset_env(aws, auth_validation_allow_private_networks),
+    Denied = [
+        {127, 0, 0, 1},
+        {169, 254, 169, 254},
+        {0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 1},
+        {16#fe80, 0, 0, 0, 0, 0, 0, 1},
+        {16#fd00, 16#0ec2, 0, 0, 0, 0, 0, 16#0254},
+        %% v6-encoded IMDS (v4-mapped) must also be denied.
+        {0, 0, 0, 0, 0, 16#ffff, 16#a9fe, 16#a9fe}
+    ],
+    Allowed = [
+        {8, 8, 8, 8},
+        {10, 0, 0, 5},
+        {172, 16, 0, 1},
+        {192, 168, 1, 1},
+        {2600, 16#1f18, 0, 0, 0, 0, 0, 1}
+    ],
+    [
+        ?assertEqual(
+            deny,
+            aws_auth_validate_http:classify_ip(IP),
+            {http_should_deny, IP}
+        )
+     || IP <- Denied
+    ],
+    [
+        ?assertEqual(
+            deny,
+            aws_auth_validate_oauth:classify_ip(IP),
+            {oauth_should_deny, IP}
+        )
+     || IP <- Denied
+    ],
+    [
+        ?assertEqual(
+            allow,
+            aws_auth_validate_http:classify_ip(IP),
+            {http_should_allow, IP}
+        )
+     || IP <- Allowed
+    ],
+    [
+        ?assertEqual(
+            allow,
+            aws_auth_validate_oauth:classify_ip(IP),
+            {oauth_should_allow, IP}
+        )
+     || IP <- Allowed
+    ],
+    %% Explicit http-vs-oauth agreement on every case.
+    [
+        ?assertEqual(
+            aws_auth_validate_http:classify_ip(IP),
+            aws_auth_validate_oauth:classify_ip(IP),
+            {parity_mismatch, IP}
+        )
+     || IP <- Denied ++ Allowed
+    ].
+
+%% The loopback-relax flag must behave identically for both backends: loopback
+%% flips allow, IMDS stays denied.
+ssrf_loopback_flag_parity_test() ->
+    application:set_env(aws, auth_validation_allow_private_networks, true),
+    try
+        ?assertEqual(allow, aws_auth_validate_http:classify_ip({127, 0, 0, 1})),
+        ?assertEqual(allow, aws_auth_validate_oauth:classify_ip({127, 0, 0, 1})),
+        %% IMDS is NOT relaxed for either.
+        ?assertEqual(deny, aws_auth_validate_http:classify_ip({169, 254, 169, 254})),
+        ?assertEqual(deny, aws_auth_validate_oauth:classify_ip({169, 254, 169, 254}))
+    after
+        application:unset_env(aws, auth_validation_allow_private_networks)
+    end.
+
+%% CIDR membership math is backend-independent; sanity-check via both wrappers.
+in_cidr_parity_test() ->
+    Cidr = {{169, 254, 0, 0}, 16},
+    ?assertEqual(
+        aws_auth_validate_http:in_cidr({169, 254, 169, 254}, Cidr),
+        aws_auth_validate_oauth:in_cidr({169, 254, 169, 254}, Cidr)
+    ),
+    ?assert(aws_auth_validate_http:in_cidr({169, 254, 169, 254}, Cidr)),
+    ?assertNot(aws_auth_validate_http:in_cidr({8, 8, 8, 8}, Cidr)).
+
+%%--------------------------------------------------------------------
+%% Scheme-allowlist divergence is INTENTIONAL: oauth is https-only, http allows
+%% both. Lock that difference in so a refactor cannot accidentally unify it.
+%%--------------------------------------------------------------------
+
+scheme_policy_divergence_test() ->
+    HttpUrl = #{scheme => "http", host => "example.com"},
+    %% http backend allows http://
+    ?assertEqual(ok, aws_auth_validate_http:url_allowed(HttpUrl)),
+    %% oauth backend rejects http:// (https-only)
+    ?assertMatch({error, input_invalid, _}, aws_auth_validate_oauth:url_allowed(HttpUrl)),
+    %% both allow https:// to a public host
+    HttpsUrl = #{scheme => "https", host => "example.com"},
+    ?assertEqual(ok, aws_auth_validate_http:url_allowed(HttpsUrl)),
+    ?assertEqual(ok, aws_auth_validate_oauth:url_allowed(HttpsUrl)).


### PR DESCRIPTION
The ldap, http, and oauth validation backends carried ~1000 lines of byte-identical code (ARN resolution + assume-role guardrail, TLS-material resolution and decoders, ssl_options validation, the SSRF/DNS-rebinding guard, and the httpc profile pool). Three hand-maintained copies meant every security fix had to be applied three times or silently drift -- which is exactly how the oauth backend fell behind (cf. the cacerts-DER, assume_role, and profile-scan fixes it was missing). Extract the shared logic into three modules so the next fix is a single edit.

- aws_auth_validate_ssl: ARN resolution (fails closed on the `none' credential sentinel -- never falls back to the instance role), the assume-role guardrail, ssl_options key/value validation, the cacert/client-cert PEM decoders (raw 'Certificate' DER, not pem_entry_decode records), the verify-default policy, httpc TLS-error classification, and the bounded connection timeout. Backend surface differences (ldap has no client cert and spells the key server_name_indication; http/oauth carry the mTLS pair and spell it sni) are absorbed by an options map, so behaviour is identical where the backends agree and explicit where they differ. Each backend keeps its own fixed R4 reason strings (passed in) so wording and tests are unchanged.
- aws_auth_validate_net: the SSRF guard (scheme allowlist + literal-IP classification + resolve-and-pin DNS-rebinding defense), parameterized by a policy map (infra denylists, scheme allowlist, reason strings). Used by http and oauth only -- the ldap backend keeps its DIFFERENT, stricter address policy (it denies ALL private/RFC1918/CGNAT ranges, not just broker infra), so it deliberately does not share this module.
- aws_auth_validate_httpc: the ephemeral httpc profile pool (claim/stop), parameterized by a per-backend name prefix so the http and oauth pools never collide. Used by http and oauth only (ldap uses eldap).

The backends now delegate: http 1277 -> 748 lines, oauth 1073 -> 593, ldap 1142 -> 1058 (leaf helpers only; its pipeline and SSRF policy stay). Backend TEST-exported helpers are retained as thin -ifdef(TEST) wrappers so existing tests target the backends unchanged. Two incidental drifts reconciled during extraction: the connection-timeout 60s cap is now uniform (http/oauth were uncapped), and oauth's duplicate ensure_trust_anchor/trust_source collapsed.

Tests: add aws_auth_validate_shared_tests -- cross-backend equivalence (classify_ip v4/v6 parity between http and oauth, loopback-flag parity, CIDR math, resolve_arn none-sentinel, timeout bounds) plus a guard pinning the INTENTIONAL http-vs-oauth scheme divergence (oauth is https-only) so a future refactor cannot accidentally unify it. Full run on the umbrella: 447 eunit and 40 CT cases pass (oauth 10, http 14, mgmt 15, config_schema 1); the ldap integration suite auto-skips without a local slapd, unchanged.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
