### PR TITLE
Decode XML attributes and document the parser contract

### DIFF
--- a/src/aws_iam.erl
+++ b/src/aws_iam.erl
@@ -7,6 +7,11 @@
 
 -export([assume_role/2]).
 
+%% Export all for unit tests
+-ifdef(TEST).
+-compile(export_all).
+-endif.
+
 -spec assume_role(string() | binary(), aws_lib:aws_state()) ->
     {ok, aws_lib:aws_state()} | {error, term()}.
 assume_role(RoleArn, State) when is_binary(RoleArn) ->

--- a/src/aws_lib_xml.erl
+++ b/src/aws_lib_xml.erl
@@ -1,7 +1,33 @@
 %% ====================================================================
 %% @author Gavin M. Roy <gavinmroy@gmail.com>
 %% @copyright 2016, Gavin M. Roy
-%% @doc Simple XML parser for AWS application/xml responses
+%% @doc XML parser for AWS application/xml responses.
+%%
+%% Decodes an xmerl parse tree into a nested proplist keyed by element name.
+%%
+%% Contract:
+%%   * An element with only text content and no attributes decodes to
+%%     `{Name, Text}' (a string).
+%%   * An element with child elements decodes to `{Name, Children}' where
+%%     Children is a proplist in document order. Repeated same-named siblings
+%%     appear as repeated keys, so a caller that expects a list (e.g. a
+%%     `volumeSet' of `item's) can walk them, but `proplists:get_value/2' on a
+%%     repeated key returns only the first -- a caller wanting all repeats must
+%%     iterate the proplist.
+%%   * Element attributes, when present, are collected under a reserved
+%%     `'@attributes'' key at the head of the element's value proplist. When an
+%%     element has attributes AND only text, the text moves under a reserved
+%%     `'#text'' key so it can sit beside the attributes. Elements WITHOUT
+%%     attributes are unaffected -- the historical text-or-proplist shape is
+%%     preserved, so existing consumers (DescribeVolumes, STS AssumeRole) are
+%%     unchanged.
+%%
+%% Known limitations (scoped to the AWS response shapes this plugin consumes):
+%%   * Mixed content (text interleaved with child elements) is not modelled
+%%     faithfully -- text and element nodes may be reordered or dropped.
+%%   * This is not a general-purpose XML decoder; it targets the EC2
+%%     DescribeVolumes and STS AssumeRole response shapes plus simple error
+%%     documents.
 %% @end
 %% ====================================================================
 -module(aws_lib_xml).
@@ -10,6 +36,11 @@
 
 -include_lib("xmerl/include/xmerl.hrl").
 
+%% Reserved keys. XML element and attribute names cannot begin with '@' or '#',
+%% so these cannot collide with a real name.
+-define(ATTRIBUTES_KEY, '@attributes').
+-define(TEXT_KEY, '#text').
+
 -spec parse(Value :: string() | binary()) -> list().
 parse(Value) when is_binary(Value) ->
     parse(binary_to_list(Value));
@@ -17,9 +48,35 @@ parse(Value) ->
     {Element, _} = xmerl_scan:string(Value),
     parse_node(Element).
 
-parse_node(#xmlElement{name = Name, content = Content}) ->
+parse_node(#xmlElement{name = Name, attributes = Attributes, content = Content}) ->
     Value = parse_content(Content, []),
-    [{atom_to_list(Name), flatten_value(Value, Value)}].
+    FlatValue = flatten_value(Value, Value),
+    [{atom_to_list(Name), with_attributes(Attributes, FlatValue)}].
+
+%% Attach parsed attributes to an element's value. With no attributes the value
+%% is returned unchanged (preserving the historical text-or-proplist shape).
+%% With attributes the value becomes a proplist headed by '@attributes'; a bare
+%% text value is relocated under '#text' so it can coexist with the attributes.
+with_attributes([], Value) ->
+    Value;
+with_attributes(Attributes, Value) ->
+    [{?ATTRIBUTES_KEY, parse_attributes(Attributes)} | as_proplist(Value)].
+
+parse_attributes(Attributes) ->
+    [
+        {atom_to_list(Name), Value}
+     || #xmlAttribute{name = Name, value = Value} <- Attributes
+    ].
+
+%% Coerce an element value into proplist form so it can carry an '@attributes'
+%% entry: an empty value stays empty, a text string moves under '#text', and a
+%% proplist of child elements is used as-is.
+as_proplist([]) ->
+    [];
+as_proplist([H | _] = Text) when is_integer(H) ->
+    [{?TEXT_KEY, Text}];
+as_proplist(Proplist) when is_list(Proplist) ->
+    Proplist.
 
 flatten_text([], Value) ->
     Value;

--- a/test/aws_iam_tests.erl
+++ b/test/aws_iam_tests.erl
@@ -1,0 +1,34 @@
+-module(aws_iam_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("aws_lib.hrl").
+
+%% End-to-end guard for the STS AssumeRole response path: a real AssumeRole XML
+%% document decoded by aws_lib_xml:parse/1 must still thread the returned
+%% credentials into the state. This pins the shape parse_assume_role_response/2
+%% depends on, so a change to the XML parser cannot silently break it.
+parse_assume_role_response_test_() ->
+    [
+        {"credentials are threaded into the state", fun() ->
+            Xml =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                "<AssumeRoleResponse xmlns=\"https://sts.amazonaws.com/doc/2011-06-15/\">"
+                "<AssumeRoleResult>"
+                "<Credentials>"
+                "<AccessKeyId>AKIDEXAMPLE</AccessKeyId>"
+                "<SecretAccessKey>wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY</SecretAccessKey>"
+                "<SessionToken>AQoEXAMPLEtoken</SessionToken>"
+                "<Expiration>2026-01-01T00:00:00Z</Expiration>"
+                "</Credentials>"
+                "</AssumeRoleResult>"
+                "</AssumeRoleResponse>",
+            Body = aws_lib_xml:parse(Xml),
+            {ok, State} = aws_iam:parse_assume_role_response(Body, aws_lib:new()),
+            {ok, Creds} = aws_lib:get_credentials(State),
+            ?assertEqual("AKIDEXAMPLE", Creds#aws_credentials.access_key),
+            ?assertEqual(
+                "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", Creds#aws_credentials.secret_key
+            ),
+            ?assertEqual("AQoEXAMPLEtoken", Creds#aws_credentials.security_token)
+        end}
+    ].

--- a/test/aws_lib_tests.erl
+++ b/test/aws_lib_tests.erl
@@ -111,6 +111,46 @@ cn_endpoint_host_test_() ->
         end}
     ].
 
+%% End-to-end guard for the DescribeVolumes response path: a real DescribeVolumes
+%% XML document decoded by aws_lib_xml:parse/1 must still parse into the expected
+%% volumes list. This pins the shape parse_volumes_response/1 depends on, so a
+%% change to the XML parser cannot silently break it.
+parse_volumes_response_test_() ->
+    [
+        {"a two-volume response parses into a volumes list", fun() ->
+            Xml =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                "<DescribeVolumesResponse xmlns=\"http://ec2.amazonaws.com/doc/2016-11-15/\">"
+                "<volumeSet>"
+                "<item>"
+                "<volumeId>vol-1111</volumeId><size>8</size>"
+                "<volumeType>gp3</volumeType><status>in-use</status>"
+                "<attachmentSet><item>"
+                "<device>/dev/sda1</device><status>attached</status>"
+                "</item></attachmentSet>"
+                "</item>"
+                "<item>"
+                "<volumeId>vol-2222</volumeId><size>16</size>"
+                "<volumeType>gp2</volumeType><status>available</status>"
+                "<attachmentSet/>"
+                "</item>"
+                "</volumeSet>"
+                "</DescribeVolumesResponse>",
+            Parsed = aws_lib_xml:parse(Xml),
+            {ok, Volumes} = aws_lib:parse_volumes_response(Parsed),
+            ?assertEqual(2, length(Volumes)),
+            [V1, V2] = Volumes,
+            ?assertEqual("vol-1111", proplists:get_value(volume_id, V1)),
+            ?assertEqual("gp3", proplists:get_value(volume_type, V1)),
+            ?assertEqual(
+                [{device, "/dev/sda1"}, {state, "attached"}],
+                proplists:get_value(attachment, V1)
+            ),
+            ?assertEqual("vol-2222", proplists:get_value(volume_id, V2)),
+            ?assertEqual([], proplists:get_value(attachment, V2))
+        end}
+    ].
+
 expired_credentials_test_() ->
     {
         foreach,

--- a/test/aws_lib_xml_tests.erl
+++ b/test/aws_lib_xml_tests.erl
@@ -46,5 +46,39 @@ parse_test_() ->
             Response = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<test>value</test>",
             Expectation = [{"test", "value"}],
             ?assertEqual(Expectation, aws_lib_xml:parse(Response))
+        end},
+        %% Repeated siblings are preserved as repeated keys, so a caller can
+        %% iterate them (proplists:get_value would see only the first).
+        {"repeated siblings are preserved as a list", fun() ->
+            Response = "<set><item>a</item><item>b</item><item>c</item></set>",
+            Expectation = [{"set", [{"item", "a"}, {"item", "b"}, {"item", "c"}]}],
+            ?assertEqual(Expectation, aws_lib_xml:parse(Response))
+        end},
+        %% Attributes on a text element: text moves under '#text' beside the
+        %% '@attributes' entry (issue #101).
+        {"attributes on a text element", fun() ->
+            Response = "<node id=\"7\" region=\"us-east-1\">hello</node>",
+            Expectation = [
+                {"node", [
+                    {'@attributes', [{"id", "7"}, {"region", "us-east-1"}]},
+                    {'#text', "hello"}
+                ]}
+            ],
+            ?assertEqual(Expectation, aws_lib_xml:parse(Response))
+        end},
+        %% Attributes on an element with children: '@attributes' heads the child
+        %% proplist.
+        {"attributes on an element with children", fun() ->
+            Response = "<node id=\"7\"><child>x</child></node>",
+            Expectation = [
+                {"node", [{'@attributes', [{"id", "7"}]}, {"child", "x"}]}
+            ],
+            ?assertEqual(Expectation, aws_lib_xml:parse(Response))
+        end},
+        %% Attribute-only (empty) element.
+        {"attribute-only element", fun() ->
+            Response = "<node id=\"7\"/>",
+            Expectation = [{"node", [{'@attributes', [{"id", "7"}]}]}],
+            ?assertEqual(Expectation, aws_lib_xml:parse(Response))
         end}
     ].

--- a/test/prop_aws_lib_xml_SUITE.erl
+++ b/test/prop_aws_lib_xml_SUITE.erl
@@ -1,0 +1,170 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% Property-based tests for aws_lib_xml:parse/1. Complements the example-based
+%% cases in aws_lib_xml_tests. A generated element tree is rendered to an XML
+%% string, parsed back, and checked to round-trip: element names, attributes,
+%% text, nesting, and repeated siblings are all recovered.
+%%
+%% The generator produces the well-formed subset the parser targets (see the
+%% aws_lib_xml module doc): each element has EITHER text OR child elements, never
+%% mixed content, and names/values avoid whitespace and XML metacharacters so no
+%% escaping or whitespace-stripping is exercised. Those are the parser's
+%% documented lossy behaviors and are covered by example tests, not here.
+-module(prop_aws_lib_xml_SUITE).
+
+-compile(nowarn_export_all).
+-compile(export_all).
+
+-include_lib("proper/include/proper.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+%% 200 iterations is ample: names, values, and attribute names are drawn from
+%% small fixed pools (see name/0, value/0), so the input space this explores is
+%% modest. The tree generator is also depth- and breadth-bounded (see
+%% element_tree/1) to keep each rendered document small; without those bounds a
+%% recursive ?SIZED generator produces documents large enough to make the run
+%% pathologically slow.
+-define(ITERATIONS, 200).
+-define(MAX_DEPTH, 4).
+-define(MAX_CHILDREN, 4).
+
+all() ->
+    [
+        prop_roundtrips
+    ].
+
+%%--------------------------------------------------------------------
+%% Generators
+%%--------------------------------------------------------------------
+
+%% An XML name drawn from a small FIXED pool. xmerl_scan interns every element
+%% and attribute name as an atom, and atoms are never garbage collected, so
+%% generating unbounded distinct names over many iterations exhausts the atom
+%% table and crashes the node. Real AWS responses use a bounded name vocabulary,
+%% so a fixed pool keeps the property realistic while bounding the atom count.
+%% Structure (nesting, repetition, attribute presence, text) still varies freely.
+name() ->
+    elements([
+        "item",
+        "volumeSet",
+        "attachmentSet",
+        "Credentials",
+        "AccessKeyId",
+        "node",
+        "child",
+        "Foo",
+        "Bar",
+        "region",
+        "id",
+        "status",
+        "value"
+    ]).
+
+%% A non-empty value drawn from a small FIXED pool. Like element names,
+%% xmerl_scan interns attribute values as atoms, so unbounded distinct values
+%% exhaust the atom table over many iterations. A fixed pool bounds the atom
+%% count while still varying which value appears where. Values contain no
+%% whitespace or XML metacharacters, so they need no escaping and are not
+%% touched by the parser's whitespace stripping.
+value() ->
+    elements([
+        "vol-1111",
+        "gp3",
+        "in-use",
+        "attached",
+        "AKIDEXAMPLE",
+        "us-east-1",
+        "8",
+        "16",
+        "x",
+        "value-1"
+    ]).
+
+%% Attributes: 0 to a few {Name, Value} pairs with unique names (XML forbids
+%% duplicate attribute names on one element). Bounded so elements stay small.
+attributes() ->
+    ?LET(
+        Pairs,
+        resize(?MAX_CHILDREN, list({name(), value()})),
+        lists:ukeysort(1, Pairs)
+    ).
+
+%% An element tree, explicitly bounded in depth (?MAX_DEPTH) and breadth
+%% (?MAX_CHILDREN). A leaf carries text; a node carries 1..?MAX_CHILDREN child
+%% elements. At depth 0 only leaves are produced so generation terminates.
+element_tree() ->
+    element_tree(?MAX_DEPTH).
+
+element_tree(0) ->
+    {name(), attributes(), {text, value()}};
+element_tree(Depth) ->
+    frequency([
+        {2, {name(), attributes(), {text, value()}}},
+        {3,
+            ?LET(
+                N,
+                choose(1, ?MAX_CHILDREN),
+                ?LET(
+                    Children,
+                    vector(N, element_tree(Depth - 1)),
+                    {name(), attributes(), {children, Children}}
+                )
+            )}
+    ]).
+
+%%--------------------------------------------------------------------
+%% Rendering: element tree -> XML string
+%%--------------------------------------------------------------------
+
+render({Name, Attrs, Body}) ->
+    AttrStr = render_attrs(Attrs),
+    case Body of
+        {text, Text} ->
+            "<" ++ Name ++ AttrStr ++ ">" ++ Text ++ "</" ++ Name ++ ">";
+        {children, Children} ->
+            "<" ++ Name ++ AttrStr ++ ">" ++
+                lists:concat([render(C) || C <- Children]) ++
+                "</" ++ Name ++ ">"
+    end.
+
+render_attrs(Attrs) ->
+    lists:concat([" " ++ K ++ "=\"" ++ V ++ "\"" || {K, V} <- Attrs]).
+
+%%--------------------------------------------------------------------
+%% Expected decoded shape for a generated tree
+%%--------------------------------------------------------------------
+
+expected({Name, Attrs, Body}) ->
+    {Name, expected_value(Attrs, Body)}.
+
+expected_value([], {text, Text}) ->
+    Text;
+expected_value(Attrs, {text, Text}) ->
+    [{'@attributes', Attrs}, {'#text', Text}];
+expected_value([], {children, Children}) ->
+    [expected(C) || C <- Children];
+expected_value(Attrs, {children, Children}) ->
+    [{'@attributes', Attrs} | [expected(C) || C <- Children]].
+
+%%--------------------------------------------------------------------
+%% Property
+%%--------------------------------------------------------------------
+
+prop_roundtrips(_Config) ->
+    rabbit_ct_proper_helpers:run_proper(
+        fun() ->
+            ?FORALL(
+                Tree,
+                element_tree(),
+                begin
+                    Xml = render(Tree),
+                    aws_lib_xml:parse(Xml) =:= [expected(Tree)]
+                end
+            )
+        end,
+        [],
+        ?ITERATIONS
+    ).

--- a/test/prop_aws_lib_xml_SUITE.erl
+++ b/test/prop_aws_lib_xml_SUITE.erl
@@ -63,12 +63,12 @@ name() ->
         "value"
     ]).
 
-%% A non-empty value drawn from a small FIXED pool. Like element names,
-%% xmerl_scan interns attribute values as atoms, so unbounded distinct values
-%% exhaust the atom table over many iterations. A fixed pool bounds the atom
-%% count while still varying which value appears where. Values contain no
-%% whitespace or XML metacharacters, so they need no escaping and are not
-%% touched by the parser's whitespace stripping.
+%% A non-empty value drawn from a small FIXED pool. Unlike element and attribute
+%% NAMES (which xmerl_scan interns as atoms -- see name/0), attribute and text
+%% VALUES are NOT interned, so a pool is not required here for atom safety. It is
+%% used for simplicity and to keep values realistic: they contain no whitespace
+%% or XML metacharacters, so they need no escaping and are not touched by the
+%% parser's whitespace stripping.
 value() ->
     elements([
         "vol-1111",


### PR DESCRIPTION
Fixes #101.

`aws_lib_xml:parse/1` only read each element's `name` and `content`, so any data carried in XML attributes was silently dropped, and the mixed-content and repeated-sibling behaviours were undocumented. `maybe_decode_body/2` routes every `*/xml` response through this parser, so a caller consuming a richer response would get incomplete data with no error.

## What changed

- Attributes are decoded into a reserved `'@attributes'` key at the head of an element's value proplist. When an element has attributes AND only text, the text moves under a reserved `'#text'` key so it can sit beside them.
- Elements WITHOUT attributes decode exactly as before (byte-identical output), so the `DescribeVolumes` and STS `AssumeRole` consumers are unchanged.
- Repeated same-named siblings are preserved as repeated proplist keys (already the behaviour); this is now documented as part of the contract.
- The module now documents its full contract, including the scoped mixed-content and whitespace limitations (this is not a general-purpose XML decoder; it targets the AWS response shapes the plugin consumes).

## Testing

- example cases for attributes (text element, element with children, attribute-only) and repeated siblings
- **new end-to-end consumer tests** feeding real `DescribeVolumes` and `AssumeRole` XML through `parse/1` into `parse_volumes_response/1` and `parse_assume_role_response/2` (the latter in a new `aws_iam_tests`; `aws_iam` gains a `-ifdef(TEST)` export block). These previously had no coverage and guard the production shapes against future parser changes.
- **new proper-based round-trip suite** (`prop_aws_lib_xml_SUITE`) over generated element trees. Coverage of a 500-tree sample: 91.8% carry attributes, 40.4% have repeated siblings, avg depth 3.1 / avg 15 nodes. The generator draws element/attribute names and values from small fixed pools (xmerl_scan interns them as atoms, so unbounded names would exhaust the atom table) and bounds tree depth and breadth.

Full eunit and the property suite pass; the property is non-vacuous (it fails against the old attribute-dropping parser).

> Note: while running the full suite I found a pre-existing flaky test on `main` unrelated to this change (`aws_lib_config_tests` "imdsv2 is available" hits real IMDS). Filed separately as #124.
