### PR TITLE
Consolidate the Gun request lifecycle into `aws_lib_httpc`

### DIFF
--- a/src/aws_lib.erl
+++ b/src/aws_lib.erl
@@ -48,7 +48,7 @@
 -include_lib("kernel/include/logger.hrl").
 
 -opaque aws_state() :: #aws_state{}.
--type connection_handle() :: {pid(), string()}.
+-type connection_handle() :: {aws_lib_httpc:conn(), string()}.
 
 %%====================================================================
 %% State construction and accessors
@@ -207,17 +207,17 @@ open_connection(Service, Options, State0) ->
 
     Host = endpoint_host(Region, Service),
     Port = 443,
-    case create_gun_connection(Host, Port, Options) of
-        {ok, GunPid} ->
-            {ok, {GunPid, Service}, State1};
+    case aws_lib_httpc:open(Host, Port, gun_open_opts(Port, Options)) of
+        {ok, Conn} ->
+            {ok, {Conn, Service}, State1};
         {error, _Reason} = Error ->
             Error
     end.
 
 %% Close a direct connection
 -spec close_connection(Handle :: connection_handle()) -> ok.
-close_connection({GunPid, _Service}) ->
-    gun:close(GunPid).
+close_connection({Conn, _Service}) ->
+    aws_lib_httpc:close(Conn).
 
 -spec direct_request(
     Handle :: connection_handle(),
@@ -821,7 +821,9 @@ ensure_timeout_option(Options, State) ->
         false -> [{timeout, get_timeout(State)} | Options]
     end.
 
-%% Gun HTTP client functions
+%% Gun HTTP client functions. The Gun lifecycle itself lives in aws_lib_httpc;
+%% these functions build the AWS-API-specific request (URI parsing, connection
+%% options from Options) and shape the result via format_response/1.
 gun_request(Method, URI, Headers, Body, Options) ->
     %% A parse or connection failure is returned as {error, Reason} (not raised)
     %% so it flows through format_response/1 into the {error, _, _} shape the
@@ -832,35 +834,19 @@ gun_request(Method, URI, Headers, Body, Options) ->
             Port = aws_lib_uri:port(Uri),
             %% target/1 carries the query: Path is the Gun request line.
             Path = aws_lib_uri:target(Uri),
-            case create_gun_connection(Host, Port, Options) of
-                {ok, GunPid} ->
-                    Reply = direct_gun_request(GunPid, Method, Path, Headers, Body, Options),
-                    gun:close(GunPid),
-                    Reply;
-                {error, _Reason} = Error ->
-                    format_response(Error)
-            end;
+            OpenOpts = gun_open_opts(Port, Options),
+            Response = aws_lib_httpc:request(
+                Host, Port, Method, Path, Headers, Body, OpenOpts
+            ),
+            format_response(Response);
         {error, _Reason} = Error ->
             format_response(Error)
     end.
 
-do_gun_request(ConnPid, get, Path, Headers, _Body) ->
-    gun:get(ConnPid, Path, Headers);
-do_gun_request(ConnPid, post, Path, Headers, Body) ->
-    gun:post(ConnPid, Path, Headers, Body, #{});
-do_gun_request(ConnPid, put, Path, Headers, Body) ->
-    gun:put(ConnPid, Path, Headers, Body, #{});
-do_gun_request(ConnPid, head, Path, Headers, _Body) ->
-    gun:head(ConnPid, Path, Headers, #{});
-do_gun_request(ConnPid, delete, Path, Headers, _Body) ->
-    gun:delete(ConnPid, Path, Headers, #{});
-do_gun_request(ConnPid, patch, Path, Headers, Body) ->
-    gun:patch(ConnPid, Path, Headers, Body, #{});
-do_gun_request(ConnPid, options, Path, Headers, _Body) ->
-    gun:options(ConnPid, Path, Headers, #{}).
-
-create_gun_connection(Host, Port, Options) ->
-    % Map HTTP version to Gun protocols, always include http as fallback
+%% Build aws_lib_httpc open options from the request Options and target port:
+%% derive Gun protocols from the requested HTTP version, use TLS on port 443,
+%% and thread the connect and request timeouts through.
+gun_open_opts(Port, Options) ->
     HttpVersion = proplists:get_value(version, Options, "HTTP/1.1"),
     Protocols =
         case HttpVersion of
@@ -871,28 +857,17 @@ create_gun_connection(Host, Port, Options) ->
             % Default: try HTTP/2, fallback to HTTP/1.1
             _ -> [http2, http]
         end,
-    ConnectTimeout = proplists:get_value(connect_timeout, Options, infinity),
-    Opts = #{
-        transport =>
-            if
-                Port == 443 -> tls;
-                true -> tcp
-            end,
+    Transport =
+        if
+            Port == 443 -> tls;
+            true -> tcp
+        end,
+    #{
+        transport => Transport,
         protocols => Protocols,
-        connect_timeout => ConnectTimeout
-    },
-    case gun:open(Host, Port, Opts) of
-        {ok, ConnPid} ->
-            case gun:await_up(ConnPid, ConnectTimeout) of
-                {ok, _Protocol} ->
-                    {ok, ConnPid};
-                {error, Reason} ->
-                    gun:close(ConnPid),
-                    {error, {gun_connection_failed, Reason}}
-            end;
-        {error, Reason} ->
-            {error, {gun_open_failed, Reason}}
-    end.
+        connect_timeout => proplists:get_value(connect_timeout, Options, infinity),
+        timeout => proplists:get_value(timeout, Options, ?DEFAULT_API_TIMEOUT)
+    }.
 
 create_uri(Host, Path) when is_list(Path) ->
     "https://" ++ Host ++ Path;
@@ -910,48 +885,22 @@ status_text(500) -> "Internal Server Error";
 status_text(Code) -> integer_to_list(Code).
 
 -spec direct_gun_request(
-    GunPid :: pid(),
+    Conn :: aws_lib_httpc:conn(),
     Method :: method(),
-    Path :: path(),
+    Path :: path() | {term(), path()},
     Headers :: headers(),
     Body :: body(),
     Options :: list()
 ) -> result().
-direct_gun_request(GunPid, Method, {_, Path}, Headers, Body, Options) ->
-    direct_gun_request(GunPid, Method, [$/ | Path], Headers, Body, Options);
-direct_gun_request(GunPid, Method, Path, Headers, Body, Options) ->
-    HeadersBin = lists:map(
-        fun({Key, Value}) ->
-            {list_to_binary(Key), list_to_binary(Value)}
-        end,
-        Headers
-    ),
+%% Issue a request on an already-open connection (the two-step API). The Gun
+%% lifecycle lives in aws_lib_httpc; this resolves the request timeout and
+%% shapes the result. A {_, Path} tuple (S3 bucket/key) is normalized to an
+%% absolute path first.
+direct_gun_request(Conn, Method, {_, Path}, Headers, Body, Options) ->
+    direct_gun_request(Conn, Method, [$/ | Path], Headers, Body, Options);
+direct_gun_request(Conn, Method, Path, Headers, Body, Options) ->
     Timeout = proplists:get_value(timeout, Options, ?DEFAULT_API_TIMEOUT),
-    Response =
-        try
-            StreamRef = do_gun_request(GunPid, Method, Path, HeadersBin, Body),
-            case gun:await(GunPid, StreamRef, Timeout) of
-                {response, fin, Status, RespHeaders} ->
-                    {ok, {{http_version, Status, status_text(Status)}, RespHeaders, <<>>}};
-                {response, nofin, Status, RespHeaders} ->
-                    %% await_body/3 can return {error, timeout} (and other
-                    %% {error, _} reasons); surface it cleanly rather than
-                    %% letting a hard match turn it into a {badmatch, _} term.
-                    case gun:await_body(GunPid, StreamRef, Timeout) of
-                        {ok, RespBody} ->
-                            {ok, {
-                                {http_version, Status, status_text(Status)}, RespHeaders, RespBody
-                            }};
-                        {error, Reason} ->
-                            {error, Reason}
-                    end;
-                {error, Reason} ->
-                    {error, Reason}
-            end
-        catch
-            _:Error ->
-                {error, Error}
-        end,
+    Response = aws_lib_httpc:request(Conn, Method, Path, Headers, Body, Timeout),
     format_response(Response).
 
 -spec parse_volumes_response(term()) -> {'ok', volumes_list()} | {'error', 'parse_error'}.

--- a/src/aws_lib_config.erl
+++ b/src/aws_lib_config.erl
@@ -618,7 +618,7 @@ lookup_credentials_from_proplist(AccessKey, SecretKey, SessionToken, Config) ->
     },
     {ok, Creds, Config}.
 
--spec with_metadata_connection(fun((pid()) -> Result)) -> Result.
+-spec with_metadata_connection(fun((aws_lib_httpc:conn()) -> Result)) -> Result.
 %% @doc Execute a function with a shared metadata service connection
 %% @end
 with_metadata_connection(Fun) ->
@@ -626,24 +626,24 @@ with_metadata_connection(Fun) ->
         {ok, Uri} ->
             Host = aws_lib_uri:host(Uri),
             Port = aws_lib_uri:port(Uri),
-            Opts = #{transport => tcp, protocols => [http]},
-            case gun:open(Host, Port, Opts) of
-                {ok, ConnPid} ->
-                    case gun:await_up(ConnPid, 5000) of
-                        {ok, _Protocol} ->
-                            Result = Fun(ConnPid),
-                            gun:close(ConnPid),
-                            Result;
-                        {error, Reason} ->
-                            gun:close(ConnPid),
-                            {error, Reason}
+            case aws_lib_httpc:open(Host, Port, metadata_open_opts()) of
+                {ok, Conn} ->
+                    try
+                        Fun(Conn)
+                    after
+                        aws_lib_httpc:close(Conn)
                     end;
-                {error, Reason} ->
-                    {error, Reason}
+                {error, _Reason} = Error ->
+                    Error
             end;
         {error, _} = Error ->
             Error
     end.
+
+%% Open options shared by the EC2 metadata-service sites: plain TCP/HTTP to the
+%% link-local IMDS host, with the short IMDS connect timeout.
+metadata_open_opts() ->
+    #{transport => tcp, protocols => [http], connect_timeout => 5000}.
 
 -spec lookup_credentials_from_instance_metadata(aws_config()) ->
     {ok, aws_credentials(), aws_config()} | error().
@@ -715,7 +715,7 @@ maybe_convert_number(Value) ->
     end.
 
 -spec maybe_get_credentials_from_instance_metadata_with_conn(
-    ConnPid :: pid(),
+    ConnPid :: aws_lib_httpc:conn(),
     Role :: string(),
     aws_config()
 ) -> {'ok', aws_credentials(), aws_config()} | error().
@@ -759,24 +759,15 @@ maybe_get_region_from_instance_metadata(Config) ->
             Error
     end.
 
--spec perform_http_get_with_conn(pid(), string(), aws_config()) ->
+-spec perform_http_get_with_conn(aws_lib_httpc:conn(), string(), aws_config()) ->
     {ok, {any(), any(), any()}, aws_config()} | {error, term()}.
 %% @doc Make HTTP GET request using existing Gun connection
 %% @end
-perform_http_get_with_conn(ConnPid, Path, Config) ->
+perform_http_get_with_conn(Conn, Path, Config) ->
     {ok, Headers, Config1} = instance_metadata_request_headers(Config),
-    StreamRef = gun:get(ConnPid, Path, Headers),
-    case gun:await(ConnPid, StreamRef, ?DEFAULT_IMDS_TIMEOUT) of
-        {response, fin, Status, RespHeaders} ->
-            {ok, {{http_version, Status, aws_lib:status_text(Status)}, RespHeaders, <<>>}, Config1};
-        {response, nofin, Status, RespHeaders} ->
-            case gun:await_body(ConnPid, StreamRef, ?DEFAULT_IMDS_TIMEOUT) of
-                {ok, Body} ->
-                    {ok, {{http_version, Status, aws_lib:status_text(Status)}, RespHeaders, Body},
-                        Config1};
-                {error, Reason} ->
-                    {error, Reason}
-            end;
+    case aws_lib_httpc:request(Conn, get, Path, Headers, <<>>, ?DEFAULT_IMDS_TIMEOUT) of
+        {ok, Response} ->
+            {ok, Response, Config1};
         {error, Reason} ->
             {error, Reason}
     end.
@@ -784,7 +775,7 @@ perform_http_get_with_conn(ConnPid, Path, Config) ->
 %% @doc Try to query the EC2 local instance metadata service to get the role
 %%      assigned to the instance using an existing connection.
 %% @end
--spec maybe_get_role_from_instance_metadata_with_conn(pid(), aws_config()) ->
+-spec maybe_get_role_from_instance_metadata_with_conn(aws_lib_httpc:conn(), aws_config()) ->
     {ok, string(), aws_config()} | error().
 maybe_get_role_from_instance_metadata_with_conn(ConnPid, Config) ->
     case aws_lib_uri:parse(instance_role_url()) of
@@ -870,54 +861,13 @@ perform_http_get_instance_metadata_conn(Uri, Config) ->
     Host = aws_lib_uri:host(Uri),
     Port = aws_lib_uri:port(Uri),
     Path = aws_lib_uri:target(Uri),
-    % Simple Gun connection for metadata service
-
-    % HTTP only, no TLS
-    Opts = #{transport => tcp, protocols => [http]},
-    case gun:open(Host, Port, Opts) of
-        {ok, ConnPid} ->
-            case gun:await_up(ConnPid, 5000) of
-                {ok, _Protocol} ->
-                    {ok, Headers, Config1} = instance_metadata_request_headers(Config),
-                    StreamRef = gun:get(ConnPid, Path, Headers),
-                    Result =
-                        case gun:await(ConnPid, StreamRef, ?DEFAULT_IMDS_TIMEOUT) of
-                            {response, fin, Status, RespHeaders} ->
-                                {ok,
-                                    {
-                                        {http_version, Status, aws_lib:status_text(Status)},
-                                        RespHeaders,
-                                        <<>>
-                                    },
-                                    Config1};
-                            {response, nofin, Status, RespHeaders} ->
-                                case
-                                    gun:await_body(
-                                        ConnPid, StreamRef, ?DEFAULT_IMDS_TIMEOUT
-                                    )
-                                of
-                                    {ok, Body} ->
-                                        {ok,
-                                            {
-                                                {http_version, Status, aws_lib:status_text(Status)},
-                                                RespHeaders,
-                                                Body
-                                            },
-                                            Config1};
-                                    {error, Reason} ->
-                                        {error, Reason}
-                                end;
-                            {error, Reason} ->
-                                {error, Reason}
-                        end,
-                    gun:close(ConnPid),
-                    Result;
-                {error, Reason} ->
-                    gun:close(ConnPid),
-                    {error, Reason}
-            end;
-        {error, Reason} ->
-            {error, Reason}
+    {ok, Headers, Config1} = instance_metadata_request_headers(Config),
+    Opts = maps:put(timeout, ?DEFAULT_IMDS_TIMEOUT, metadata_open_opts()),
+    case aws_lib_httpc:request(Host, Port, get, Path, Headers, <<>>, Opts) of
+        {ok, Response} ->
+            {ok, Response, Config1};
+        {error, _Reason} = Error ->
+            Error
     end.
 
 -spec get_instruction_on_instance_metadata_error(string()) -> string().
@@ -997,88 +947,25 @@ load_imdsv2_token(Uri) ->
     Host = aws_lib_uri:host(Uri),
     Port = aws_lib_uri:port(Uri),
     Path = aws_lib_uri:target(Uri),
-    % Simple Gun connection for metadata service
-
-    % HTTP only, no TLS
-    Opts = #{transport => tcp, protocols => [http]},
-    case gun:open(Host, Port, Opts) of
-        {ok, ConnPid} ->
-            case gun:await_up(ConnPid, 5000) of
-                {ok, _Protocol} ->
-                    % PUT request with IMDSv2 token TTL header
-                    Headers = [
-                        {?METADATA_TOKEN_TTL_HEADER, integer_to_list(?METADATA_TOKEN_TTL_SECONDS)}
-                    ],
-                    StreamRef = gun:put(ConnPid, Path, Headers, <<>>),
-                    Result =
-                        case gun:await(ConnPid, StreamRef, ?DEFAULT_IMDS_TIMEOUT) of
-                            {response, fin, 200, _RespHeaders} ->
-                                ?LOG_DEBUG("Successfully obtained EC2 IMDSv2 token."),
-                                % Empty body for fin response
-                                <<>>;
-                            {response, nofin, 200, _RespHeaders} ->
-                                case
-                                    gun:await_body(
-                                        ConnPid, StreamRef, ?DEFAULT_IMDS_TIMEOUT
-                                    )
-                                of
-                                    {ok, Body} ->
-                                        ?LOG_DEBUG("Successfully obtained EC2 IMDSv2 token."),
-                                        binary_to_list(Body);
-                                    {error, Reason} ->
-                                        ?LOG_WARNING(
-                                            get_instruction_on_instance_metadata_error(
-                                                "Failed to read EC2 IMDSv2 token body: ~tp. "
-                                                "Falling back to EC2 IMDSv1 for now. It is recommended to use EC2 IMDSv2."
-                                            ),
-                                            [Reason]
-                                        ),
-                                        undefined
-                                end;
-                            {response, _, 400, _RespHeaders} ->
-                                ?LOG_WARNING(
-                                    "Failed to obtain EC2 IMDSv2 token: Missing or Invalid Parameters – The PUT request is not valid."
-                                ),
-                                undefined;
-                            {error, Reason} ->
-                                ?LOG_WARNING(
-                                    get_instruction_on_instance_metadata_error(
-                                        "Failed to obtain EC2 IMDSv2 token: ~tp. "
-                                        "Falling back to EC2 IMDSv1 for now. It is recommended to use EC2 IMDSv2."
-                                    ),
-                                    [Reason]
-                                ),
-                                undefined;
-                            Other ->
-                                ?LOG_WARNING(
-                                    get_instruction_on_instance_metadata_error(
-                                        "Failed to obtain EC2 IMDSv2 token: ~tp. "
-                                        "Falling back to EC2 IMDSv1 for now. It is recommended to use EC2 IMDSv2."
-                                    ),
-                                    [Other]
-                                ),
-                                undefined
-                        end,
-                    gun:close(ConnPid),
-                    Result;
-                {error, Reason} ->
-                    gun:close(ConnPid),
-                    ?LOG_WARNING(
-                        get_instruction_on_instance_metadata_error(
-                            "Failed to connect for EC2 IMDSv2 token: ~tp. "
-                            "Falling back to EC2 IMDSv1 for now. It is recommended to use EC2 IMDSv2."
-                        ),
-                        [Reason]
-                    ),
-                    undefined
-            end;
-        {error, Reason} ->
+    % PUT request with IMDSv2 token TTL header
+    Headers = [{?METADATA_TOKEN_TTL_HEADER, integer_to_list(?METADATA_TOKEN_TTL_SECONDS)}],
+    Opts = maps:put(timeout, ?DEFAULT_IMDS_TIMEOUT, metadata_open_opts()),
+    case aws_lib_httpc:request(Host, Port, put, Path, Headers, <<>>, Opts) of
+        {ok, {{_, 200, _}, _RespHeaders, Body}} ->
+            ?LOG_DEBUG("Successfully obtained EC2 IMDSv2 token."),
+            binary_to_list(Body);
+        {ok, {{_, 400, _}, _RespHeaders, _Body}} ->
+            ?LOG_WARNING(
+                "Failed to obtain EC2 IMDSv2 token: Missing or Invalid Parameters – The PUT request is not valid."
+            ),
+            undefined;
+        Other ->
             ?LOG_WARNING(
                 get_instruction_on_instance_metadata_error(
-                    "Failed to open connection for EC2 IMDSv2 token: ~tp. "
+                    "Failed to obtain EC2 IMDSv2 token: ~tp. "
                     "Falling back to EC2 IMDSv1 for now. It is recommended to use EC2 IMDSv2."
                 ),
-                [Reason]
+                [Other]
             ),
             undefined
     end.

--- a/src/aws_lib_httpc.erl
+++ b/src/aws_lib_httpc.erl
@@ -1,0 +1,178 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% The single owner of the Gun request lifecycle for the plugin.
+%%
+%% Before this module, the open -> await_up -> request -> await -> await_body ->
+%% close sequence was open-coded in the AWS API path (aws_lib) and in three
+%% near-identical metadata-service sites (aws_lib_config). That duplication
+%% caused real bugs (the await_body error handling had to be fixed in three
+%% places) and drift (connect timeouts differed between paths). Every caller now
+%% routes through here, so the lifecycle, timeout handling, header
+%% normalization, and response shaping live in exactly one place.
+%%
+%% The connection handle is an OPAQUE conn(): callers obtain one from open/3,
+%% hand it back to request/6 and close/1, and never touch the underlying Gun pid
+%% directly. This keeps the "one place owns Gun" invariant enforceable -- a
+%% caller cannot reach around the boundary and issue its own gun:get/await on the
+%% handle.
+-module(aws_lib_httpc).
+
+-export([open/3, request/6, request/7, close/1]).
+
+-export_type([conn/0]).
+
+-include("aws_lib.hrl").
+
+%% Opaque connection handle. A bare Gun pid today; kept opaque so it can grow
+%% (e.g. to carry host/port for stale-connection reconnect, issues #91/#107)
+%% without changing any caller.
+-opaque conn() :: pid().
+
+-type open_opts() :: #{
+    transport => tcp | tls,
+    protocols => [http | http2],
+    connect_timeout => timeout(),
+    %% Request (await/await_body) timeout, consulted only by request/7.
+    timeout => timeout()
+}.
+
+%% The response tuple this module produces, consumed by
+%% aws_lib:format_response/1 and the metadata-service callers. NOTE: the first
+%% status-line element is the literal atom `http_version', not an
+%% http_version() string -- this is the shape the plugin has always built, so it
+%% is typed as-is rather than as aws_lib.hrl's status_line() (whose first element
+%% is a string).
+-type response() ::
+    {ok, {{http_version, status_code(), reason_phrase()}, headers(), body()}}
+    | {error, term()}.
+
+-spec open(Host :: string(), Port :: inet:port_number(), Opts :: open_opts()) ->
+    {ok, conn()} | {error, {gun_open_failed | gun_connection_failed, term()}}.
+%% @doc Open a Gun connection and wait for it to come up. The transport,
+%% protocols, and connect timeout are taken from Opts; an open failure is
+%% reported as {gun_open_failed, _} and an await_up failure as
+%% {gun_connection_failed, _}, with the socket closed in the latter case.
+%% @end
+open(Host, Port, Opts) ->
+    ConnectTimeout = maps:get(connect_timeout, Opts, infinity),
+    GunOpts = #{
+        transport => maps:get(transport, Opts, tcp),
+        protocols => maps:get(protocols, Opts, [http]),
+        connect_timeout => ConnectTimeout
+    },
+    case gun:open(Host, Port, GunOpts) of
+        {ok, ConnPid} ->
+            case gun:await_up(ConnPid, ConnectTimeout) of
+                {ok, _Protocol} ->
+                    {ok, ConnPid};
+                {error, Reason} ->
+                    gun:close(ConnPid),
+                    {error, {gun_connection_failed, Reason}}
+            end;
+        {error, Reason} ->
+            {error, {gun_open_failed, Reason}}
+    end.
+
+-spec request(
+    Conn :: conn(),
+    Method :: method(),
+    Path :: path(),
+    Headers :: headers(),
+    Body :: body(),
+    Timeout :: timeout()
+) -> response().
+%% @doc Issue one request on an existing connection and read the full response.
+%% Headers are normalized to binaries; the await/await_body dance is performed
+%% here so its error handling lives in one place. Returns the status-line-shaped
+%% tuple aws_lib:format_response/1 accepts, or {error, Reason} for any transport
+%% or body-read failure (including a raise, which is caught).
+%% @end
+request(Conn, Method, Path, Headers, Body, Timeout) ->
+    HeadersBin = normalize_headers(Headers),
+    try
+        StreamRef = do_gun_request(Conn, Method, Path, HeadersBin, Body),
+        case gun:await(Conn, StreamRef, Timeout) of
+            {response, fin, Status, RespHeaders} ->
+                {ok, {{http_version, Status, aws_lib:status_text(Status)}, RespHeaders, <<>>}};
+            {response, nofin, Status, RespHeaders} ->
+                %% await_body/3 can return {error, timeout} (and other {error, _}
+                %% reasons); surface it cleanly rather than letting a hard match
+                %% turn it into a {badmatch, _} term.
+                case gun:await_body(Conn, StreamRef, Timeout) of
+                    {ok, RespBody} ->
+                        {ok, {
+                            {http_version, Status, aws_lib:status_text(Status)},
+                            RespHeaders,
+                            RespBody
+                        }};
+                    {error, Reason} ->
+                        {error, Reason}
+                end;
+            {error, Reason} ->
+                {error, Reason}
+        end
+    catch
+        _:Error ->
+            {error, Error}
+    end.
+
+-spec request(
+    Host :: string(),
+    Port :: inet:port_number(),
+    Method :: method(),
+    Path :: path(),
+    Headers :: headers(),
+    Body :: body(),
+    Opts :: open_opts()
+) -> response().
+%% @doc One-shot request: open a connection, issue the request, and close the
+%% connection, whatever the outcome. The request timeout is taken from Opts
+%% (`timeout' key, defaulting to the connect timeout). An open/await_up failure
+%% is returned (not raised) so it flows through the caller's error handling.
+%% @end
+request(Host, Port, Method, Path, Headers, Body, Opts) ->
+    case open(Host, Port, Opts) of
+        {ok, Conn} ->
+            Timeout = maps:get(timeout, Opts, maps:get(connect_timeout, Opts, infinity)),
+            try
+                request(Conn, Method, Path, Headers, Body, Timeout)
+            after
+                close(Conn)
+            end;
+        {error, _Reason} = Error ->
+            Error
+    end.
+
+-spec close(Conn :: conn()) -> ok.
+%% @doc Close a connection opened with open/3.
+%% @end
+close(Conn) ->
+    gun:close(Conn).
+
+%%--------------------------------------------------------------------
+%% Internal
+%%--------------------------------------------------------------------
+
+normalize_headers(Headers) ->
+    [{to_binary(Key), to_binary(Value)} || {Key, Value} <- Headers].
+
+to_binary(Value) when is_binary(Value) -> Value;
+to_binary(Value) when is_list(Value) -> list_to_binary(Value).
+
+do_gun_request(Conn, get, Path, Headers, _Body) ->
+    gun:get(Conn, Path, Headers);
+do_gun_request(Conn, post, Path, Headers, Body) ->
+    gun:post(Conn, Path, Headers, Body, #{});
+do_gun_request(Conn, put, Path, Headers, Body) ->
+    gun:put(Conn, Path, Headers, Body, #{});
+do_gun_request(Conn, head, Path, Headers, _Body) ->
+    gun:head(Conn, Path, Headers, #{});
+do_gun_request(Conn, delete, Path, Headers, _Body) ->
+    gun:delete(Conn, Path, Headers, #{});
+do_gun_request(Conn, patch, Path, Headers, Body) ->
+    gun:patch(Conn, Path, Headers, Body, #{});
+do_gun_request(Conn, options, Path, Headers, _Body) ->
+    gun:options(Conn, Path, Headers, #{}).

--- a/test/aws_lib_config_tests.erl
+++ b/test/aws_lib_config_tests.erl
@@ -6,7 +6,7 @@
 mock_gun_imdsv2_failure() ->
     meck:expect(gun, open, fun(_, _, _) -> {ok, fake_conn} end),
     meck:expect(gun, await_up, fun(_, _) -> {ok, http} end),
-    meck:expect(gun, put, fun(_, _, _, _) -> fake_stream end),
+    meck:expect(gun, put, fun(_, _, _, _, _) -> fake_stream end),
     meck:expect(gun, get, fun(_, _, _) -> fake_stream end),
     meck:expect(gun, await, fun(_, _, _) -> {response, fin, 404, []} end),
     meck:expect(gun, close, fun(_) -> ok end).
@@ -651,7 +651,7 @@ load_imdsv2_token_test_() ->
                 meck:expect(gun, open, fun(_, _, _) -> {ok, pid} end),
                 meck:expect(gun, close, fun(_) -> ok end),
                 meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
-                meck:expect(gun, put, fun(_, _, _, _) -> stream_ref end),
+                meck:expect(gun, put, fun(_, _, _, _, _) -> stream_ref end),
                 meck:expect(gun, await, fun(_, _, _) -> {response, nofin, 400, headers} end),
                 meck:expect(gun, await_body, fun(_, _, _) ->
                     {ok, <<"Missing or Invalid Parameters – The PUT request is not valid.">>}
@@ -664,7 +664,7 @@ load_imdsv2_token_test_() ->
                 meck:expect(gun, open, fun(_, _, _) -> {ok, pid} end),
                 meck:expect(gun, close, fun(_) -> ok end),
                 meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
-                meck:expect(gun, put, fun(_, _, _, _) -> stream_ref end),
+                meck:expect(gun, put, fun(_, _, _, _, _) -> stream_ref end),
                 meck:expect(gun, await, fun(_, _, _) -> {response, nofin, 200, headers} end),
                 meck:expect(gun, await_body, fun(_, _, _) -> {error, timeout} end),
                 ?assertEqual(undefined, aws_lib_config:load_imdsv2_token())
@@ -674,7 +674,7 @@ load_imdsv2_token_test_() ->
                 meck:expect(gun, open, fun(_, _, _) -> {ok, pid} end),
                 meck:expect(gun, close, fun(_) -> ok end),
                 meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
-                meck:expect(gun, put, fun(_, _, _, _) -> stream_ref end),
+                meck:expect(gun, put, fun(_, _, _, _, _) -> stream_ref end),
                 meck:expect(gun, await, fun(_, _, _) -> {response, nofin, 200, headers} end),
                 meck:expect(gun, await_body, fun(_, _, _) -> {ok, list_to_binary(IMDSv2Token)} end),
                 ?assertEqual(IMDSv2Token, aws_lib_config:load_imdsv2_token())
@@ -706,7 +706,7 @@ maybe_imdsv2_token_headers_test_() ->
                 meck:expect(gun, open, fun(_, _, _) -> {ok, pid} end),
                 meck:expect(gun, close, fun(_) -> ok end),
                 meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
-                meck:expect(gun, put, fun(_, _, _, _) -> stream_ref end),
+                meck:expect(gun, put, fun(_, _, _, _, _) -> stream_ref end),
                 meck:expect(gun, await, fun(_, _, _) -> {response, nofin, 200, headers} end),
                 meck:expect(gun, await_body, fun(_, _, _) -> {ok, list_to_binary(IMDSv2Token)} end),
                 {ok, Headers, _S1} = aws_lib_config:maybe_imdsv2_token_headers(S),

--- a/test/aws_lib_httpc_tests.erl
+++ b/test/aws_lib_httpc_tests.erl
@@ -1,0 +1,170 @@
+-module(aws_lib_httpc_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% Direct unit tests for the Gun lifecycle boundary. gun is mocked so these pin
+%% aws_lib_httpc's own contract (open wrapping, the await/await_body dance and
+%% its error handling, one-shot open/close) independently of the callers that
+%% exercise it transitively.
+
+%%--------------------------------------------------------------------
+%% open/3
+%%--------------------------------------------------------------------
+
+open_test_() ->
+    {foreach,
+        fun() ->
+            meck:new(gun, []),
+            [gun]
+        end,
+        fun meck:unload/1, [
+            {"success returns the connection", fun() ->
+                meck:expect(gun, open, fun(_, _, _) -> {ok, conn} end),
+                meck:expect(gun, await_up, fun(_, _) -> {ok, http} end),
+                ?assertEqual({ok, conn}, aws_lib_httpc:open("h", 80, #{}))
+            end},
+            {"open failure is wrapped as gun_open_failed", fun() ->
+                meck:expect(gun, open, fun(_, _, _) -> {error, enetunreach} end),
+                ?assertEqual(
+                    {error, {gun_open_failed, enetunreach}},
+                    aws_lib_httpc:open("h", 80, #{})
+                )
+            end},
+            {"await_up failure is wrapped as gun_connection_failed and closes", fun() ->
+                meck:expect(gun, open, fun(_, _, _) -> {ok, conn} end),
+                meck:expect(gun, await_up, fun(_, _) -> {error, timeout} end),
+                meck:expect(gun, close, fun(_) -> ok end),
+                ?assertEqual(
+                    {error, {gun_connection_failed, timeout}},
+                    aws_lib_httpc:open("h", 80, #{})
+                ),
+                %% the socket opened by gun:open is torn down on await_up failure
+                ?assertEqual(1, meck:num_calls(gun, close, [conn]))
+            end}
+        ]}.
+
+%%--------------------------------------------------------------------
+%% request/6 (on an already-open connection)
+%%--------------------------------------------------------------------
+
+request_on_conn_test_() ->
+    {foreach,
+        fun() ->
+            meck:new(gun, []),
+            [gun]
+        end,
+        fun meck:unload/1, [
+            {"fin response yields an empty body", fun() ->
+                meck:expect(gun, get, fun(_, _, _) -> stream end),
+                meck:expect(gun, await, fun(_, _, _) -> {response, fin, 200, [{h, v}]} end),
+                ?assertEqual(
+                    {ok, {{http_version, 200, "OK"}, [{h, v}], <<>>}},
+                    aws_lib_httpc:request(conn, get, "/", [], <<>>, 1000)
+                )
+            end},
+            {"nofin response reads the body", fun() ->
+                meck:expect(gun, get, fun(_, _, _) -> stream end),
+                meck:expect(gun, await, fun(_, _, _) -> {response, nofin, 200, [{h, v}]} end),
+                meck:expect(gun, await_body, fun(_, _, _) -> {ok, <<"payload">>} end),
+                ?assertEqual(
+                    {ok, {{http_version, 200, "OK"}, [{h, v}], <<"payload">>}},
+                    aws_lib_httpc:request(conn, get, "/", [], <<>>, 1000)
+                )
+            end},
+            {"await error is surfaced", fun() ->
+                meck:expect(gun, get, fun(_, _, _) -> stream end),
+                meck:expect(gun, await, fun(_, _, _) -> {error, timeout} end),
+                ?assertEqual(
+                    {error, timeout},
+                    aws_lib_httpc:request(conn, get, "/", [], <<>>, 1000)
+                )
+            end},
+            {"await_body error is surfaced, not a badmatch", fun() ->
+                meck:expect(gun, get, fun(_, _, _) -> stream end),
+                meck:expect(gun, await, fun(_, _, _) -> {response, nofin, 200, []} end),
+                meck:expect(gun, await_body, fun(_, _, _) -> {error, timeout} end),
+                ?assertEqual(
+                    {error, timeout},
+                    aws_lib_httpc:request(conn, get, "/", [], <<>>, 1000)
+                )
+            end},
+            {"a raise is caught and returned as an error", fun() ->
+                meck:expect(gun, get, fun(_, _, _) -> error(boom) end),
+                ?assertEqual(
+                    {error, boom},
+                    aws_lib_httpc:request(conn, get, "/", [], <<>>, 1000)
+                )
+            end},
+            {"string and binary headers are normalized to binaries", fun() ->
+                Self = self(),
+                meck:expect(gun, get, fun(_, _, Headers) ->
+                    Self ! {headers, Headers},
+                    stream
+                end),
+                meck:expect(gun, await, fun(_, _, _) -> {response, fin, 200, []} end),
+                aws_lib_httpc:request(
+                    conn, get, "/", [{"x-str", "v"}, {<<"x-bin">>, <<"w">>}], <<>>, 1000
+                ),
+                receive
+                    {headers, H} ->
+                        ?assertEqual([{<<"x-str">>, <<"v">>}, {<<"x-bin">>, <<"w">>}], H)
+                after 1000 -> ?assert(false)
+                end
+            end},
+            {"the method selects the matching gun function", fun() ->
+                meck:expect(gun, put, fun(_, _, _, _, _) -> stream end),
+                %% 200 is in aws_lib:status_text/1's table, so its reason phrase
+                %% is a known string; this also exercises the put/5 dispatch.
+                meck:expect(gun, await, fun(_, _, _) -> {response, fin, 200, []} end),
+                ?assertEqual(
+                    {ok, {{http_version, 200, "OK"}, [], <<>>}},
+                    aws_lib_httpc:request(conn, put, "/", [], <<"body">>, 1000)
+                ),
+                ?assertEqual(1, meck:num_calls(gun, put, ['_', '_', '_', '_', '_']))
+            end}
+        ]}.
+
+%%--------------------------------------------------------------------
+%% request/7 (one-shot: open + request + close)
+%%--------------------------------------------------------------------
+
+one_shot_test_() ->
+    {foreach,
+        fun() ->
+            meck:new(gun, []),
+            [gun]
+        end,
+        fun meck:unload/1, [
+            {"opens, requests, and closes on success", fun() ->
+                meck:expect(gun, open, fun(_, _, _) -> {ok, conn} end),
+                meck:expect(gun, await_up, fun(_, _) -> {ok, http} end),
+                meck:expect(gun, get, fun(_, _, _) -> stream end),
+                meck:expect(gun, await, fun(_, _, _) -> {response, fin, 200, []} end),
+                meck:expect(gun, close, fun(_) -> ok end),
+                ?assertEqual(
+                    {ok, {{http_version, 200, "OK"}, [], <<>>}},
+                    aws_lib_httpc:request("h", 80, get, "/", [], <<>>, #{})
+                ),
+                ?assertEqual(1, meck:num_calls(gun, close, [conn]))
+            end},
+            {"closes the connection even when the request errors", fun() ->
+                meck:expect(gun, open, fun(_, _, _) -> {ok, conn} end),
+                meck:expect(gun, await_up, fun(_, _) -> {ok, http} end),
+                meck:expect(gun, get, fun(_, _, _) -> stream end),
+                meck:expect(gun, await, fun(_, _, _) -> {error, timeout} end),
+                meck:expect(gun, close, fun(_) -> ok end),
+                ?assertEqual(
+                    {error, timeout},
+                    aws_lib_httpc:request("h", 80, get, "/", [], <<>>, #{})
+                ),
+                ?assertEqual(1, meck:num_calls(gun, close, [conn]))
+            end},
+            {"an open failure short-circuits without a request or close", fun() ->
+                meck:expect(gun, open, fun(_, _, _) -> {error, enetunreach} end),
+                ?assertEqual(
+                    {error, {gun_open_failed, enetunreach}},
+                    aws_lib_httpc:request("h", 80, get, "/", [], <<>>, #{})
+                ),
+                ?assertEqual(0, meck:num_calls(gun, close, '_'))
+            end}
+        ]}.


### PR DESCRIPTION
Fixes #95.

The Gun request lifecycle -- `gun:open` -> `await_up` -> request -> `await` -> `await_body` -> `close` -- was open-coded in the AWS API path (`aws_lib`) and in three near-identical metadata-service sites (`aws_lib_config`). That duplication caused real bugs (the `await_body` error handling had to be fixed in three places, #90) and drift (connect timeouts differed between paths).

## What changed

Introduce `aws_lib_httpc` as the single owner of the Gun lifecycle:

- `open/3` -- open + `await_up`, with `{gun_open_failed, _}` / `{gun_connection_failed, _}` wrapping
- `request/6` -- one request-and-read on an open connection (header normalization + the `await`/`await_body` dance and its error handling, in one place)
- `request/7` -- one-shot open / request / close
- `close/1`

The connection handle is an **opaque `conn()`**, so no caller can reach around the boundary and issue its own Gun calls on it -- which keeps the "one place owns Gun" invariant enforceable (dialyzer flags any module that tries). This also gives the handle room to grow (e.g. to carry host/port for stale-connection reconnect) without breaking callers, which sets up #91 and #107.

The AWS API path, the two-step connection API, and all three metadata sites now route through `aws_lib_httpc`; no direct `gun:` call remains outside it. Net -164 lines across the two existing modules.

## Behavior notes (caller-transparent)

Two deliberate changes fall out of unifying the paths:

- metadata-service connection errors are now wrapped as `{gun_open_failed, _}` / `{gun_connection_failed, _}` (matching the API path; callers propagate them opaquely and do not inspect the reason)
- `gun:put` is issued at arity 5 everywhere (the metadata PUT was arity 4); the affected test mocks were updated

The short IMDS connect timeout (5000ms) is preserved as-is -- unifying the timeout *value* would be a behavior change and is left as possible follow-up.

## Testing

- new `aws_lib_httpc` unit tests (13): open wrapping (success + both failure modes), the request dance (fin/nofin, `await` error, `await_body` error, raise-safety), header normalization, method dispatch, and one-shot close-on-all-paths
- full eunit suite passes (416); dialyzer is at the pre-existing baseline with no new warnings and none in the changed/new modules; the `await_body`-error and raise-safety tests are non-vacuous (they fail against a hard-matched / catch-less variant)
