### PR TITLE
Reuse a connection across the boot ARN-resolution pass

### DIFF
--- a/include/aws_lib.hrl
+++ b/include/aws_lib.hrl
@@ -106,7 +106,14 @@
 
 -record(aws_state, {
     credentials :: aws_credentials() | undefined,
-    config :: aws_config() | undefined
+    config :: aws_config() | undefined,
+    %% A reusable connection carried across a bounded unit of work (e.g. the
+    %% boot ARN-resolution pass). `undefined' = one-shot mode (the default for
+    %% all callers that do not opt in). `none' = reuse mode armed but no
+    %% connection cached yet. `{Conn, Host, Port}' = a cached connection to the
+    %% given endpoint. api_request_with_retries seeds from and writes back to
+    %% this field when it is not `undefined'.
+    reuse_conn :: {aws_lib_httpc:conn(), string(), inet:port_number()} | none | undefined
 }).
 %% Type aws_state() and related result types are defined in aws_lib.erl
 

--- a/src/aws_arn_config.erl
+++ b/src/aws_arn_config.erl
@@ -26,9 +26,7 @@ process_arns() ->
             {error, Error, {iam_role_result, assumed}} ->
                 ?AWS_LOG_ERROR("~tp", [Error]);
             {error, Error, {iam_role_result, not_assumed}} ->
-                ?AWS_LOG_ERROR("~tp", [Error]);
-            Unexpected ->
-                ?AWS_LOG_ERROR("unexpected result: ~tp", [Unexpected])
+                ?AWS_LOG_ERROR("~tp", [Error])
         end
     catch
         Class:Reason:Stacktrace ->

--- a/src/aws_arn_config.erl
+++ b/src/aws_arn_config.erl
@@ -23,8 +23,6 @@ process_arns() ->
                 ?AWS_LOG_INFO("success");
             {ok, {iam_role_result, not_assumed}} ->
                 ?AWS_LOG_INFO("success");
-            {error, credentials, _} = Error ->
-                ?AWS_LOG_ERROR("~tp", [Error]);
             {error, Error, {iam_role_result, assumed}} ->
                 ?AWS_LOG_ERROR("~tp", [Error]);
             {error, Error, {iam_role_result, not_assumed}} ->
@@ -78,18 +76,22 @@ process_arn_config({handle_env_arns, ArnList, ArnConfig}) ->
         {handle_assume_role, maybe_assume_role({arn_config, ArnConfig, State})}, ArnList
     ).
 
-process_arn_config({handle_assume_role, {ok, AssumeRoleResult, State}}, ArnList) ->
-    handle_arn_handlers_result(run_arn_handlers(ArnList, State), AssumeRoleResult);
+process_arn_config({handle_assume_role, {ok, AssumeRoleResult, State0}}, ArnList) ->
+    State1 = aws_lib:enable_connection_reuse(State0),
+    Result = run_arn_handlers(ArnList, State1),
+    handle_arn_handlers_result(Result, AssumeRoleResult);
 process_arn_config({handle_assume_role, {error, _}} = Error, _ArnList) ->
     {error, Error, {iam_role_result, not_assumed}}.
 
-handle_arn_handlers_result(ok, AssumeRoleResult) ->
+handle_arn_handlers_result({ok, State}, AssumeRoleResult) ->
+    _ = aws_lib:close_reuse_connection(State),
     {ok, {iam_role_result, AssumeRoleResult}};
-handle_arn_handlers_result({error, Error}, AssumeRoleResult) ->
+handle_arn_handlers_result({error, Error, State}, AssumeRoleResult) ->
+    _ = aws_lib:close_reuse_connection(State),
     {error, Error, {iam_role_result, AssumeRoleResult}}.
 
-run_arn_handlers([], _State) ->
-    ok;
+run_arn_handlers([], State) ->
+    {ok, State};
 run_arn_handlers([{Mod, undefined, _SchemaKey, Args} | Rest], State) ->
     %% Pure-sink / self-resolving handler. The only such handler is the oauth2
     %% providers map (aws_arn_config_oauth2:run/4), which resolves a map of ARNs
@@ -100,8 +102,8 @@ run_arn_handlers([{Mod, undefined, _SchemaKey, Args} | Rest], State) ->
     case erlang:apply(Mod, run, Args ++ [State]) of
         {ok, State1} ->
             run_arn_handlers(Rest, State1);
-        Error ->
-            Error
+        {error, _} = Error ->
+            {error, Error, State}
     end;
 run_arn_handlers([{Mod, Arn, SchemaKey, Args} | Rest], State) ->
     case aws_arn_util:resolve_arn(Arn, State) of
@@ -109,11 +111,11 @@ run_arn_handlers([{Mod, Arn, SchemaKey, Args} | Rest], State) ->
             case erlang:apply(Mod, run, [ArnData | Args]) of
                 ok ->
                     run_arn_handlers(Rest, State1);
-                Error ->
-                    Error
+                {error, _} = Error ->
+                    {error, Error, State1}
             end;
-        Error ->
-            get_resolve_arn_error(Arn, SchemaKey, Error)
+        {error, _} = Error ->
+            {error, get_resolve_arn_error(Arn, SchemaKey, Error), State}
     end.
 
 get_resolve_arn_error(Arn, SchemaKey, {error, E} = Error) ->
@@ -122,4 +124,4 @@ get_resolve_arn_error(Arn, SchemaKey, {error, E} = Error) ->
         [Arn, SchemaKey, E]
     ),
     ErrMsg1 = rabbit_data_coercion:to_utf8_binary(ErrMsg0),
-    {error, {ErrMsg1, Error}}.
+    {ErrMsg1, Error}.

--- a/src/aws_lib.erl
+++ b/src/aws_lib.erl
@@ -34,7 +34,9 @@
     direct_request/7,
     endpoint/4,
     sign_headers/10,
-    instance_volumes/1
+    instance_volumes/1,
+    enable_connection_reuse/1,
+    close_reuse_connection/1
 ]).
 
 -export_type([aws_state/0]).
@@ -103,6 +105,27 @@ get_credentials(#aws_state{credentials = undefined}) ->
     {error, undefined};
 get_credentials(#aws_state{credentials = Creds}) ->
     {ok, Creds}.
+
+-spec enable_connection_reuse(State :: aws_state()) -> aws_state().
+%% @doc Arm the state for connection reuse: subsequent api_get_request /
+%% api_post_request calls that target the same Host:Port reuse a single
+%% connection across calls instead of opening a fresh one each time. The caller
+%% MUST call close_reuse_connection/1 when the unit of work is complete.
+%% @end
+enable_connection_reuse(State) ->
+    State#aws_state{reuse_conn = none}.
+
+-spec close_reuse_connection(State :: aws_state()) -> aws_state().
+%% @doc Close any connection held in the reuse slot and clear it, returning the
+%% state to one-shot mode. Safe to call when no connection is held.
+%% @end
+close_reuse_connection(#aws_state{reuse_conn = undefined} = State) ->
+    State;
+close_reuse_connection(#aws_state{reuse_conn = none} = State) ->
+    State#aws_state{reuse_conn = undefined};
+close_reuse_connection(#aws_state{reuse_conn = {Conn, _Host, _Port}} = State) ->
+    aws_lib_httpc:close(Conn),
+    State#aws_state{reuse_conn = undefined}.
 
 %%====================================================================
 %% Legacy functions - to be updated
@@ -802,10 +825,12 @@ instance_volumes(State0 = #aws_state{config = Config0}) ->
 api_request_with_retries(Service, Method, Path, Body, Headers, Retries, WaitTime, State) ->
     %% Open a single connection and reuse it across the whole retry sequence
     %% instead of opening a fresh TCP+TLS connection per attempt (issue #91).
-    %% The connection is threaded as the extra argument, starting as `undefined'
-    %% (nothing open yet), and is closed however the sequence ends.
+    %% When the state carries a reuse_conn (cross-request reuse, issue #107),
+    %% seed from it so the first attempt avoids a fresh handshake; otherwise
+    %% start with `undefined' (nothing open yet, opened lazily on first attempt).
+    Conn0 = seed_conn_from_state(State),
     api_request_with_retries(
-        Service, Method, Path, Body, Headers, Retries, WaitTime, State, undefined
+        Service, Method, Path, Body, Headers, Retries, WaitTime, State, Conn0
     ).
 
 -spec api_request_with_retries(
@@ -836,10 +861,8 @@ api_request_with_retries(Service, Method, Path, Body, Headers, Retries, WaitTime
             case Result of
                 {ok, {_Headers, Payload}, State2} ->
                     ?LOG_DEBUG("AWS request: ~ts~nResponse: ~tp", [Path, Payload]),
-                    %% Success ends the unit of work: close the connection rather
-                    %% than keep it alive (this is bounded reuse, not a pool).
-                    close_if_open(Conn1),
-                    {ok, Payload, State2};
+                    State3 = finish_conn_success(Conn1, State2),
+                    {ok, Payload, State3};
                 {error, Message, Response} ->
                     %% Message may be a status string (from format_response/1
                     %% on an HTTP error) or a tuple such as
@@ -869,14 +892,14 @@ api_request_with_retries(Service, Method, Path, Body, Headers, Retries, WaitTime
     end.
 
 %% Perform one request attempt on a reusable connection. Opens a connection when
-%% none is carried and reuses the carried one otherwise. Returns the same result
-%% shape as request/6 together with the connection to carry into the next
-%% attempt: the connection after an HTTP-level error (so the retry reuses it), or
+%% none is carried (or the carried one targets a different host) and reuses the
+%% carried one otherwise. Returns the same result shape as request/6 together
+%% with the connection slot to carry into the next attempt: a live
+%% {Conn, Host, Port} after an HTTP-level error (so the retry reuses it), or
 %% `undefined' after a transport failure (so the retry reopens). The connection
 %% is opened with `retry => 0' so a dropped socket terminates the Gun process; a
 %% request on a since-dead connection then fails fast through gun:await's process
-%% monitor ({error, {down, _}}) and is reopened on the next attempt, so no
-%% separate liveness check is needed.
+%% monitor ({error, {down, _}}) and is reopened on the next attempt.
 -spec perform_request_reuse(
     Service :: string(),
     Method :: method(),
@@ -885,10 +908,13 @@ api_request_with_retries(Service, Method, Path, Body, Headers, Retries, WaitTime
     Body :: body(),
     Options :: http_options(),
     State :: aws_state(),
-    Conn :: aws_lib_httpc:conn() | undefined
+    ConnSlot :: {aws_lib_httpc:conn(), string(), inet:port_number()} | undefined
 ) ->
-    {{ok, {headers(), term()}, aws_state()} | result_error(), aws_lib_httpc:conn() | undefined}.
-perform_request_reuse(Service, Method, Headers, Path, Body, Options, State0, Conn0) ->
+    {
+        {ok, {headers(), term()}, aws_state()} | result_error(),
+        {aws_lib_httpc:conn(), string(), inet:port_number()} | undefined
+    }.
+perform_request_reuse(Service, Method, Headers, Path, Body, Options, State0, ConnSlot0) ->
     case prepare_signed_request(Service, Method, Headers, Path, Body, Options, undefined, State0) of
         {ok, URI, SignedHeaders, Options1, State1} ->
             case aws_lib_uri:parse(URI) of
@@ -897,7 +923,7 @@ perform_request_reuse(Service, Method, Headers, Path, Body, Options, State0, Con
                     Port = aws_lib_uri:port(Uri),
                     Target = aws_lib_uri:target(Uri),
                     OpenOpts = (gun_open_opts(Port, Options1))#{retry => 0},
-                    case ensure_open(Conn0, Host, Port, OpenOpts) of
+                    case ensure_open(ConnSlot0, Host, Port, OpenOpts) of
                         {ok, Conn1} ->
                             Timeout = proplists:get_value(
                                 timeout, Options1, ?DEFAULT_API_TIMEOUT
@@ -905,46 +931,66 @@ perform_request_reuse(Service, Method, Headers, Path, Body, Options, State0, Con
                             Response = aws_lib_httpc:request(
                                 Conn1, Method, Target, SignedHeaders, Body, Timeout
                             ),
-                            classify_reuse_response(format_response(Response), State1, Conn1);
+                            classify_reuse_response(
+                                format_response(Response), State1, {Conn1, Host, Port}
+                            );
                         {error, Reason} ->
-                            %% Could not (re)open the connection: a transport-level
-                            %% failure that re-enters the retry loop with no
-                            %% connection to carry.
                             {format_response({error, Reason}), undefined}
                     end;
                 {error, _Reason} = Error ->
-                    %% A malformed URI never becomes valid on retry, but preserve
-                    %% the pre-existing behaviour of routing it through the retry
-                    %% loop; the connection is unaffected, so carry it forward.
-                    {format_response(Error), Conn0}
+                    {format_response(Error), ConnSlot0}
             end;
         {error, _} = Error ->
-            {Error, Conn0}
+            {Error, ConnSlot0}
     end.
 
-%% Attach the connection to carry forward based on the request outcome: a 2xx
-%% success or an HTTP-level error leaves the connection intact (kept for reuse);
-%% a transport failure (format_response/1's {error, _, undefined}) makes it
-%% unusable, so close it and carry `undefined' to force a reopen.
-classify_reuse_response({ok, Result}, State, Conn) ->
-    {{ok, Result, State}, Conn};
-classify_reuse_response({error, _Reason, undefined} = Err, _State, Conn) ->
+%% Attach the connection slot to carry forward based on the request outcome:
+%% success or an HTTP-level error leaves the connection intact; a transport
+%% failure (format_response/1's {error, _, undefined}) makes it unusable.
+classify_reuse_response({ok, Result}, State, ConnSlot) ->
+    {{ok, Result, State}, ConnSlot};
+classify_reuse_response({error, _Reason, undefined} = Err, _State, {Conn, _, _}) ->
     aws_lib_httpc:close(Conn),
     {Err, undefined};
-classify_reuse_response({error, _Message, _Payload} = Err, _State, Conn) ->
-    {Err, Conn}.
+classify_reuse_response({error, _Message, _Payload} = Err, _State, ConnSlot) ->
+    {Err, ConnSlot}.
 
-%% Reuse the carried connection, or open one when none is carried. A carried
-%% connection is reused as-is: if it has since died, gun:await detects it via its
-%% process monitor and the request returns a transport error that reopens on the
-%% next attempt, so no liveness pre-check is needed here.
+%% Return a usable connection to Host:Port. If the carried slot targets the same
+%% host, reuse it; if it targets a different host (cross-service boot pass),
+%% close the old one and open fresh; if none is carried, open fresh. A carried
+%% connection is reused as-is: if it has since died, gun:await's process monitor
+%% surfaces a transport error and the next attempt reopens.
 ensure_open(undefined, Host, Port, OpenOpts) ->
     aws_lib_httpc:open(Host, Port, OpenOpts);
-ensure_open(Conn, _Host, _Port, _OpenOpts) ->
-    {ok, Conn}.
+ensure_open({Conn, Host, Port}, Host, Port, _OpenOpts) ->
+    {ok, Conn};
+ensure_open({OldConn, _OldHost, _OldPort}, Host, Port, OpenOpts) ->
+    aws_lib_httpc:close(OldConn),
+    aws_lib_httpc:open(Host, Port, OpenOpts).
 
 close_if_open(undefined) -> ok;
-close_if_open(Conn) -> aws_lib_httpc:close(Conn).
+close_if_open({Conn, _Host, _Port}) -> aws_lib_httpc:close(Conn).
+
+%% Seed the retry loop's connection slot from the state's reuse_conn. In
+%% one-shot mode (reuse_conn = undefined, the default) this returns `undefined'
+%% and the loop opens fresh on the first attempt. In reuse mode (none or a
+%% cached {Conn, Host, Port}) the state's slot is handed in so the first attempt
+%% avoids a handshake when possible.
+seed_conn_from_state(#aws_state{reuse_conn = undefined}) ->
+    undefined;
+seed_conn_from_state(#aws_state{reuse_conn = none}) ->
+    undefined;
+seed_conn_from_state(#aws_state{reuse_conn = ConnSlot}) ->
+    ConnSlot.
+
+%% On success: in reuse mode, write the live connection back into the state so
+%% the next api_*_request call in the same unit of work reuses it. In one-shot
+%% mode (reuse_conn = undefined), close the connection.
+finish_conn_success(ConnSlot, #aws_state{reuse_conn = undefined} = State) ->
+    close_if_open(ConnSlot),
+    State;
+finish_conn_success(ConnSlot, State) ->
+    State#aws_state{reuse_conn = ConnSlot}.
 
 %% Add the state's AWS API timeout to the request options unless the caller
 %% already passed an explicit `timeout'. A per-request `timeout' option therefore

--- a/test/aws_arn_config_tests.erl
+++ b/test/aws_arn_config_tests.erl
@@ -386,10 +386,11 @@ different_host_arns_reopen() ->
     meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
     meck:expect(gun, get, fun(_, _, _) -> stream_ref end),
     meck:expect(gun, post, fun(_, _, _, _, _) -> stream_ref end),
-    %% text/plain avoids maybe_decode_body's JSON decode, so the raw binary
-    %% reaches aws_sms:make_request which calls rabbit_json:decode itself.
+    %% Secrets Manager replies with JSON; maybe_decode_body decodes it into the
+    %% string-keyed proplist aws_sms:find_secret/1 matches (issue #131 fixed the
+    %% earlier double-decode, so aws_sms no longer decodes it a second time).
     meck:expect(gun, await, fun(_, _, _) ->
-        {response, nofin, 200, [{<<"content-type">>, <<"text/plain">>}]}
+        {response, nofin, 200, [{<<"content-type">>, <<"application/x-amz-json-1.1">>}]}
     end),
     meck:expect(gun, await_body, fun(_, _, _) ->
         {ok, <<"{\"SecretString\": \"secret-value\"}">>}
@@ -407,6 +408,9 @@ different_host_arns_reopen() ->
     ?assertMatch({ok, {iam_role_result, assumed}}, Result),
     %% Two different hosts -> two opens.
     ?assertEqual(2, meck:num_calls(gun, open, '_')),
+    %% Two closes: ensure_open closes the S3 connection when it switches to the
+    %% Secrets Manager host, and the end-of-pass close tears the second one down.
+    ?assertEqual(2, meck:num_calls(gun, close, '_')),
     Conn ! stop.
 
 %% The connection is closed at the end of the pass (not leaked).

--- a/test/aws_arn_config_tests.erl
+++ b/test/aws_arn_config_tests.erl
@@ -319,6 +319,16 @@ conn_reuse_setup() ->
         },
         {ok, Creds, Config}
     end),
+    %% Resolve the region deterministically. Without this, do_refresh_credentials
+    %% resolves an undefined region via aws_lib_config:region/1, which falls
+    %% through to the EC2 metadata service when no region is configured in the
+    %% environment. The mocked gun then returns the response body as the
+    %% availability zone, corrupting the endpoint host. This is host-dependent:
+    %% it passes where ~/.aws/config supplies a region but fails in CI where none
+    %% is set.
+    meck:expect(aws_lib_config, region, fun(Config) ->
+        {ok, "us-east-1", Config}
+    end),
     %% Assume-role succeeds trivially.
     meck:expect(aws_iam, assume_role, fun(_RoleArn, State) -> {ok, State} end),
     %% Handler always succeeds.

--- a/test/aws_arn_config_tests.erl
+++ b/test/aws_arn_config_tests.erl
@@ -288,3 +288,140 @@ flush_seen() ->
         {seen, Arn, Key} -> {Arn, Key}
     after 1000 -> erlang:error(resolve_arn_not_called)
     end.
+
+%%--------------------------------------------------------------------
+%% Connection reuse across the boot ARN-resolution pass (issue #107).
+%%
+%% These exercise the full path from process_arn_config through
+%% api_get_request down to gun, counting gun:open calls to prove that
+%% same-host ARNs reuse one connection. gun is mocked; no real network.
+%%--------------------------------------------------------------------
+
+connection_reuse_boot_test_() ->
+    {foreach, fun conn_reuse_setup/0, fun conn_reuse_teardown/1, [
+        fun same_host_arns_reuse_one_connection/0,
+        fun different_host_arns_reopen/0,
+        fun connection_closed_at_end_of_pass/0
+    ]}.
+
+conn_reuse_setup() ->
+    ok = meck:new(gun, []),
+    ok = meck:new(aws_iam, [no_link]),
+    ok = meck:new(aws_lib_config, [passthrough]),
+    ok = meck:new(?HANDLER, [non_strict, no_link]),
+    %% Provide valid credentials so ensure_credentials_valid does not hit IMDS.
+    meck:expect(aws_lib_config, credentials, fun(Config) ->
+        Creds = #aws_credentials{
+            access_key = "AKID",
+            secret_key = "SECRET",
+            security_token = undefined,
+            expiration = {{3016, 1, 1}, {0, 0, 0}}
+        },
+        {ok, Creds, Config}
+    end),
+    %% Assume-role succeeds trivially.
+    meck:expect(aws_iam, assume_role, fun(_RoleArn, State) -> {ok, State} end),
+    %% Handler always succeeds.
+    meck:expect(?HANDLER, run, fun(_Data, _Key, _Sub) -> ok end),
+    ok.
+
+conn_reuse_teardown(_) ->
+    catch meck:unload(?HANDLER),
+    catch meck:unload(gun),
+    catch meck:unload(aws_iam),
+    catch meck:unload(aws_lib_config),
+    ok.
+
+%% Two S3 ARNs in the same region hit the same host (s3.us-east-1.amazonaws.com).
+%% The boot pass should open one connection and reuse it for both resolves.
+same_host_arns_reuse_one_connection() ->
+    Conn = spawn_link(fun() ->
+        receive
+            stop -> ok
+        end
+    end),
+    meck:expect(gun, open, fun(_, _, _) -> {ok, Conn} end),
+    meck:expect(gun, close, fun(_) -> ok end),
+    meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
+    meck:expect(gun, get, fun(_, _, _) -> stream_ref end),
+    meck:expect(gun, await, fun(_, _, _) ->
+        {response, nofin, 200, [{<<"content-type">>, <<"application/xml">>}]}
+    end),
+    meck:expect(gun, await_body, fun(_, _, _) ->
+        {ok, <<"<data>cert-pem</data>">>}
+    end),
+    ArnConfig = [
+        {assume_role_arn, "arn:aws:iam::123456789012:role/r"},
+        {arns, [
+            {?HANDLER, "arn:aws:s3:::bucket/cert1.pem", ssl_cacertfile, [ssl_options, cacertfile]},
+            {?HANDLER, "arn:aws:s3:::bucket/cert2.pem", ssl_certfile, [ssl_options, certfile]}
+        ]}
+    ],
+    Result = aws_arn_config:process_arn_config({handle_env_arn_config, {ok, ArnConfig}}),
+    ?assertMatch({ok, {iam_role_result, assumed}}, Result),
+    ?assertEqual(1, meck:num_calls(gun, open, '_')),
+    Conn ! stop.
+
+%% An S3 ARN and a Secrets Manager ARN hit different hosts (s3.us-east-1 vs
+%% secretsmanager.us-east-1). The pass should close the first connection and
+%% open a second for the different host.
+different_host_arns_reopen() ->
+    Conn = spawn_link(fun() ->
+        receive
+            stop -> ok
+        end
+    end),
+    meck:expect(gun, open, fun(_, _, _) -> {ok, Conn} end),
+    meck:expect(gun, close, fun(_) -> ok end),
+    meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
+    meck:expect(gun, get, fun(_, _, _) -> stream_ref end),
+    meck:expect(gun, post, fun(_, _, _, _, _) -> stream_ref end),
+    %% text/plain avoids maybe_decode_body's JSON decode, so the raw binary
+    %% reaches aws_sms:make_request which calls rabbit_json:decode itself.
+    meck:expect(gun, await, fun(_, _, _) ->
+        {response, nofin, 200, [{<<"content-type">>, <<"text/plain">>}]}
+    end),
+    meck:expect(gun, await_body, fun(_, _, _) ->
+        {ok, <<"{\"SecretString\": \"secret-value\"}">>}
+    end),
+    ArnConfig = [
+        {assume_role_arn, "arn:aws:iam::123456789012:role/r"},
+        {arns, [
+            {?HANDLER, "arn:aws:s3:::bucket/cert.pem", ssl_cacertfile, [ssl_options, cacertfile]},
+            {?HANDLER, "arn:aws:secretsmanager:us-east-1:123456789012:secret:key", ssl_keyfile, [
+                ssl_options, keyfile
+            ]}
+        ]}
+    ],
+    Result = aws_arn_config:process_arn_config({handle_env_arn_config, {ok, ArnConfig}}),
+    ?assertMatch({ok, {iam_role_result, assumed}}, Result),
+    %% Two different hosts -> two opens.
+    ?assertEqual(2, meck:num_calls(gun, open, '_')),
+    Conn ! stop.
+
+%% The connection is closed at the end of the pass (not leaked).
+connection_closed_at_end_of_pass() ->
+    Conn = spawn_link(fun() ->
+        receive
+            stop -> ok
+        end
+    end),
+    meck:expect(gun, open, fun(_, _, _) -> {ok, Conn} end),
+    meck:expect(gun, close, fun(_) -> ok end),
+    meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
+    meck:expect(gun, get, fun(_, _, _) -> stream_ref end),
+    meck:expect(gun, await, fun(_, _, _) ->
+        {response, nofin, 200, [{<<"content-type">>, <<"application/xml">>}]}
+    end),
+    meck:expect(gun, await_body, fun(_, _, _) ->
+        {ok, <<"<data>cert-pem</data>">>}
+    end),
+    ArnConfig = [
+        {assume_role_arn, "arn:aws:iam::123456789012:role/r"},
+        {arns, [
+            {?HANDLER, "arn:aws:s3:::bucket/cert.pem", ssl_cacertfile, [ssl_options, cacertfile]}
+        ]}
+    ],
+    _ = aws_arn_config:process_arn_config({handle_env_arn_config, {ok, ArnConfig}}),
+    ?assertEqual(1, meck:num_calls(gun, close, '_')),
+    Conn ! stop.


### PR DESCRIPTION
Fixes #107.

At boot, `aws_arn_config:run_arn_handlers/2` resolves the configured ARNs sequentially, each resolution reaching `aws_lib:api_get_request` / `api_post_request`. After #91 each logical request still opened and closed its own connection, so a broker configured with several ARNs paid a full TLS handshake per ARN -- even when many resolve against the same regional endpoint (the densest cluster of same-host requests in the plugin).

## What changed

Carry a reusable connection in the threaded `aws_state()`. This keeps every intermediate layer (`aws_arn_util:resolve_arn`, `aws_s3`, `aws_sms`, `aws_acm_pca`) untouched, since `aws_state()` already flows through all of them.

A new `reuse_conn` field holds one of:

- `undefined` -- one-shot mode, the default for every caller that does not opt in (unchanged behaviour)
- `none` -- reuse armed, nothing open yet
- `{Conn, Host, Port}` -- a cached connection to that endpoint

`enable_connection_reuse/1` arms the state; `close_reuse_connection/1` tears the connection down at the end of the unit of work.

In reuse mode, `api_request_with_retries` seeds its connection from the state and, on success, writes the live connection back into the returned state so the next resolution reuses it. `ensure_open/4` reuses a cached connection only when the target Host:Port matches; a different host (for example s3 then secretsmanager) closes the old connection and opens a fresh one. Bounded reuse within one unit of work -- not a pool.

### Stale-connection handling

Inherited from #91: the connection is opened with `retry => 0`, so a dropped socket terminates the Gun process and the next request reopens via `gun:await`'s process monitor (`{error, {down, _}}`). No liveness poking.

### Boot orchestration

`aws_arn_config` arms the state before the pass and closes the connection afterward. `run_arn_handlers/2` now returns `{ok, State}` or `{error, Error, State}` so the accumulated connection is always available for cleanup regardless of outcome. The `{error, credentials, _}` clause in `process_arns/0`, which this return-type narrowing proves unreachable, is removed.

## Behaviour notes for the reviewer

- **One-shot callers are unaffected**: with `reuse_conn` defaulting to `undefined`, the retry loop opens, uses, and closes per logical request exactly as before. All pre-#107 tests pass unchanged
- **State-threading invariant**: reuse depends on each handler threading the returned `aws_state()` forward. `aws_s3` / `aws_sms` / `aws_acm_pca` and `run_arn_handlers` all do; a future handler that drops the returned state would leak its connection until the pass-end close (not a correctness bug, but worth noting)
- **No end-to-end boot CT**: the new tests mock gun and drive `process_arn_config` directly (same level as the existing boot-path tests). The reuse logic is covered; a real multi-ARN broker boot is not exercised in CI

## Testing

- new tests (3): same-host ARNs reuse one connection (one `gun:open` for two resolves), different-host ARNs close and reopen (two opens), connection closed at end of pass (one `gun:close`); both open-count assertions proven non-vacuous
- full eunit suite passes (484); dialyzer at the pre-existing baseline with no new warnings; xref clean

## Related

While writing the integration-level tests here, I uncovered a latent double-decode bug in `aws_sms` / `aws_acm_pca` (they re-decode a body `maybe_decode_body` already decoded after #99) and filed it as #131.
