### PR TITLE
Stop double-decoding JSON responses in aws_sms and aws_acm_pca

### DIFF
--- a/src/aws_acm_pca.erl
+++ b/src/aws_acm_pca.erl
@@ -23,10 +23,13 @@ fetch_certificate(CaArn, Region, State) ->
 make_request(RequestBody, Headers, State) ->
     case aws_lib:api_post_request("acm-pca", "/", RequestBody, Headers, State) of
         {ok, ResponseBody, State1} ->
-            case rabbit_json:decode(ResponseBody) of
-                #{<<"Certificate">> := Certificate} ->
-                    {ok, Certificate, State1};
-                _ ->
+            %% api_post_request already decodes the JSON body
+            %% (aws_lib_json:decode) into a string-keyed proplist, so match it
+            %% directly rather than decoding a second time (issue #131).
+            case lists:keyfind("Certificate", 1, ResponseBody) of
+                {"Certificate", Certificate} ->
+                    {ok, rabbit_data_coercion:to_utf8_binary(Certificate), State1};
+                false ->
                     {error, no_certificate}
             end;
         {error, _} = Error ->

--- a/src/aws_sms.erl
+++ b/src/aws_sms.erl
@@ -24,14 +24,28 @@ fetch_secret(Arn, Region, State) ->
 make_request(RequestBody, Headers, State) ->
     case aws_lib:api_post_request("secretsmanager", "/", RequestBody, Headers, State) of
         {ok, ResponseBody, State1} ->
-            case rabbit_json:decode(ResponseBody) of
-                #{<<"SecretString">> := SecretValue} ->
-                    {ok, SecretValue, State1};
-                #{<<"SecretBinary">> := SecretBinary} ->
-                    {ok, base64:decode(SecretBinary), State1};
-                _ ->
-                    {error, no_secret_value}
+            case find_secret(ResponseBody) of
+                {ok, Secret} ->
+                    {ok, Secret, State1};
+                {error, _} = Error ->
+                    Error
             end;
         {error, _} = Error ->
             Error
+    end.
+
+%% api_post_request already decodes the JSON body (aws_lib_json:decode) into a
+%% string-keyed proplist, so match it directly rather than decoding a second
+%% time (issue #131).
+find_secret(ResponseBody) ->
+    case lists:keyfind("SecretString", 1, ResponseBody) of
+        {"SecretString", SecretValue} ->
+            {ok, rabbit_data_coercion:to_utf8_binary(SecretValue)};
+        false ->
+            case lists:keyfind("SecretBinary", 1, ResponseBody) of
+                {"SecretBinary", SecretBinary} ->
+                    {ok, base64:decode(SecretBinary)};
+                false ->
+                    {error, no_secret_value}
+            end
     end.

--- a/test/aws_acm_pca_tests.erl
+++ b/test/aws_acm_pca_tests.erl
@@ -1,0 +1,63 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+-module(aws_acm_pca_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("aws_lib.hrl").
+
+%%--------------------------------------------------------------------
+%% End-to-end guard for the ACM Private CA response path (issue #131).
+%%
+%% ACM-PCA replies with the `application/x-amz-json-1.1' content type, which
+%% aws_lib:maybe_decode_body/2 now decodes into a string-keyed proplist (since
+%% #99). These cases mock gun so the real api_post_request path runs, then
+%% assert fetch_certificate/3 returns the certificate without a second decode.
+%% Before the fix a second rabbit_json:decode ran on the proplist and crashed
+%% with badarg.
+%%--------------------------------------------------------------------
+
+fetch_certificate_test_() ->
+    {foreach, fun setup/0, fun teardown/1, [
+        fun certificate_is_returned/0,
+        fun missing_certificate_reports_error/0
+    ]}.
+
+setup() ->
+    ok = meck:new(gun, []),
+    meck:expect(gun, open, fun(_, _, _) -> {ok, self()} end),
+    meck:expect(gun, close, fun(_) -> ok end),
+    meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
+    meck:expect(gun, post, fun(_, _, _, _, _) -> stream_ref end),
+    meck:expect(gun, await, fun(_, _, _) ->
+        {response, nofin, 200, [{<<"content-type">>, <<"application/x-amz-json-1.1">>}]}
+    end),
+    ok.
+
+teardown(_) ->
+    catch meck:unload(gun),
+    ok.
+
+%% A state that already carries credentials so ensure_credentials_valid does
+%% not attempt to reach IMDS.
+state() ->
+    {ok, State} = aws_lib:set_credentials("AKID", "SECRET", "TOKEN", aws_lib:new()),
+    State.
+
+certificate_is_returned() ->
+    meck:expect(gun, await_body, fun(_, _, _) ->
+        {ok, <<"{\"Certificate\": \"-----BEGIN CERTIFICATE-----\"}">>}
+    end),
+    Arn = "arn:aws:acm-pca:us-east-1:1:certificate-authority/ca",
+    Result = aws_acm_pca:fetch_certificate(Arn, "us-east-1", state()),
+    ?assertMatch({ok, <<"-----BEGIN CERTIFICATE-----">>, _}, Result).
+
+missing_certificate_reports_error() ->
+    meck:expect(gun, await_body, fun(_, _, _) ->
+        {ok, <<"{\"CertificateChain\": \"chain\"}">>}
+    end),
+    Arn = "arn:aws:acm-pca:us-east-1:1:certificate-authority/ca",
+    Result = aws_acm_pca:fetch_certificate(Arn, "us-east-1", state()),
+    ?assertEqual({error, no_certificate}, Result).

--- a/test/aws_sms_tests.erl
+++ b/test/aws_sms_tests.erl
@@ -1,0 +1,75 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+-module(aws_sms_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("aws_lib.hrl").
+
+%%--------------------------------------------------------------------
+%% End-to-end guard for the Secrets Manager response path (issue #131).
+%%
+%% Secrets Manager replies with the `application/x-amz-json-1.1' content
+%% type, which aws_lib:maybe_decode_body/2 now decodes into a string-keyed
+%% proplist (since #99). These cases mock gun so the real api_post_request
+%% path runs, then assert fetch_secret/3 returns the secret without a second
+%% decode. Before the fix a second rabbit_json:decode ran on the proplist and
+%% crashed with badarg.
+%%--------------------------------------------------------------------
+
+fetch_secret_test_() ->
+    {foreach, fun setup/0, fun teardown/1, [
+        fun secret_string_is_returned/0,
+        fun secret_binary_is_decoded/0,
+        fun missing_secret_reports_error/0
+    ]}.
+
+setup() ->
+    ok = meck:new(gun, []),
+    meck:expect(gun, open, fun(_, _, _) -> {ok, self()} end),
+    meck:expect(gun, close, fun(_) -> ok end),
+    meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
+    meck:expect(gun, post, fun(_, _, _, _, _) -> stream_ref end),
+    meck:expect(gun, await, fun(_, _, _) ->
+        {response, nofin, 200, [{<<"content-type">>, <<"application/x-amz-json-1.1">>}]}
+    end),
+    ok.
+
+teardown(_) ->
+    catch meck:unload(gun),
+    ok.
+
+%% A state that already carries credentials so ensure_credentials_valid does
+%% not attempt to reach IMDS.
+state() ->
+    {ok, State} = aws_lib:set_credentials("AKID", "SECRET", "TOKEN", aws_lib:new()),
+    State.
+
+secret_string_is_returned() ->
+    meck:expect(gun, await_body, fun(_, _, _) ->
+        {ok, <<"{\"SecretString\": \"the-secret-value\"}">>}
+    end),
+    Result = aws_sms:fetch_secret(
+        "arn:aws:secretsmanager:us-east-1:1:secret:s", "us-east-1", state()
+    ),
+    ?assertMatch({ok, <<"the-secret-value">>, _}, Result).
+
+secret_binary_is_decoded() ->
+    Encoded = base64:encode(<<"binary-secret">>),
+    Body = <<"{\"SecretBinary\": \"", Encoded/binary, "\"}">>,
+    meck:expect(gun, await_body, fun(_, _, _) -> {ok, Body} end),
+    Result = aws_sms:fetch_secret(
+        "arn:aws:secretsmanager:us-east-1:1:secret:s", "us-east-1", state()
+    ),
+    ?assertMatch({ok, <<"binary-secret">>, _}, Result).
+
+missing_secret_reports_error() ->
+    meck:expect(gun, await_body, fun(_, _, _) ->
+        {ok, <<"{\"ARN\": \"arn:aws:secretsmanager:us-east-1:1:secret:s\"}">>}
+    end),
+    Result = aws_sms:fetch_secret(
+        "arn:aws:secretsmanager:us-east-1:1:secret:s", "us-east-1", state()
+    ),
+    ?assertEqual({error, no_secret_value}, Result).


### PR DESCRIPTION
Fixes #131

## Problem

`aws_sms:make_request/3` and `aws_acm_pca:make_request/3` call
`rabbit_json:decode/1` on a response body that `aws_lib:api_post_request/5`
has already decoded. Both services reply with the `application/x-amz-json-1.1`
content type, which `maybe_decode_body/2` routes through
`aws_lib_json:decode/1` since #99 (PR #126). The second decode then receives
an Erlang proplist instead of a binary and crashes with `badarg` inside
`iolist_to_binary/1`, so ARN resolution fails:

```
** error:badarg
in function erlang:iolist_to_binary/1
  called as iolist_to_binary([{"SecretString","secret-value"}])
in call from thoas:decode/2
in call from rabbit_json:decode/2
in call from aws_sms:make_request/3
```

## Fix

Match the already-decoded body directly, mirroring the existing idiom in
`aws_iam:parse_assume_role_response/2`. `aws_lib_json:decode/1` returns a
string-keyed proplist (not a `rabbit_json` map), so the callers use
`lists:keyfind/3` and coerce the value back to a binary with
`rabbit_data_coercion:to_utf8_binary/1` to preserve the `{ok, binary(), State}`
contract that downstream consumers (`aws_pem_util`, the secret handlers)
expect.

## Testing

New end-to-end tests for both modules (`aws_sms_tests`, `aws_acm_pca_tests`)
mock gun so the real `api_post_request` path runs and returns an
`x-amz-json-1.1` body, reproducing the original crash. They cover the
`SecretString`, `SecretBinary` (base64), and `Certificate` success paths plus
the missing-value error branches. The pre-existing boot ARN-resolution tests
mock `aws_arn_util:resolve_arn/2` above `api_post_request`, so this path was
never exercised in eunit.

Verified non-vacuous: reintroducing the second decode reproduces the exact
`iolist_to_binary/1` badarg and fails the new tests.

- eunit: 486/486 pass
- dialyzer: baseline (30 warnings, none in the touched modules)
- xref: clean
