### PR TITLE
Read UTC directly so signing survives DST transitions

### DIFF
--- a/src/aws_lib.erl
+++ b/src/aws_lib.erl
@@ -566,11 +566,15 @@ expired_credentials(Expiration) ->
     Now >= Expires.
 
 -spec local_time() -> calendar:datetime().
-%% @doc Return the current local time.
+%% @doc Return the current UTC time. Callers compare this against UTC expiration
+%% timestamps, so it must be UTC. We read calendar:universal_time/0 directly
+%% rather than converting local time via local_time_to_universal_time_dst/1:
+%% that conversion returns two datetimes during a DST fall-back transition (the
+%% local hour is ambiguous) and none during a spring-forward gap, so matching a
+%% single [Value] crashed with badmatch in the transition window.
 %% @end
 local_time() ->
-    [Value] = calendar:local_time_to_universal_time_dst(calendar:local_time()),
-    Value.
+    calendar:universal_time().
 
 -spec maybe_decode_body(ContentType :: {nonempty_string(), nonempty_string()}, Body :: body()) ->
     list() | body().

--- a/src/aws_lib_sign.erl
+++ b/src/aws_lib_sign.erl
@@ -192,11 +192,15 @@ hmac_sign(Key, Message) ->
     binary_to_list(SignedValue).
 
 -spec local_time() -> string().
-%% @doc Return the current timestamp in GMT formatted in ISO8601 basic format.
+%% @doc Return the current UTC timestamp formatted in ISO8601 basic format. We
+%% read calendar:universal_time/0 directly rather than converting local time via
+%% local_time_to_universal_time_dst/1: that conversion returns two datetimes
+%% during a DST fall-back transition (the local hour is ambiguous) and none
+%% during a spring-forward gap, so matching a single [LocalTime] crashed with
+%% badmatch in the transition window.
 %% @end
 local_time() ->
-    [LocalTime] = calendar:local_time_to_universal_time_dst(calendar:local_time()),
-    local_time(LocalTime).
+    local_time(calendar:universal_time()).
 
 -spec local_time(calendar:datetime()) -> string().
 %% @doc Return the current timestamp in GMT formatted in ISO8601 basic format.

--- a/test/aws_lib_sign_tests.erl
+++ b/test/aws_lib_sign_tests.erl
@@ -371,11 +371,23 @@ local_time_0_test_() ->
         end,
         [
             {"variation1", fun() ->
-                meck:expect(calendar, local_time_to_universal_time_dst, fun(_) ->
-                    [{{2015, 05, 08}, {12, 36, 00}}]
+                meck:expect(calendar, universal_time, fun() ->
+                    {{2015, 05, 08}, {12, 36, 00}}
                 end),
                 Expectation = "20150508T123600Z",
                 ?assertEqual(Expectation, aws_lib_sign:local_time()),
+                meck:validate(calendar)
+            end},
+            %% Regression for #87: local_time/0 reads calendar:universal_time/0
+            %% directly, so a UTC datetime that falls inside a DST fall-back
+            %% window (which local_time_to_universal_time_dst/1 would have
+            %% returned as two ambiguous datetimes) yields a single, well-formed
+            %% timestamp rather than a badmatch crash.
+            {"dst fall-back instant does not crash", fun() ->
+                meck:expect(calendar, universal_time, fun() ->
+                    {{2024, 11, 3}, {8, 30, 00}}
+                end),
+                ?assertEqual("20241103T083000Z", aws_lib_sign:local_time()),
                 meck:validate(calendar)
             end}
         ]}.
@@ -404,8 +416,8 @@ headers_test_() ->
         end,
         [
             {"without signing key", fun() ->
-                meck:expect(calendar, local_time_to_universal_time_dst, fun(_) ->
-                    [{{2015, 08, 30}, {12, 36, 00}}]
+                meck:expect(calendar, universal_time, fun() ->
+                    {{2015, 08, 30}, {12, 36, 00}}
                 end),
                 Request = #request{
                     access_key = "AKIDEXAMPLE",
@@ -431,8 +443,8 @@ headers_test_() ->
                 meck:validate(calendar)
             end},
             {"with host header", fun() ->
-                meck:expect(calendar, local_time_to_universal_time_dst, fun(_) ->
-                    [{{2015, 08, 30}, {12, 36, 00}}]
+                meck:expect(calendar, universal_time, fun() ->
+                    {{2015, 08, 30}, {12, 36, 00}}
                 end),
                 Request = #request{
                     access_key = "AKIDEXAMPLE",

--- a/test/aws_lib_tests.erl
+++ b/test/aws_lib_tests.erl
@@ -123,8 +123,8 @@ expired_credentials_test_() ->
             {"true", fun() ->
                 Value = {{2016, 4, 1}, {12, 0, 0}},
                 Expectation = true,
-                meck:expect(calendar, local_time_to_universal_time_dst, fun(_) ->
-                    [{{2016, 4, 1}, {12, 0, 0}}]
+                meck:expect(calendar, universal_time, fun() ->
+                    {{2016, 4, 1}, {12, 0, 0}}
                 end),
                 ?assertEqual(Expectation, aws_lib:expired_credentials(Value)),
                 meck:validate(calendar)
@@ -132,8 +132,8 @@ expired_credentials_test_() ->
             {"false", fun() ->
                 Value = {{2016, 5, 1}, {16, 30, 0}},
                 Expectation = false,
-                meck:expect(calendar, local_time_to_universal_time_dst, fun(_) ->
-                    [{{2016, 4, 1}, {12, 0, 0}}]
+                meck:expect(calendar, universal_time, fun() ->
+                    {{2016, 4, 1}, {12, 0, 0}}
                 end),
                 ?assertEqual(Expectation, aws_lib:expired_credentials(Value)),
                 meck:validate(calendar)
@@ -242,7 +242,7 @@ local_time_test_() ->
         [
             {"value", fun() ->
                 Value = {{2016, 5, 1}, {12, 0, 0}},
-                meck:expect(calendar, local_time_to_universal_time_dst, fun(_) -> [Value] end),
+                meck:expect(calendar, universal_time, fun() -> Value end),
                 ?assertEqual(Value, aws_lib:local_time()),
                 meck:validate(calendar)
             end}
@@ -387,7 +387,7 @@ sign_headers_test_() ->
         [
             {"with security token", fun() ->
                 Value = {{2016, 5, 1}, {12, 0, 0}},
-                meck:expect(calendar, local_time_to_universal_time_dst, fun(_) -> [Value] end),
+                meck:expect(calendar, universal_time, fun() -> Value end),
                 AccessKey = "AKIDEXAMPLE",
                 SecretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
                 SecurityToken =
@@ -669,14 +669,12 @@ ensure_credentials_valid_test_() ->
 expired_imdsv2_token_test_() ->
     [
         {"imdsv2 token is valid", fun() ->
-            [Value] = calendar:local_time_to_universal_time_dst(calendar:local_time()),
-            Now = calendar:datetime_to_gregorian_seconds(Value),
+            Now = calendar:datetime_to_gregorian_seconds(calendar:universal_time()),
             Imdsv2Token = #imdsv2token{token = "value", expiration = Now + 100},
             ?assertEqual(false, aws_lib:expired_imdsv2_token(Imdsv2Token))
         end},
         {"imdsv2 token is expired", fun() ->
-            [Value] = calendar:local_time_to_universal_time_dst(calendar:local_time()),
-            Now = calendar:datetime_to_gregorian_seconds(Value),
+            Now = calendar:datetime_to_gregorian_seconds(calendar:universal_time()),
             Imdsv2Token = #imdsv2token{token = "value", expiration = Now - 100},
             ?assertEqual(true, aws_lib:expired_imdsv2_token(Imdsv2Token))
         end},


### PR DESCRIPTION
Fixes #87.

Both `aws_lib:local_time/0` and `aws_lib_sign:local_time/0` computed the current time with:

```erlang
[Value] = calendar:local_time_to_universal_time_dst(calendar:local_time())
```

During a DST fall-back transition the local hour is ambiguous, so `calendar:local_time_to_universal_time_dst/1` returns two datetimes (and none during a spring-forward gap). The single-element match then crashes with `badmatch`. Any request signing or credential-expiry check occurring in that ~1 hour window fails.

## Fix

Read `calendar:universal_time/0` directly instead. Both functions already needed UTC -- callers compare the result against AWS `Expiration` timestamps parsed as UTC (`parse_iso8601_timestamp`), and the signer doc already described the value as GMT -- so this removes the pointless local-to-UTC round trip and the DST ambiguity along with it. The docstrings, which mislabeled the result as local time, are corrected.

## Testing

- migrated the existing tests from mocking `calendar:local_time_to_universal_time_dst` to `calendar:universal_time`, matching the new code path
- fixed two `expired_imdsv2_token` tests that computed "now" via the same crashing pattern
- added a regression test that a DST fall-back instant yields a single, well-formed timestamp rather than a crash

Note: this cannot be reproduced empirically on a UTC host or in CI (`local_time_to_universal_time_dst/1` returns a single element when there is no local DST), which is exactly why the bug is easy to miss. The regression test guards the contract -- `universal_time/0`, a single datetime -- that structurally prevents recurrence. Full eunit suite passes; dialyzer is clean for the changed modules.
