### PR TITLE
Reuse one connection across API request retries

### DIFF
--- a/src/aws_lib.erl
+++ b/src/aws_lib.erl
@@ -421,6 +421,35 @@ ensure_credentials_valid(State) ->
     State :: aws_state()
 ) -> {ok, {headers(), term()}, aws_state()} | result_error().
 perform_request_direct(Service, Method, Headers, Path, Body, Options, Host, State0) ->
+    case prepare_signed_request(Service, Method, Headers, Path, Body, Options, Host, State0) of
+        {ok, URI, SignedHeaders, Options1, State1} ->
+            case gun_request(Method, URI, SignedHeaders, Body, Options1) of
+                {ok, Response} ->
+                    {ok, Response, State1};
+                Error ->
+                    Error
+            end;
+        {error, _} = Error ->
+            Error
+    end.
+
+-spec prepare_signed_request(
+    Service :: string(),
+    Method :: method(),
+    Headers :: headers(),
+    Path :: path(),
+    Body :: body(),
+    Options :: http_options(),
+    Host :: string() | undefined,
+    State :: aws_state()
+) ->
+    {ok, URI :: string(), headers(), http_options(), aws_state()}
+    | {error, term()}.
+%% Ensure credentials, resolve the region, build the endpoint URI, and sign the
+%% request headers. Shared by the one-shot path (perform_request_direct/8) and
+%% the connection-reusing retry path (perform_request_reuse/8); it performs no
+%% network I/O of its own beyond a possible credential refresh.
+prepare_signed_request(Service, Method, Headers, Path, Body, Options, Host, State0) ->
     % Ensure we have credentials
     State1 =
         case has_credentials(State0) of
@@ -464,12 +493,7 @@ perform_request_direct(Service, Method, Headers, Path, Body, Options, Host, Stat
             of
                 {ok, SignedHeaders} ->
                     Options1 = ensure_timeout_option(Options, State1),
-                    case gun_request(Method, URI, SignedHeaders, Body, Options1) of
-                        {ok, Response} ->
-                            {ok, Response, State1};
-                        Error ->
-                            Error
-                    end;
+                    {ok, URI, SignedHeaders, Options1, State1};
                 {error, _} = Error ->
                     Error
             end;
@@ -775,17 +799,46 @@ instance_volumes(State0 = #aws_state{config = Config0}) ->
     {ok, list(), aws_state()} | {error, term()}.
 %% @doc Invoke an API call to an AWS service with retries.
 %% @end
-api_request_with_retries(_Service, _Method, _Path, _Body, _Headers, Retries, _WaitTime, _State) when
+api_request_with_retries(Service, Method, Path, Body, Headers, Retries, WaitTime, State) ->
+    %% Open a single connection and reuse it across the whole retry sequence
+    %% instead of opening a fresh TCP+TLS connection per attempt (issue #91).
+    %% The connection is threaded as the extra argument, starting as `undefined'
+    %% (nothing open yet), and is closed however the sequence ends.
+    api_request_with_retries(
+        Service, Method, Path, Body, Headers, Retries, WaitTime, State, undefined
+    ).
+
+-spec api_request_with_retries(
+    Service :: string(),
+    Method :: method(),
+    Path :: path(),
+    Body :: body(),
+    Headers :: headers(),
+    Retries :: integer(),
+    WaitTime :: integer(),
+    State :: aws_state(),
+    Conn :: aws_lib_httpc:conn() | undefined
+) ->
+    {ok, list(), aws_state()} | {error, term()}.
+api_request_with_retries(
+    _Service, _Method, _Path, _Body, _Headers, Retries, _WaitTime, _State, Conn
+) when
     Retries =< 0
 ->
+    close_if_open(Conn),
     ?LOG_ERROR("Request to AWS service has failed after ~b retries", [?MAX_RETRIES]),
     {error, "AWS service is unavailable"};
-api_request_with_retries(Service, Method, Path, Body, Headers, Retries, WaitTime, State0) ->
+api_request_with_retries(Service, Method, Path, Body, Headers, Retries, WaitTime, State0, Conn0) ->
     case ensure_credentials_valid(State0) of
         {ok, State1} ->
-            case request(Service, Method, Path, Body, Headers, State1) of
+            {Result, Conn1} =
+                perform_request_reuse(Service, Method, Headers, Path, Body, [], State1, Conn0),
+            case Result of
                 {ok, {_Headers, Payload}, State2} ->
                     ?LOG_DEBUG("AWS request: ~ts~nResponse: ~tp", [Path, Payload]),
+                    %% Success ends the unit of work: close the connection rather
+                    %% than keep it alive (this is bounded reuse, not a pool).
+                    close_if_open(Conn1),
                     {ok, Payload, State2};
                 {error, Message, Response} ->
                     %% Message may be a status string (from format_response/1
@@ -803,13 +856,95 @@ api_request_with_retries(Service, Method, Path, Body, Headers, Retries, WaitTime
                     end,
                     ?LOG_WARNING("Will retry AWS request, remaining retries: ~b", [Retries]),
                     timer:sleep(WaitTime),
+                    %% perform_request_reuse/8 hands back a live connection after
+                    %% an HTTP-level error (reused on the next attempt) or
+                    %% `undefined' after a transport failure (reopened next attempt).
                     api_request_with_retries(
-                        Service, Method, Path, Body, Headers, Retries - 1, WaitTime, State1
+                        Service, Method, Path, Body, Headers, Retries - 1, WaitTime, State1, Conn1
                     )
             end;
         {error, Reason} ->
+            close_if_open(Conn0),
             {error, {credentials, Reason}}
     end.
+
+%% Perform one request attempt on a reusable connection. Opens a connection when
+%% none is carried and reuses the carried one otherwise. Returns the same result
+%% shape as request/6 together with the connection to carry into the next
+%% attempt: the connection after an HTTP-level error (so the retry reuses it), or
+%% `undefined' after a transport failure (so the retry reopens). The connection
+%% is opened with `retry => 0' so a dropped socket terminates the Gun process; a
+%% request on a since-dead connection then fails fast through gun:await's process
+%% monitor ({error, {down, _}}) and is reopened on the next attempt, so no
+%% separate liveness check is needed.
+-spec perform_request_reuse(
+    Service :: string(),
+    Method :: method(),
+    Headers :: headers(),
+    Path :: path(),
+    Body :: body(),
+    Options :: http_options(),
+    State :: aws_state(),
+    Conn :: aws_lib_httpc:conn() | undefined
+) ->
+    {{ok, {headers(), term()}, aws_state()} | result_error(), aws_lib_httpc:conn() | undefined}.
+perform_request_reuse(Service, Method, Headers, Path, Body, Options, State0, Conn0) ->
+    case prepare_signed_request(Service, Method, Headers, Path, Body, Options, undefined, State0) of
+        {ok, URI, SignedHeaders, Options1, State1} ->
+            case aws_lib_uri:parse(URI) of
+                {ok, Uri} ->
+                    Host = aws_lib_uri:host(Uri),
+                    Port = aws_lib_uri:port(Uri),
+                    Target = aws_lib_uri:target(Uri),
+                    OpenOpts = (gun_open_opts(Port, Options1))#{retry => 0},
+                    case ensure_open(Conn0, Host, Port, OpenOpts) of
+                        {ok, Conn1} ->
+                            Timeout = proplists:get_value(
+                                timeout, Options1, ?DEFAULT_API_TIMEOUT
+                            ),
+                            Response = aws_lib_httpc:request(
+                                Conn1, Method, Target, SignedHeaders, Body, Timeout
+                            ),
+                            classify_reuse_response(format_response(Response), State1, Conn1);
+                        {error, Reason} ->
+                            %% Could not (re)open the connection: a transport-level
+                            %% failure that re-enters the retry loop with no
+                            %% connection to carry.
+                            {format_response({error, Reason}), undefined}
+                    end;
+                {error, _Reason} = Error ->
+                    %% A malformed URI never becomes valid on retry, but preserve
+                    %% the pre-existing behaviour of routing it through the retry
+                    %% loop; the connection is unaffected, so carry it forward.
+                    {format_response(Error), Conn0}
+            end;
+        {error, _} = Error ->
+            {Error, Conn0}
+    end.
+
+%% Attach the connection to carry forward based on the request outcome: a 2xx
+%% success or an HTTP-level error leaves the connection intact (kept for reuse);
+%% a transport failure (format_response/1's {error, _, undefined}) makes it
+%% unusable, so close it and carry `undefined' to force a reopen.
+classify_reuse_response({ok, Result}, State, Conn) ->
+    {{ok, Result, State}, Conn};
+classify_reuse_response({error, _Reason, undefined} = Err, _State, Conn) ->
+    aws_lib_httpc:close(Conn),
+    {Err, undefined};
+classify_reuse_response({error, _Message, _Payload} = Err, _State, Conn) ->
+    {Err, Conn}.
+
+%% Reuse the carried connection, or open one when none is carried. A carried
+%% connection is reused as-is: if it has since died, gun:await detects it via its
+%% process monitor and the request returns a transport error that reopens on the
+%% next attempt, so no liveness pre-check is needed here.
+ensure_open(undefined, Host, Port, OpenOpts) ->
+    aws_lib_httpc:open(Host, Port, OpenOpts);
+ensure_open(Conn, _Host, _Port, _OpenOpts) ->
+    {ok, Conn}.
+
+close_if_open(undefined) -> ok;
+close_if_open(Conn) -> aws_lib_httpc:close(Conn).
 
 %% Add the state's AWS API timeout to the request options unless the caller
 %% already passed an explicit `timeout'. A per-request `timeout' option therefore

--- a/src/aws_lib_httpc.erl
+++ b/src/aws_lib_httpc.erl
@@ -35,6 +35,12 @@
     transport => tcp | tls,
     protocols => [http | http2],
     connect_timeout => timeout(),
+    %% Gun's reconnection count. Omitted, gun defaults to 5 (a dropped socket
+    %% reconnects in the background). A bounded reuse caller (issue #91) passes
+    %% 0 so a dropped connection terminates the Gun process instead: a request
+    %% on it then fails fast via gun:await's process monitor ({error, {down,
+    %% _}}) rather than blocking on a background reconnect.
+    retry => non_neg_integer(),
     %% Request (await/await_body) timeout, consulted only by request/7.
     timeout => timeout()
 }.
@@ -58,11 +64,18 @@
 %% @end
 open(Host, Port, Opts) ->
     ConnectTimeout = maps:get(connect_timeout, Opts, infinity),
-    GunOpts = #{
+    GunOpts0 = #{
         transport => maps:get(transport, Opts, tcp),
         protocols => maps:get(protocols, Opts, [http]),
         connect_timeout => ConnectTimeout
     },
+    %% Only override gun's default retry count when the caller asks; existing
+    %% one-shot callers leave it unset and keep gun's default behaviour.
+    GunOpts =
+        case maps:find(retry, Opts) of
+            {ok, Retry} -> GunOpts0#{retry => Retry};
+            error -> GunOpts0
+        end,
     case gun:open(Host, Port, GunOpts) of
         {ok, ConnPid} ->
             case gun:await_up(ConnPid, ConnectTimeout) of

--- a/test/aws_lib_tests.erl
+++ b/test/aws_lib_tests.erl
@@ -718,6 +718,192 @@ api_get_request_test_() ->
         ]
     }.
 
+%% Issue #91: the retry loop reuses one connection across attempts instead of
+%% opening a fresh TCP+TLS connection every time. These tests pin that
+%% behaviour by counting gun:open calls, which is the whole point of the change.
+connection_reuse_across_retries_test_() ->
+    {
+        foreach,
+        fun() ->
+            setup(),
+            meck:new(gun, []),
+            meck:new(aws_lib_config, []),
+            [gun, aws_lib_config]
+        end,
+        fun(Mods) ->
+            teardown(ok),
+            meck:unload(Mods)
+        end,
+        [
+            {"one connection is reused across HTTP-error retries", fun() ->
+                State0 = set_test_credentials("ExpiredKey", "ExpiredAccessKey", undefined, {
+                    {3016, 4, 1}, {12, 0, 0}
+                }),
+                {ok, State} = aws_lib:set_region("us-east-1", State0),
+
+                %% A long-lived pid so the reuse liveness check (is_process_alive)
+                %% sees the connection as alive between attempts.
+                Conn = spawn(fun() ->
+                    receive
+                        stop -> ok
+                    end
+                end),
+                meck:expect(gun, open, fun(_, _, _) -> {ok, Conn} end),
+                meck:expect(gun, close, fun(_) -> ok end),
+                meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
+                meck:expect(gun, get, fun(_Pid, _Path, _Headers) -> nofin end),
+                %% Two 500s (HTTP-level errors, connection stays intact) then a 200.
+                meck:expect(
+                    gun,
+                    await,
+                    3,
+                    meck:seq([
+                        {response, nofin, 500, [{<<"content-type">>, <<"application/json">>}]},
+                        {response, nofin, 500, [{<<"content-type">>, <<"application/json">>}]},
+                        {response, nofin, 200, [{<<"content-type">>, <<"application/json">>}]}
+                    ])
+                ),
+                meck:expect(
+                    gun,
+                    await_body,
+                    3,
+                    meck:seq([
+                        {ok, <<"{\"error\": \"e\"}">>},
+                        {ok, <<"{\"error\": \"e\"}">>},
+                        {ok, <<"{\"data\": \"value\"}">>}
+                    ])
+                ),
+
+                {ok, Body, _State1} = aws_lib:api_get_request("AWS", "API", State),
+                ?assertEqual([{"data", "value"}], Body),
+                %% Three attempts, but the connection was opened exactly once and
+                %% reused for the two retries.
+                ?assertEqual(1, meck:num_calls(gun, open, '_')),
+                %% Opened once and closed once (on the terminating success).
+                ?assertEqual(1, meck:num_calls(gun, close, '_')),
+                Conn ! stop,
+                meck:validate(gun)
+            end},
+            {"a transport failure reopens the connection on the next attempt", fun() ->
+                State0 = set_test_credentials("ExpiredKey", "ExpiredAccessKey", undefined, {
+                    {3016, 4, 1}, {12, 0, 0}
+                }),
+                {ok, State} = aws_lib:set_region("us-east-1", State0),
+
+                Conn = spawn(fun() ->
+                    receive
+                        stop -> ok
+                    end
+                end),
+                meck:expect(gun, open, fun(_, _, _) -> {ok, Conn} end),
+                meck:expect(gun, close, fun(_) -> ok end),
+                meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
+                meck:expect(gun, get, fun(_Pid, _Path, _Headers) -> nofin end),
+                %% A transport error (await returns {error, _}) makes the
+                %% connection unusable, so it is closed and reopened; then a 200.
+                meck:expect(
+                    gun,
+                    await,
+                    3,
+                    meck:seq([
+                        {error, "network error"},
+                        {response, nofin, 200, [{<<"content-type">>, <<"application/json">>}]}
+                    ])
+                ),
+                meck:expect(
+                    gun,
+                    await_body,
+                    fun(_Pid, _, _) -> {ok, <<"{\"data\": \"value\"}">>} end
+                ),
+
+                {ok, Body, _State1} = aws_lib:api_get_request("AWS", "API", State),
+                ?assertEqual([{"data", "value"}], Body),
+                %% One transport failure -> a second open (reopen); two total.
+                ?assertEqual(2, meck:num_calls(gun, open, '_')),
+                Conn ! stop,
+                meck:validate(gun)
+            end},
+            {"a connection that died between attempts is detected and reopened", fun() ->
+                State0 = set_test_credentials("ExpiredKey", "ExpiredAccessKey", undefined, {
+                    {3016, 4, 1}, {12, 0, 0}
+                }),
+                {ok, State} = aws_lib:set_region("us-east-1", State0),
+
+                Conn = spawn(fun() ->
+                    receive
+                        stop -> ok
+                    end
+                end),
+                meck:expect(gun, open, fun(_, _, _) -> {ok, Conn} end),
+                meck:expect(gun, close, fun(_) -> ok end),
+                meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
+                meck:expect(gun, get, fun(_Pid, _Path, _Headers) -> nofin end),
+                %% Attempt 1: HTTP 500 (connection stays intact, carried forward).
+                %% Attempt 2: the carried connection has since died, which gun
+                %% surfaces as {error, {down, _}} from await's process monitor --
+                %% a transport failure that closes and reopens. Attempt 3: 200 on
+                %% the reopened connection.
+                meck:expect(
+                    gun,
+                    await,
+                    3,
+                    meck:seq([
+                        {response, nofin, 500, [{<<"content-type">>, <<"application/json">>}]},
+                        {error, {down, noproc}},
+                        {response, nofin, 200, [{<<"content-type">>, <<"application/json">>}]}
+                    ])
+                ),
+                meck:expect(
+                    gun,
+                    await_body,
+                    3,
+                    meck:seq([
+                        {ok, <<"{\"error\": \"e\"}">>},
+                        {ok, <<"{\"data\": \"value\"}">>}
+                    ])
+                ),
+
+                {ok, Body, _State1} = aws_lib:api_get_request("AWS", "API", State),
+                ?assertEqual([{"data", "value"}], Body),
+                %% Opened once up front; the {down, _} on attempt 2 forced exactly
+                %% one reopen -- two opens total. The HTTP 500 on attempt 1 did
+                %% NOT reopen (that connection was still usable).
+                ?assertEqual(2, meck:num_calls(gun, open, '_')),
+                Conn ! stop,
+                meck:validate(gun)
+            end},
+            {"retry => 0 is passed to the reused connection's open options", fun() ->
+                State0 = set_test_credentials("ExpiredKey", "ExpiredAccessKey", undefined, {
+                    {3016, 4, 1}, {12, 0, 0}
+                }),
+                {ok, State} = aws_lib:set_region("us-east-1", State0),
+
+                Self = self(),
+                Conn = spawn(fun() ->
+                    receive
+                        stop -> ok
+                    end
+                end),
+                meck:expect(gun, open, fun(_, _, Opts) ->
+                    Self ! {open_opts, Opts},
+                    {ok, Conn}
+                end),
+                meck:expect(gun, close, fun(_) -> ok end),
+                meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
+                meck:expect(gun, get, fun(_Pid, _Path, _Headers) -> nofin end),
+                meck:expect(gun, await, fun(_Pid, _, _) -> {response, fin, 200, []} end),
+
+                {ok, _, _} = aws_lib:api_get_request("AWS", "API", State),
+                receive
+                    {open_opts, Opts} -> ?assertEqual(0, maps:get(retry, Opts))
+                after 1000 -> ?assert(false)
+                end,
+                Conn ! stop,
+                meck:validate(gun)
+            end}
+        ]
+    }.
+
 ensure_credentials_valid_test_() ->
     {
         foreach,


### PR DESCRIPTION
Fixes #91.

The retry loop in `api_request_with_retries` opened a fresh TCP+TLS connection for every attempt through `gun_request/5` and tore it down immediately after. A throttled or 5xx endpoint retried up to five times paid a full TLS handshake (50-150ms) on each attempt -- up to ~750ms of handshake overhead in a single logical request.

## What changed

Thread a single connection through the whole retry sequence: open once, reuse it across attempts, close it when the sequence ends (success, retry-exhaustion, or a credentials error). The unit of work is one logical request -- this is bounded reuse, not a connection pool (we have deliberately decided against a pool for this plugin; see #91/#107).

Per-attempt outcome:

- **2xx success** -- close the connection, return
- **HTTP-level error** (non-2xx, transport intact) -- reuse the warm connection on the next attempt (the win: a retried 429/5xx no longer re-handshakes)
- **transport failure** -- close and reopen before the next attempt

### Stale-connection handling

The reuse connection is opened with `retry => 0`, so a socket that drops between attempts terminates the Gun process instead of silently background-reconnecting. A request issued on a since-dead connection then fails fast through `gun:await`'s process monitor (`{error, {down, _}}`), which the loop classifies as a transport failure and reopens on the next attempt. This leans on Gun's own request/await contract rather than inspecting connection liveness (no `is_process_alive`, no `gun:info` state poking).

### Refactor

Extract `prepare_signed_request/8` (ensure credentials, resolve region, build the endpoint URI, sign headers) so the one-shot path and the reuse path share it. `perform_request_direct/8` and the public `request/6,7,8` one-shot API are behaviour-preserving. `aws_lib_httpc` gains a `retry` open option, applied only when the caller sets it, so existing one-shot callers keep Gun's default.

## Testing

- new tests (4): connection reused across HTTP-error retries (one `gun:open` for three attempts), reopen on transport failure, a connection that dies between attempts detected via `gun:await`'s `{down, _}` and reopened, and `retry => 0` threaded into the reuse open options; non-vacuity of the open-count assertions confirmed
- full eunit suite passes (481); dialyzer at the pre-existing baseline with no new warnings and none in the changed modules; xref clean
