### PR TITLE
Decode all AWS JSON content types, not just 1.0 and plain

### DIFF
--- a/src/aws_lib.erl
+++ b/src/aws_lib.erl
@@ -578,14 +578,30 @@ local_time() ->
 %% @end
 maybe_decode_body(_, <<>>) ->
     <<>>;
-maybe_decode_body({"application", "x-amz-json-1.0"}, Body) ->
-    aws_lib_json:decode(Body);
-maybe_decode_body({"application", "json"}, Body) ->
-    aws_lib_json:decode(Body);
-maybe_decode_body({_, "xml"}, Body) ->
+maybe_decode_body({"application", Subtype}, Body) ->
+    case is_json_subtype(Subtype) of
+        true -> aws_lib_json:decode(Body);
+        false -> maybe_decode_xml(Subtype, Body)
+    end;
+maybe_decode_body({_, Subtype}, Body) ->
+    maybe_decode_xml(Subtype, Body).
+
+maybe_decode_xml("xml", Body) ->
     aws_lib_xml:parse(Body);
-maybe_decode_body(_ContentType, Body) ->
+maybe_decode_xml(_Subtype, Body) ->
     Body.
+
+%% Recognise the JSON subtypes AWS services return. Covers plain `json', every
+%% AWS JSON protocol version (`x-amz-json-1.0', `x-amz-json-1.1', and any future
+%% `x-amz-json-*'), and the RFC 6839 structured `+json' suffix. Secrets Manager
+%% and other services use the JSON 1.1 protocol, so matching only 1.0/plain left
+%% those responses undecoded (issue #99).
+is_json_subtype("json") ->
+    true;
+is_json_subtype("x-amz-json-" ++ _Version) ->
+    true;
+is_json_subtype(Subtype) ->
+    lists:suffix("+json", Subtype).
 
 -spec parse_content_type(ContentType :: string()) -> {Type :: string(), Subtype :: string()}.
 %% @doc parse a content type string returning a tuple of type/subtype

--- a/test/aws_lib_tests.erl
+++ b/test/aws_lib_tests.erl
@@ -257,8 +257,21 @@ maybe_decode_body_test_() ->
             Expectation = [{"test", true}],
             ?assertEqual(Expectation, aws_lib:maybe_decode_body(ContentType, Body))
         end},
+        {"application/x-amz-json-1.1", fun() ->
+            %% The JSON 1.1 protocol (e.g. Secrets Manager) must decode too (#99).
+            ContentType = {"application", "x-amz-json-1.1"},
+            Body = "{\"test\": true}",
+            Expectation = [{"test", true}],
+            ?assertEqual(Expectation, aws_lib:maybe_decode_body(ContentType, Body))
+        end},
         {"application/json", fun() ->
             ContentType = {"application", "json"},
+            Body = "{\"test\": true}",
+            Expectation = [{"test", true}],
+            ?assertEqual(Expectation, aws_lib:maybe_decode_body(ContentType, Body))
+        end},
+        {"application/*+json structured suffix", fun() ->
+            ContentType = {"application", "vnd.api+json"},
             Body = "{\"test\": true}",
             Expectation = [{"test", true}],
             ?assertEqual(Expectation, aws_lib:maybe_decode_body(ContentType, Body))
@@ -272,6 +285,13 @@ maybe_decode_body_test_() ->
         {"text/html [unsupported]", fun() ->
             ContentType = {"text", "html"},
             Body = "<html><head></head><body></body></html>",
+            ?assertEqual(Body, aws_lib:maybe_decode_body(ContentType, Body))
+        end},
+        {"application/octet-stream is not decoded", fun() ->
+            %% A non-JSON application/* subtype must fall through undecoded, not
+            %% be treated as JSON.
+            ContentType = {"application", "octet-stream"},
+            Body = <<"raw bytes">>,
             ?assertEqual(Body, aws_lib:maybe_decode_body(ContentType, Body))
         end}
     ].


### PR DESCRIPTION
Fixes #99.

`maybe_decode_body/2` only matched `application/x-amz-json-1.0` and `application/json`, so an `application/x-amz-json-1.1` response fell through to the catch-all and was returned undecoded, despite the documented contract that JSON responses are decoded automatically. Secrets Manager uses the JSON 1.1 protocol, so this would bite once `aws_sms` relies on the library's auto-decoding (issue #53).

## What changed

Decode any JSON subtype via a guard. `is_json_subtype/1` matches:

- plain `json`
- every AWS JSON protocol version (`x-amz-json-1.0`, `x-amz-json-1.1`, and any future `x-amz-json-*`)
- the RFC 6839 structured `+json` suffix

XML and unknown subtypes are unchanged (routed through `maybe_decode_xml/2`).

## Testing

- new positive cases: `x-amz-json-1.1` (the bug) and an `application/vnd.api+json` structured suffix
- new negative case: `application/octet-stream` must fall through undecoded (guards against the JSON match being too greedy)
- existing `x-amz-json-1.0`, `application/json`, `text/xml`, and `text/html` cases retained

Full eunit and dialyzer are clean for the changed module; the new tests are non-vacuous (they fail against the previous clause-based matching).
