### PR TITLE
Refresh credentials within a buffer window before expiry

### DIFF
--- a/include/aws_lib.hrl
+++ b/include/aws_lib.hrl
@@ -43,6 +43,11 @@
 
 -define(METADATA_TOKEN, "X-aws-ec2-metadata-token").
 
+% Refresh credentials this many seconds before they actually expire, so a
+% request does not start with credentials that lapse mid-flight. Matches the
+% 5-minute buffer erlcloud uses.
+-define(CREDENTIAL_REFRESH_BUFFER_SECONDS, 300).
+
 -define(LINEAR_BACK_OFF_MILLIS, 500).
 -define(MAX_RETRIES, 5).
 

--- a/src/aws_lib.erl
+++ b/src/aws_lib.erl
@@ -556,14 +556,18 @@ get_content_type(Headers) ->
     parse_content_type(Value).
 
 -spec expired_credentials(Expiration :: calendar:datetime()) -> boolean().
-%% @doc Indicates if the date that is passed in has expired.
+%% @doc Indicates whether the given expiration is at or within the refresh
+%% buffer window. Credentials are treated as expired a few minutes before they
+%% actually lapse (?CREDENTIAL_REFRESH_BUFFER_SECONDS) so they are refreshed
+%% proactively rather than after a request has already started with credentials
+%% that expire mid-flight.
 %% end
 expired_credentials(undefined) ->
     false;
 expired_credentials(Expiration) ->
     Now = calendar:datetime_to_gregorian_seconds(local_time()),
     Expires = calendar:datetime_to_gregorian_seconds(Expiration),
-    Now >= Expires.
+    Now >= (Expires - ?CREDENTIAL_REFRESH_BUFFER_SECONDS).
 
 -spec local_time() -> calendar:datetime().
 %% @doc Return the current UTC time. Callers compare this against UTC expiration

--- a/test/aws_lib_tests.erl
+++ b/test/aws_lib_tests.erl
@@ -138,6 +138,25 @@ expired_credentials_test_() ->
                 ?assertEqual(Expectation, aws_lib:expired_credentials(Value)),
                 meck:validate(calendar)
             end},
+            %% Within the refresh buffer window (#93): credentials that expire in
+            %% 4 minutes are still valid on the clock but are treated as expired
+            %% so they refresh before a request can start with them.
+            {"within refresh buffer is treated as expired", fun() ->
+                Now = {{2016, 4, 1}, {12, 0, 0}},
+                %% Expires 240s from now, inside the 300s buffer.
+                Expiration = {{2016, 4, 1}, {12, 4, 0}},
+                meck:expect(calendar, universal_time, fun() -> Now end),
+                ?assertEqual(true, aws_lib:expired_credentials(Expiration)),
+                meck:validate(calendar)
+            end},
+            %% Just outside the buffer window: expires in 6 minutes, still valid.
+            {"outside refresh buffer is still valid", fun() ->
+                Now = {{2016, 4, 1}, {12, 0, 0}},
+                Expiration = {{2016, 4, 1}, {12, 6, 0}},
+                meck:expect(calendar, universal_time, fun() -> Now end),
+                ?assertEqual(false, aws_lib:expired_credentials(Expiration)),
+                meck:validate(calendar)
+            end},
             {"undefined", fun() ->
                 ?assertEqual(false, aws_lib:expired_credentials(undefined))
             end}


### PR DESCRIPTION
Fixes #93.

> **Stacked on #121** (`fix/local-time-dst-crash`). This PR is based on that branch because `expired_credentials/1` calls `local_time/0`, which #121 makes DST-safe (`calendar:universal_time/0`). It targets `fix/local-time-dst-crash` and should merge after #121; the diff will collapse to the changes described below once #121 lands. Review the DST fix itself in #121.

`expired_credentials/1` only reported credentials as expired once the expiration time had already passed:

```erlang
Now >= Expires.
```

Credentials valid for one more second passed the check. A request using them could then fail mid-flight with an authentication error when they lapsed, instead of the client refreshing first.

## Fix

Treat credentials as expired once they are within a buffer window of expiry, so the refresh chain (`ensure_credentials_valid/1` -> `refresh_credentials/1`) runs proactively:

```erlang
Now >= (Expires - ?CREDENTIAL_REFRESH_BUFFER_SECONDS).
```

`?CREDENTIAL_REFRESH_BUFFER_SECONDS` is 300 (5 minutes), matching the buffer erlcloud uses. Because this branch is stacked on #121, `local_time/0` already returns UTC, so no separate DST handling is needed here.

## Testing

- added a boundary test that credentials expiring in 4 minutes (inside the 300s buffer) are treated as expired
- added a boundary test that credentials expiring in 6 minutes (outside the buffer) are still valid
- full eunit suite passes; dialyzer is clean for the changed module
