### PR TITLE
Default AWS API requests to a 30s timeout, separate from IMDS

### DIFF
--- a/include/aws_lib.hrl
+++ b/include/aws_lib.hrl
@@ -19,13 +19,19 @@
 
 % rabbitmq/rabbitmq-peer-discovery-aws#25
 
-% Note: this timeout must not be greater than the default
-% gen_server:call timeout of 5000ms. INSTANCE_HOST is
-% a pseudo-ip that should have good performance, and the
-% data should be returned quickly. Note that `timeout`,
-% when set, is used as the connect and then request timeout
-% by `httpc`
--define(DEFAULT_HTTP_TIMEOUT, 2250).
+% Timeout for EC2 Instance Metadata service (IMDS) requests. INSTANCE_HOST is a
+% link-local pseudo-IP that should have good performance and return data
+% quickly, so a short timeout is appropriate here. This is NOT used for AWS API
+% requests -- see ?DEFAULT_API_TIMEOUT.
+-define(DEFAULT_IMDS_TIMEOUT, 2250).
+
+% Default timeout for AWS API requests, applied when neither the request options
+% nor the aws_config() specify one. AWS API operations (S3 uploads,
+% CreateSnapshot, DynamoDB batch writes, and so on) can routinely exceed a few
+% seconds, so this matches the AWS SDK default of 30s rather than the short IMDS
+% timeout. Overridable per request via the `timeout' option or per state via
+% aws_lib:set_timeout/2.
+-define(DEFAULT_API_TIMEOUT, 30000).
 
 -define(INSTANCE_CREDENTIALS, "iam/security-credentials").
 -define(INSTANCE_METADATA_BASE, "latest/meta-data").
@@ -86,7 +92,10 @@
 
 -record(aws_config, {
     region = undefined :: region(),
-    imdsv2_token = undefined :: imdsv2token() | undefined
+    imdsv2_token = undefined :: imdsv2token() | undefined,
+    %% Per-state override for the AWS API request timeout (ms). undefined means
+    %% use ?DEFAULT_API_TIMEOUT. Set via aws_lib:set_timeout/2.
+    timeout = undefined :: timeout() | undefined
 }).
 -type aws_config() :: #aws_config{}.
 

--- a/src/aws_lib.erl
+++ b/src/aws_lib.erl
@@ -11,6 +11,8 @@
     new/0, new/1,
     get_region/1,
     set_region/2,
+    get_timeout/1,
+    set_timeout/2,
     get_credentials/1,
     get/3, get/4, get/5,
     put/5, put/6,
@@ -77,6 +79,22 @@ get_region(#aws_state{config = #aws_config{region = Region}}) ->
 %% @end
 set_region(Region, State = #aws_state{config = Config}) ->
     {ok, State#aws_state{config = Config#aws_config{region = Region}}}.
+
+-spec get_timeout(State :: aws_state()) -> timeout().
+%% @doc Get the AWS API request timeout (ms) from the state, falling back to
+%% ?DEFAULT_API_TIMEOUT when the state does not set one.
+%% @end
+get_timeout(#aws_state{config = #aws_config{timeout = undefined}}) ->
+    ?DEFAULT_API_TIMEOUT;
+get_timeout(#aws_state{config = #aws_config{timeout = Timeout}}) ->
+    Timeout.
+
+-spec set_timeout(Timeout :: timeout(), State :: aws_state()) -> {ok, aws_state()}.
+%% @doc Set the AWS API request timeout (ms) in the state. Applied to requests
+%% that do not pass an explicit `timeout' option.
+%% @end
+set_timeout(Timeout, State = #aws_state{config = Config}) ->
+    {ok, State#aws_state{config = Config#aws_config{timeout = Timeout}}}.
 
 -spec get_credentials(State :: aws_state()) -> {ok, aws_credentials()} | {error, undefined}.
 %% @doc Get the credentials from the state.
@@ -254,7 +272,8 @@ direct_request({GunPid, Service}, Method, Path, Body, Headers, Options, State0) 
                 )
             of
                 {ok, SignedHeaders} ->
-                    case direct_gun_request(GunPid, Method, Path, SignedHeaders, Body, Options) of
+                    Options1 = ensure_timeout_option(Options, State1),
+                    case direct_gun_request(GunPid, Method, Path, SignedHeaders, Body, Options1) of
                         {ok, Response} ->
                             {ok, Response, State1};
                         Error ->
@@ -444,7 +463,8 @@ perform_request_direct(Service, Method, Headers, Path, Body, Options, Host, Stat
                 )
             of
                 {ok, SignedHeaders} ->
-                    case gun_request(Method, URI, SignedHeaders, Body, Options) of
+                    Options1 = ensure_timeout_option(Options, State1),
+                    case gun_request(Method, URI, SignedHeaders, Body, Options1) of
                         {ok, Response} ->
                             {ok, Response, State1};
                         Error ->
@@ -783,6 +803,16 @@ api_request_with_retries(Service, Method, Path, Body, Headers, Retries, WaitTime
             {error, {credentials, Reason}}
     end.
 
+%% Add the state's AWS API timeout to the request options unless the caller
+%% already passed an explicit `timeout'. A per-request `timeout' option therefore
+%% takes precedence over the per-state value (aws_lib:set_timeout/2), which in
+%% turn falls back to ?DEFAULT_API_TIMEOUT via get_timeout/1.
+ensure_timeout_option(Options, State) ->
+    case proplists:is_defined(timeout, Options) of
+        true -> Options;
+        false -> [{timeout, get_timeout(State)} | Options]
+    end.
+
 %% Gun HTTP client functions
 gun_request(Method, URI, Headers, Body, Options) ->
     %% A parse or connection failure is returned as {error, Reason} (not raised)
@@ -888,7 +918,7 @@ direct_gun_request(GunPid, Method, Path, Headers, Body, Options) ->
         end,
         Headers
     ),
-    Timeout = proplists:get_value(timeout, Options, ?DEFAULT_HTTP_TIMEOUT),
+    Timeout = proplists:get_value(timeout, Options, ?DEFAULT_API_TIMEOUT),
     Response =
         try
             StreamRef = do_gun_request(GunPid, Method, Path, HeadersBin, Body),

--- a/src/aws_lib_config.erl
+++ b/src/aws_lib_config.erl
@@ -66,10 +66,10 @@
 %%      credentials.
 %%
 %%      When the EC2 instance metadata server is checked for but does not exist,
-%%      the operation will timeout in ``?DEFAULT_HTTP_TIMEOUT``ms.
+%%      the operation will timeout in ``?DEFAULT_IMDS_TIMEOUT``ms.
 %%
 %%      When the EC2 instance metadata server exists, but data is not returned
-%%      quickly, the operation will timeout in ``?DEFAULT_HTTP_TIMEOUT``ms.
+%%      quickly, the operation will timeout in ``?DEFAULT_IMDS_TIMEOUT``ms.
 %%
 %%      If the service does exist, it will attempt to use the
 %%      ``/meta-data/iam/security-credentials`` endpoint to request expiring
@@ -115,10 +115,10 @@ credentials(Config) ->
 %%      credentials.
 %%
 %%      When the EC2 instance metadata server is checked for but does not exist,
-%%      the operation will timeout in ``?DEFAULT_HTTP_TIMEOUT``ms.
+%%      the operation will timeout in ``?DEFAULT_IMDS_TIMEOUT``ms.
 %%
 %%      When the EC2 instance metadata server exists, but data is not returned
-%%      quickly, the operation will timeout in ``?DEFAULT_HTTP_TIMEOUT``ms.
+%%      quickly, the operation will timeout in ``?DEFAULT_IMDS_TIMEOUT``ms.
 %%
 %%      If the service does exist, it will attempt to use the
 %%      ``/meta-data/iam/security-credentials`` endpoint to request expiring
@@ -766,11 +766,11 @@ maybe_get_region_from_instance_metadata(Config) ->
 perform_http_get_with_conn(ConnPid, Path, Config) ->
     {ok, Headers, Config1} = instance_metadata_request_headers(Config),
     StreamRef = gun:get(ConnPid, Path, Headers),
-    case gun:await(ConnPid, StreamRef, ?DEFAULT_HTTP_TIMEOUT) of
+    case gun:await(ConnPid, StreamRef, ?DEFAULT_IMDS_TIMEOUT) of
         {response, fin, Status, RespHeaders} ->
             {ok, {{http_version, Status, aws_lib:status_text(Status)}, RespHeaders, <<>>}, Config1};
         {response, nofin, Status, RespHeaders} ->
-            case gun:await_body(ConnPid, StreamRef, ?DEFAULT_HTTP_TIMEOUT) of
+            case gun:await_body(ConnPid, StreamRef, ?DEFAULT_IMDS_TIMEOUT) of
                 {ok, Body} ->
                     {ok, {{http_version, Status, aws_lib:status_text(Status)}, RespHeaders, Body},
                         Config1};
@@ -881,7 +881,7 @@ perform_http_get_instance_metadata_conn(Uri, Config) ->
                     {ok, Headers, Config1} = instance_metadata_request_headers(Config),
                     StreamRef = gun:get(ConnPid, Path, Headers),
                     Result =
-                        case gun:await(ConnPid, StreamRef, ?DEFAULT_HTTP_TIMEOUT) of
+                        case gun:await(ConnPid, StreamRef, ?DEFAULT_IMDS_TIMEOUT) of
                             {response, fin, Status, RespHeaders} ->
                                 {ok,
                                     {
@@ -893,7 +893,7 @@ perform_http_get_instance_metadata_conn(Uri, Config) ->
                             {response, nofin, Status, RespHeaders} ->
                                 case
                                     gun:await_body(
-                                        ConnPid, StreamRef, ?DEFAULT_HTTP_TIMEOUT
+                                        ConnPid, StreamRef, ?DEFAULT_IMDS_TIMEOUT
                                     )
                                 of
                                     {ok, Body} ->
@@ -1011,7 +1011,7 @@ load_imdsv2_token(Uri) ->
                     ],
                     StreamRef = gun:put(ConnPid, Path, Headers, <<>>),
                     Result =
-                        case gun:await(ConnPid, StreamRef, ?DEFAULT_HTTP_TIMEOUT) of
+                        case gun:await(ConnPid, StreamRef, ?DEFAULT_IMDS_TIMEOUT) of
                             {response, fin, 200, _RespHeaders} ->
                                 ?LOG_DEBUG("Successfully obtained EC2 IMDSv2 token."),
                                 % Empty body for fin response
@@ -1019,7 +1019,7 @@ load_imdsv2_token(Uri) ->
                             {response, nofin, 200, _RespHeaders} ->
                                 case
                                     gun:await_body(
-                                        ConnPid, StreamRef, ?DEFAULT_HTTP_TIMEOUT
+                                        ConnPid, StreamRef, ?DEFAULT_IMDS_TIMEOUT
                                     )
                                 of
                                     {ok, Body} ->

--- a/test/aws_lib_tests.erl
+++ b/test/aws_lib_tests.erl
@@ -151,6 +151,17 @@ parse_volumes_response_test_() ->
         end}
     ].
 
+timeout_test_() ->
+    [
+        {"defaults to the API timeout when unset", fun() ->
+            ?assertEqual(30000, aws_lib:get_timeout(aws_lib:new()))
+        end},
+        {"set_timeout/2 overrides the default", fun() ->
+            {ok, State} = aws_lib:set_timeout(60000, aws_lib:new()),
+            ?assertEqual(60000, aws_lib:get_timeout(State))
+        end}
+    ].
+
 expired_credentials_test_() ->
     {
         foreach,
@@ -406,6 +417,58 @@ perform_request_test_() ->
                     ?assertEqual([{<<"content-type">>, <<"application/json">>}], Headers1),
                     ?assertEqual([{"pass", true}], Body1),
                     ?assert(is_record(State1, aws_state)),
+                    meck:validate(gun)
+                end
+            },
+            {
+                "the state timeout reaches gun:await when no option is given",
+                fun() ->
+                    State0 = set_test_credentials(
+                        "AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+                    ),
+                    {ok, State1} = aws_lib:set_region("us-east-1", State0),
+                    {ok, State} = aws_lib:set_timeout(45000, State1),
+                    Self = self(),
+                    meck:expect(gun, open, fun(_, _, _) -> {ok, pid} end),
+                    meck:expect(gun, close, fun(_) -> ok end),
+                    meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
+                    meck:expect(gun, get, fun(_Pid, _Path, _Headers) -> nofin end),
+                    %% Capture the timeout gun:await/3 is called with.
+                    meck:expect(gun, await, fun(_Pid, _, Timeout) ->
+                        Self ! {await_timeout, Timeout},
+                        {response, fin, 200, []}
+                    end),
+                    {ok, _, _} = aws_lib:request("ec2", get, "/", "", [], [], State),
+                    receive
+                        {await_timeout, T} -> ?assertEqual(45000, T)
+                    after 1000 -> ?assert(false)
+                    end,
+                    meck:validate(gun)
+                end
+            },
+            {
+                "an explicit timeout option overrides the state timeout",
+                fun() ->
+                    State0 = set_test_credentials(
+                        "AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+                    ),
+                    {ok, State1} = aws_lib:set_region("us-east-1", State0),
+                    {ok, State} = aws_lib:set_timeout(45000, State1),
+                    Self = self(),
+                    meck:expect(gun, open, fun(_, _, _) -> {ok, pid} end),
+                    meck:expect(gun, close, fun(_) -> ok end),
+                    meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
+                    meck:expect(gun, get, fun(_Pid, _Path, _Headers) -> nofin end),
+                    meck:expect(gun, await, fun(_Pid, _, Timeout) ->
+                        Self ! {await_timeout, Timeout},
+                        {response, fin, 200, []}
+                    end),
+                    %% Options carries an explicit timeout that must win.
+                    {ok, _, _} = aws_lib:request("ec2", get, "/", "", [], [{timeout, 1234}], State),
+                    receive
+                        {await_timeout, T} -> ?assertEqual(1234, T)
+                    after 1000 -> ?assert(false)
+                    end,
                     meck:validate(gun)
                 end
             },


### PR DESCRIPTION
Fixes #89.

`direct_gun_request` defaulted every AWS API request to `?DEFAULT_HTTP_TIMEOUT` (2250ms). That value was chosen for the old `gen_server:call` architecture (its comment even cited the 5000ms call timeout), but requests are now direct function calls with no call timeout. 2250ms is too aggressive for AWS operations like S3 uploads, `CreateSnapshot`, or DynamoDB batch writes, which routinely take longer and were failing spuriously.

## What changed

Split the IMDS and API timeout concerns, and make the API timeout configurable:

- renamed `?DEFAULT_HTTP_TIMEOUT` -> `?DEFAULT_IMDS_TIMEOUT` (still 2250ms, appropriate for the link-local EC2 metadata service)
- added `?DEFAULT_API_TIMEOUT` (30000ms, matching the AWS SDK default) for AWS API requests
- added a `timeout` field to `aws_config()` with `aws_lib:get_timeout/1` and `aws_lib:set_timeout/2`, threaded into both request paths
- removed the outdated `gen_server` comment

Precedence for the effective timeout: an explicit per-request `timeout` option, then the per-state value (`set_timeout/2`), then `?DEFAULT_API_TIMEOUT`.

## Testing

- `get_timeout/1` defaults to 30000 and reflects `set_timeout/2`
- a request with no explicit timeout sends the state's timeout to `gun:await`, and an explicit `timeout` option overrides it (both verified through mocked gun)
- full eunit suite passes; dialyzer is clean for the changed modules
