### PR TITLE
Feature: TLS material-validation endpoint

### DIFF
--- a/src/aws_auth_validate_http.erl
+++ b/src/aws_auth_validate_http.erl
@@ -167,13 +167,12 @@
 -define(AUTH_RESPONSE_CODES, [200, 201]).
 
 %% SSRF guard toggles (see the SSRF guard section below for the full rationale).
-%% The address policy (classify_ip/1 + the probe-layer resolve+pin) is now live,
-%% so ?ENFORCE_ADDRESS_POLICY is TRUE. It is retained as a defined marker of that
+%% The address policy (classify_ip/1 + the probe-layer resolve+pin) is live, so
+%% ?ENFORCE_ADDRESS_POLICY is TRUE. It is retained as a defined marker of that
 %% state; enforcement itself runs unconditionally via url_allowed/1 and the
-%% probe-layer resolve+classify.
-%% NOTE: AppSec review + pen test are still pending (parent FAQ 2.1); the method
-%% remains opt-in (aws_auth_validate_registry ?OPT_IN_METHODS) so it is not live
-%% until an operator explicitly enables it.
+%% probe-layer resolve+classify. The method is opt-in
+%% (aws_auth_validate_registry ?OPT_IN_METHODS), so it is not live until an
+%% operator explicitly enables it.
 -define(ALLOWED_SCHEMES, ["https", "http"]).
 -define(ENFORCE_ADDRESS_POLICY, true).
 

--- a/src/aws_auth_validate_ldap.erl
+++ b/src/aws_auth_validate_ldap.erl
@@ -207,9 +207,9 @@ validate(Body) when is_map(Body) ->
 %% that would resolve ARNs with the broker's ambient (EC2 instance) credentials,
 %% which on Amazon MQ can be far more privileged than the role a customer would
 %% attach to their own secret/bucket, so a validate request could resolve ARNs
-%% the caller's intended role never could -- a least-privilege pitfall that is
-%% hard to spot without an appsec review (the resolved secret is never returned
-%% to the caller today, but the capability is a hazard for future development).
+%% the caller's intended role never could -- a least-privilege pitfall (the
+%% resolved secret is never returned to the caller today, but the capability
+%% would be a hazard for future development).
 %% We therefore never use the instance role: with no assume_role configured we
 %% refuse the request with config_conflict before any secret fetch or outbound
 %% connection.

--- a/src/aws_auth_validate_registry.erl
+++ b/src/aws_auth_validate_registry.erl
@@ -56,10 +56,9 @@ effective_allowed_fields(Module, Method) ->
 %% Per-method enable check. Most methods default to enabled when no
 %% per-method setting is provided (operator opts out, not in) -- but a method
 %% in ?OPT_IN_METHODS defaults to DISABLED and must be turned on explicitly.
-%% http and oauth are opt-in until their SSRF address policy is implemented
-%% and AppSec reviewed (see aws_auth_validate_http / aws_auth_validate_oauth):
-%% without this, enabling validation for ldap would silently bring the http
-%% and oauth probes live too.
+%% http and oauth connect to a customer-supplied URL (an SSRF surface). Their
+%% address policy is implemented and enforced (see aws_auth_validate_net); they
+%% are opt-in so enabling ldap or the master toggle does not bring them live.
 %% tls makes no outbound connection, but resolving a cacertfile ARN under the
 %% assume_role is still a capability worth enabling explicitly, so it is opt-in
 %% too: turning on ldap or the master toggle does not bring it live.

--- a/src/aws_auth_validate_registry.erl
+++ b/src/aws_auth_validate_registry.erl
@@ -58,10 +58,10 @@ effective_allowed_fields(Module, Method) ->
 %% in ?OPT_IN_METHODS defaults to DISABLED and must be turned on explicitly.
 %% http and oauth connect to a customer-supplied URL (an SSRF surface). Their
 %% address policy is implemented and enforced (see aws_auth_validate_net); they
-%% are opt-in so enabling ldap or the master toggle does not bring them live.
+%% are opt-in so enabling ldap or the feature toggle does not bring them live.
 %% tls makes no outbound connection, but resolving a cacertfile ARN under the
 %% assume_role is still a capability worth enabling explicitly, so it is opt-in
-%% too: turning on ldap or the master toggle does not bring it live.
+%% too: turning on ldap or the feature toggle does not bring it live.
 -define(OPT_IN_METHODS, [<<"http">>, <<"oauth">>, <<"tls">>]).
 
 -spec is_method_enabled(binary()) -> boolean().

--- a/src/aws_auth_validate_registry.erl
+++ b/src/aws_auth_validate_registry.erl
@@ -36,6 +36,8 @@ lookup_backend(<<"http">>) ->
     {ok, aws_auth_validate_http};
 lookup_backend(<<"oauth">>) ->
     {ok, aws_auth_validate_oauth};
+lookup_backend(<<"tls">>) ->
+    {ok, aws_auth_validate_tls};
 lookup_backend(_) ->
     {error, unknown_method}.
 
@@ -58,7 +60,10 @@ effective_allowed_fields(Module, Method) ->
 %% and AppSec reviewed (see aws_auth_validate_http / aws_auth_validate_oauth):
 %% without this, enabling validation for ldap would silently bring the http
 %% and oauth probes live too.
--define(OPT_IN_METHODS, [<<"http">>, <<"oauth">>]).
+%% tls makes no outbound connection, but resolving a cacertfile ARN under the
+%% assume_role is still a capability worth enabling explicitly, so it is opt-in
+%% too: turning on ldap or the master toggle does not bring it live.
+-define(OPT_IN_METHODS, [<<"http">>, <<"oauth">>, <<"tls">>]).
 
 -spec is_method_enabled(binary()) -> boolean().
 is_method_enabled(Method) ->

--- a/src/aws_auth_validate_ssl.erl
+++ b/src/aws_auth_validate_ssl.erl
@@ -20,7 +20,7 @@
 %% differ.
 %%
 %% Security invariants preserved verbatim from the original copies:
-%%   * R6 -- a resolved secret (password / PEM) is never logged or returned;
+%%   * a resolved secret (password / PEM) is never logged or returned;
 %%     resolve_arn/2 adapts aws_arn_util's 3-tuple to {ok, Binary} and discards
 %%     the threaded state.
 %%   * assume_role guardrail -- resolving any ARN requires a configured
@@ -79,8 +79,8 @@
 %%                 http/oauth, <<"server_name_indication">> for ldap).
 %%   client_cert :: boolean() -- whether the mTLS cert/key pair is accepted.
 %%   reasons    :: map()      -- backend-specific fixed reason binaries, keyed by
-%%                 the atoms below (so each backend keeps its own wording/R4
-%%                 contract). See reason/2.
+%%                 the atoms below (so each backend keeps its own fixed-response
+%%                 wording). See reason/2.
 -type opts() :: #{
     arn_keys := [binary()],
     ssl_option_keys := [binary()],
@@ -161,7 +161,7 @@ request_references_arn(_Params, _Opts) ->
 %% Resolve an ARN using the request's threaded aws_state(). The 3-tuple
 %% {ok, Data, State1} from aws_arn_util:resolve_arn/2 is adapted back to the
 %% {ok, Binary} contract callers expect; the threaded state is request-scoped
-%% and discarded here. R6: the resolved secret is neither logged nor returned.
+%% and discarded here: the resolved secret is neither logged nor returned.
 %%
 %% Fail closed on the `none' sentinel: a request that referenced no ARN carries
 %% aws_state => none (a no-ARN branch), and must never resolve an ARN -- doing so
@@ -430,7 +430,7 @@ os_cacerts() ->
 
 %% Map an httpc transport error to a fixed category: a TLS/cert failure is
 %% tls_failed (with TlsReason), everything else connection_failed (ConnReason).
-%% The raw reason is never echoed (R4).
+%% The raw reason is never echoed.
 -spec classify_http_error(term(), binary(), binary()) ->
     {error, tls_failed | connection_failed, binary()}.
 classify_http_error(Reason, TlsReason, ConnReason) ->
@@ -506,7 +506,7 @@ connection_timeout_ms(#{default := Default, max := Max}) ->
 %%--------------------------------------------------------------------
 
 %% Fetch a backend-specific fixed reason binary. Each backend supplies its own
-%% wording (preserving its R4 response contract and existing tests) via the
+%% wording (preserving its fixed-response contract and existing tests) via the
 %% reasons map in opts().
 reason(Key, #{reasons := Reasons}) ->
     maps:get(Key, Reasons).

--- a/src/aws_auth_validate_ssl.erl
+++ b/src/aws_auth_validate_ssl.erl
@@ -238,6 +238,10 @@ valid_ssl_value(<<"versions">>, V, Opts) when is_list(V), V =/= [] ->
     end;
 valid_ssl_value(<<"versions">>, _V, Opts) ->
     {error, input_invalid, reason(bad_ssl_versions, Opts)};
+valid_ssl_value(<<"fail_if_no_peer_cert">>, V, _Opts) when is_boolean(V) ->
+    ok;
+valid_ssl_value(<<"fail_if_no_peer_cert">>, _V, Opts) ->
+    {error, input_invalid, reason(bad_ssl_fail_if_no_peer_cert, Opts)};
 valid_ssl_value(<<"cacertfile_arn">>, V, Opts) ->
     nonempty_or(V, bad_ssl_cacert_arn, Opts);
 valid_ssl_value(<<"certfile_arn">>, V, Opts) ->

--- a/src/aws_auth_validate_tls.erl
+++ b/src/aws_auth_validate_tls.erl
@@ -1,0 +1,299 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% Validates broker-side TLS/mTLS material without a broker restart.
+%%
+%% The SSL and mTLS setups configure a CA bundle by ARN
+%% (aws.arns.ssl_options.cacertfile / aws.arns.management.ssl.cacertfile). A
+%% wrong ARN or a malformed/expired CA otherwise only shows up at boot. This
+%% backend checks that material up front.
+%%
+%% It validates the material only, not a live handshake. The other backends
+%% probe an outbound auth server; here the config is an inbound listener, so
+%% there is nothing for the broker to connect to (and no client keystore to
+%% connect with). Checks:
+%%   1. the cacertfile ARN resolves,
+%%   2. the resolved PEM holds at least one well-formed CA certificate,
+%%   3. none of those certificates is expired or not yet valid,
+%%   4. verify / fail_if_no_peer_cert / depth / versions are well-shaped.
+%%
+%% A pass means the material is usable, not that mTLS as a whole works: it does
+%% not cover client-cert chaining, common-name-to-user mapping, network
+%% reachability, or whether the broker is actually running this config.
+%%
+%% Result categories (shared with the other backends):
+%%   * input_invalid (400) -- bad target/ssl_options, missing cacertfile_arn,
+%%     ARN resolve failure, or a PEM with no parseable CA certificate.
+%%   * tls_failed (400) -- a CA certificate is expired or not yet valid.
+%%   * config_conflict (422) -- a cacertfile_arn is given but no
+%%     aws.arns.assume_role_arn is configured.
+-module(aws_auth_validate_tls).
+
+-behaviour(aws_auth_validate_backend).
+
+-export([method_name/0, validate/1, allowed_fields/0]).
+
+-ifdef(TEST).
+%% Exposed for the unit tests: the pure input parser and the certificate-validity
+%% helpers (classify_validity/3 lets the expired/not-yet-valid branches be tested
+%% without generating an actually-expired cert).
+-export([
+    parse_input/1,
+    check_cert_validity/1,
+    cert_validity_seconds/1,
+    classify_validity/3
+]).
+-endif.
+
+-include_lib("public_key/include/public_key.hrl").
+
+%% The listener a request targets. The material check is the same for both; a
+%% request must name one, there is no default.
+-define(TARGET_VALUES, [<<"listener">>, <<"management">>]).
+
+%% Accepted ssl_options keys, named as in rabbitmq.conf (ssl_options.* /
+%% management.ssl.*) so a config can be pasted as-is. cacertfile_arn is the only
+%% material these setups supply -- the server cert is AWS-managed -- so there is
+%% no certfile_arn/keyfile_arn and no sni.
+-define(SSL_OPTION_KEYS, [
+    <<"cacertfile_arn">>,
+    <<"verify">>,
+    <<"fail_if_no_peer_cert">>,
+    <<"depth">>,
+    <<"versions">>
+]).
+
+%% Fixed reason strings: the response never echoes the ARN, cert details, or a
+%% raw decode error.
+-define(REASON_BAD_TARGET, <<"target must be \"listener\" or \"management\"">>).
+-define(REASON_MISSING_CACERT, <<"ssl_options.cacertfile_arn is required">>).
+-define(REASON_BAD_SSL_OPTIONS, <<"ssl_options must be an object">>).
+-define(REASON_UNKNOWN_SSL_OPTION, <<
+    "ssl_options contains an unknown key; allowed keys are cacertfile_arn, "
+    "verify, fail_if_no_peer_cert, depth, versions"
+>>).
+-define(REASON_BAD_SSL_VERIFY, <<"ssl_options.verify must be verify_peer or verify_none">>).
+-define(REASON_BAD_SSL_DEPTH, <<"ssl_options.depth must be a non-negative integer">>).
+-define(REASON_BAD_SSL_VERSIONS, <<"ssl_options.versions must be a list of known TLS versions">>).
+-define(REASON_BAD_SSL_FAIL_IF_NO_PEER_CERT,
+    <<"ssl_options.fail_if_no_peer_cert must be true or false">>
+).
+-define(REASON_BAD_SSL_CACERT_ARN, <<"ssl_options.cacertfile_arn must be a non-empty string">>).
+-define(REASON_ARN_RESOLVE, <<"failed to resolve ARN">>).
+-define(REASON_NO_CERTS, <<"cacertfile ARN did not resolve to any CA certificates">>).
+-define(REASON_BAD_CERT, <<"a certificate in the CA bundle could not be parsed">>).
+-define(REASON_CERT_EXPIRED, <<"the CA bundle contains an expired certificate">>).
+-define(REASON_CERT_NOT_YET_VALID,
+    <<"the CA bundle contains a certificate that is not yet valid">>
+).
+-define(REASON_ASSUME_ROLE, <<"failed to assume the configured role">>).
+-define(REASON_NO_ASSUME_ROLE, <<
+    "auth validation requires an assume_role to be configured; "
+    "set aws.arns.assume_role_arn"
+>>).
+
+%% Surface passed to the shared aws_auth_validate_ssl helpers: the ARN-bearing
+%% keys, the allowed-key set, and this backend's reason strings. client_cert is
+%% false (no client pair) and sni_key is unused here; both are required by the
+%% shared opts() type.
+ssl_opts() ->
+    #{
+        arn_keys => [<<"cacertfile_arn">>],
+        ssl_option_keys => ?SSL_OPTION_KEYS,
+        sni_key => <<"sni">>,
+        client_cert => false,
+        reasons => #{
+            no_assume_role => ?REASON_NO_ASSUME_ROLE,
+            assume_role => ?REASON_ASSUME_ROLE,
+            unknown_ssl_option => ?REASON_UNKNOWN_SSL_OPTION,
+            bad_ssl_options => ?REASON_BAD_SSL_OPTIONS,
+            bad_ssl_verify => ?REASON_BAD_SSL_VERIFY,
+            bad_ssl_depth => ?REASON_BAD_SSL_DEPTH,
+            bad_ssl_versions => ?REASON_BAD_SSL_VERSIONS,
+            bad_ssl_fail_if_no_peer_cert => ?REASON_BAD_SSL_FAIL_IF_NO_PEER_CERT,
+            bad_ssl_cacert_arn => ?REASON_BAD_SSL_CACERT_ARN
+        }
+    }.
+
+%%--------------------------------------------------------------------
+%% Behaviour callbacks
+%%--------------------------------------------------------------------
+
+method_name() ->
+    <<"tls">>.
+
+allowed_fields() ->
+    [<<"target">>, <<"ssl_options">>].
+
+-spec validate(map()) -> aws_auth_validate_backend:result().
+validate(Body) when is_map(Body) ->
+    %% Validate the whole request before touching the network, so a malformed
+    %% request never triggers an AssumeRole or an ARN fetch.
+    case parse_input(Body) of
+        {error, _, _} = Err ->
+            Err;
+        {ok, Params} ->
+            case aws_auth_validate_ssl:resolve_request_state(Params, ssl_opts()) of
+                {error, _, _} = Err -> Err;
+                {ok, Params1} -> do_tls_validate(Params1)
+            end
+    end.
+
+%%--------------------------------------------------------------------
+%% Input parsing (pure, no network)
+%%--------------------------------------------------------------------
+
+parse_input(Body) ->
+    Steps = [
+        fun parse_target/2,
+        fun parse_ssl_options/2,
+        fun require_cacert/2
+    ],
+    run_steps(Steps, Body, #{}).
+
+run_steps([], _Body, Acc) ->
+    {ok, Acc};
+run_steps([Step | Rest], Body, Acc0) ->
+    case Step(Body, Acc0) of
+        {ok, Acc1} -> run_steps(Rest, Body, Acc1);
+        {error, _, _} = Err -> Err
+    end.
+
+%% target is mandatory and must name a known listener.
+parse_target(Body, Acc) ->
+    case maps:get(<<"target">>, Body, undefined) of
+        T when is_binary(T) ->
+            case lists:member(T, ?TARGET_VALUES) of
+                true -> {ok, Acc#{target => T}};
+                false -> {error, input_invalid, ?REASON_BAD_TARGET}
+            end;
+        _ ->
+            {error, input_invalid, ?REASON_BAD_TARGET}
+    end.
+
+%% Key and value-shape checks are shared; delegate with this backend's surface.
+%% An absent ssl_options yields an empty map, which require_cacert/2 rejects.
+parse_ssl_options(Body, Acc) ->
+    aws_auth_validate_ssl:parse_ssl_options(
+        maps:get(<<"ssl_options">>, Body, undefined), Acc, ssl_opts()
+    ).
+
+%% cacertfile_arn is mandatory. Checked after parse_ssl_options so an ill-shaped
+%% value reports its own error first.
+require_cacert(_Body, #{ssl_options := Map} = Acc) ->
+    case maps:is_key(<<"cacertfile_arn">>, Map) of
+        true -> {ok, Acc};
+        false -> {error, input_invalid, ?REASON_MISSING_CACERT}
+    end.
+
+%%--------------------------------------------------------------------
+%% Material validation (resolve the ARN, then check the certificates)
+%%--------------------------------------------------------------------
+
+%% Resolve the cacertfile ARN, then decode and check the CA bundle. The only
+%% network call is the ARN fetch; nothing connects to a listener.
+do_tls_validate(#{ssl_options := Map} = Params) ->
+    %% A request that referenced no ARN carries the `none' sentinel, which
+    %% resolve_arn/2 refuses. cacertfile_arn is required, so a valid request
+    %% always has a real state; `none' just keeps the failure closed.
+    State = maps:get(aws_state, Params, none),
+    Arn = maps:get(<<"cacertfile_arn">>, Map),
+    case aws_auth_validate_ssl:resolve_arn(Arn, State) of
+        {error, _} ->
+            {error, input_invalid, ?REASON_ARN_RESOLVE};
+        {ok, Pem} ->
+            decode_and_check(Pem)
+    end.
+
+%% Decode the CA PEM and check each certificate. The decode is wrapped because
+%% public_key:pem_decode/1 raises (rather than returning `skip') on a
+%% cert-framed PEM with a malformed base64 body -- one of the misconfigurations
+%% this catches -- so it must map to input_invalid, not crash.
+decode_and_check(Pem) ->
+    Decoded =
+        try
+            aws_auth_validate_ssl:decode_pem_cacerts(Pem)
+        catch
+            _Class:_Reason -> error
+        end,
+    case Decoded of
+        error -> {error, input_invalid, ?REASON_NO_CERTS};
+        skip -> {error, input_invalid, ?REASON_NO_CERTS};
+        Ders -> check_cert_validity(Ders)
+    end.
+
+%% Check every certificate's [notBefore, notAfter] window against now, failing
+%% on the first bad one. Wrapped so a certificate that cannot be parsed maps to
+%% input_invalid rather than crashing.
+-spec check_cert_validity([binary()]) -> aws_auth_validate_backend:result().
+check_cert_validity(Ders) ->
+    Now = calendar:datetime_to_gregorian_seconds(calendar:universal_time()),
+    try
+        check_each(Ders, Now)
+    catch
+        _Class:_Reason ->
+            {error, input_invalid, ?REASON_BAD_CERT}
+    end.
+
+check_each([], _Now) ->
+    ok;
+check_each([Der | Rest], Now) ->
+    {NotBefore, NotAfter} = cert_validity_seconds(Der),
+    case classify_validity(NotBefore, NotAfter, Now) of
+        valid -> check_each(Rest, Now);
+        not_yet_valid -> {error, tls_failed, ?REASON_CERT_NOT_YET_VALID};
+        expired -> {error, tls_failed, ?REASON_CERT_EXPIRED}
+    end.
+
+%% Classify a validity window against a reference time. Separate so the
+%% expired/not-yet-valid branches can be tested without a real expired cert.
+-spec classify_validity(integer(), integer(), integer()) ->
+    valid | not_yet_valid | expired.
+classify_validity(NotBefore, _NotAfter, Now) when Now < NotBefore ->
+    not_yet_valid;
+classify_validity(_NotBefore, NotAfter, Now) when Now > NotAfter ->
+    expired;
+classify_validity(_NotBefore, _NotAfter, _Now) ->
+    valid.
+
+%% Extract {NotBefore, NotAfter} as gregorian seconds from a DER certificate.
+%% RFC 5280 requires UTC ("Z") times for these fields, so there is no offset to
+%% handle; anything else raises and is caught by check_cert_validity/1.
+-spec cert_validity_seconds(binary()) -> {integer(), integer()}.
+cert_validity_seconds(Der) ->
+    OTPCert = public_key:pkix_decode_cert(Der, otp),
+    TBS = OTPCert#'OTPCertificate'.tbsCertificate,
+    #'Validity'{notBefore = NotBefore, notAfter = NotAfter} =
+        TBS#'OTPTBSCertificate'.validity,
+    {asn1_time_to_seconds(NotBefore), asn1_time_to_seconds(NotAfter)}.
+
+%% UTCTime is "YYMMDDHHMMSSZ" with a 2-digit year (RFC 5280: YY >= 50 => 19YY,
+%% else 20YY). GeneralizedTime is "YYYYMMDDHHMMSSZ" with a 4-digit year.
+asn1_time_to_seconds({utcTime, T}) ->
+    S = to_str(T),
+    YY = list_to_integer(lists:sublist(S, 1, 2)),
+    Year =
+        case YY >= 50 of
+            true -> 1900 + YY;
+            false -> 2000 + YY
+        end,
+    ymd_to_seconds(Year, lists:nthtail(2, S));
+asn1_time_to_seconds({generalTime, T}) ->
+    S = to_str(T),
+    Year = list_to_integer(lists:sublist(S, 1, 4)),
+    ymd_to_seconds(Year, lists:nthtail(4, S)).
+
+%% Rest is "MMDDHHMMSS" (optionally followed by "Z"); take the fixed-width
+%% fields positionally.
+ymd_to_seconds(Year, Rest) ->
+    Month = list_to_integer(lists:sublist(Rest, 1, 2)),
+    Day = list_to_integer(lists:sublist(Rest, 3, 2)),
+    Hour = list_to_integer(lists:sublist(Rest, 5, 2)),
+    Min = list_to_integer(lists:sublist(Rest, 7, 2)),
+    Sec = list_to_integer(lists:sublist(Rest, 9, 2)),
+    calendar:datetime_to_gregorian_seconds({{Year, Month, Day}, {Hour, Min, Sec}}).
+
+to_str(T) when is_binary(T) -> binary_to_list(T);
+to_str(T) when is_list(T) -> T.

--- a/src/aws_auth_validate_tls.erl
+++ b/src/aws_auth_validate_tls.erl
@@ -271,6 +271,15 @@ cert_validity_seconds(Der) ->
 
 %% UTCTime is "YYMMDDHHMMSSZ" with a 2-digit year (RFC 5280: YY >= 50 => 19YY,
 %% else 20YY). GeneralizedTime is "YYYYMMDDHHMMSSZ" with a 4-digit year.
+%%
+%% The fixed 50 pivot is deliberate: RFC 5280 4.1.2.5 requires validity dates
+%% through 2049 to be UTCTime and dates in 2050 or later to be GeneralizedTime,
+%% so in a compliant certificate a 2-digit year can only mean 1950-2049 and this
+%% pivot is exact. Do not replace it with a sliding window relative to the
+%% current year (as public_key's pubkey_cert:time_str_2_gregorian_sec/1 does):
+%% that only matters for non-compliant certificates that encode a post-2049 date
+%% as UTCTime, which this pivot reads as a past year and so rejects as expired --
+%% the safe, fail-closed outcome for a pre-flight material check.
 asn1_time_to_seconds({utcTime, T}) ->
     S = to_str(T),
     YY = list_to_integer(lists:sublist(S, 1, 2)),

--- a/test/aws_auth_validate_tls_SUITE.erl
+++ b/test/aws_auth_validate_tls_SUITE.erl
@@ -58,7 +58,7 @@ groups() ->
     [
         {tls_method, [], [
             %% tls is opt-in: with the feature on but the method not enabled it
-            %% must 404 (enabling ldap/the master toggle does not bring it live).
+            %% must 404 (enabling ldap/the feature toggle does not bring it live).
             tls_disabled_by_default_returns_404,
             %% The method enabled + a valid, in-window CA -> 204.
             tls_valid_ca_returns_204,
@@ -168,8 +168,10 @@ pem_for_case(tls_malformed_pem_returns_400_input_invalid, _Config) ->
     %% this, which the backend must catch and report as input_invalid.
     <<"-----BEGIN CERTIFICATE-----\nnot base64 %%%\n-----END CERTIFICATE-----\n">>;
 pem_for_case(tls_no_certs_returns_400_input_invalid, _Config) ->
-    %% Well-formed PEM but no certificate entries (an RSA key only).
-    <<"-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBAKn\n-----END RSA PRIVATE KEY-----\n">>;
+    %% Well-formed PEM with no certificate entries: public_key:pem_decode/1
+    %% decodes the body but yields zero certificates (the `skip' branch), as
+    %% opposed to the malformed-base64 case above, which raises.
+    <<"-----BEGIN PRIVATE KEY-----\naGVsbG8=\n-----END PRIVATE KEY-----\n">>;
 pem_for_case(_TC, Config) ->
     %% Default (valid CA) for tls_valid_ca_returns_204 / tls_response_no_ca_material.
     ?config(valid_ca_pem, Config).

--- a/test/aws_auth_validate_tls_SUITE.erl
+++ b/test/aws_auth_validate_tls_SUITE.erl
@@ -1,0 +1,367 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% Integration tests for PUT /api/aws/auth/validate/tls against a real broker.
+%%
+%% The full request pipeline runs end to end (mgmt auth, opt-in gate, registry
+%% dispatch, the tls backend, ARN resolution + cert checks, and the handler's
+%% category-to-status mapping). Only aws_iam:assume_role and
+%% aws_arn_util:resolve_arn are mocked on the broker node; everything else is
+%% production code.
+%%
+%% No external dependency -- the tls method makes no outbound connection, so a
+%% broker node plus openssl is all this needs.
+-module(aws_auth_validate_tls_SUITE).
+
+-export([
+    all/0,
+    groups/0,
+    init_per_suite/1,
+    end_per_suite/1,
+    init_per_group/2,
+    end_per_group/2,
+    init_per_testcase/2,
+    end_per_testcase/2
+]).
+
+-export([
+    tls_disabled_by_default_returns_404/1,
+    tls_valid_ca_returns_204/1,
+    tls_expired_ca_returns_400_tls_failed/1,
+    tls_malformed_pem_returns_400_input_invalid/1,
+    tls_no_certs_returns_400_input_invalid/1,
+    tls_missing_cacert_arn_returns_400/1,
+    tls_no_assume_role_returns_422_config_conflict/1,
+    tls_response_no_ca_material/1
+]).
+
+%% Invoked on the broker node via rpc to install/remove the AWS-boundary mocks.
+-export([mock_resolve/1, unmock_resolve/0]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("rabbitmq_ct_helpers/include/rabbit_mgmt_test.hrl").
+-include("aws.hrl").
+
+-define(API, "/aws/auth/validate/tls").
+-define(ROLE_ARN, "arn:aws:iam::123456789012:role/validation").
+-define(CACERT_ARN, <<"arn:aws:s3:::test-ca/ca.pem">>).
+
+all() ->
+    [
+        {group, tls_method}
+    ].
+
+groups() ->
+    [
+        {tls_method, [], [
+            %% tls is opt-in: with the feature on but the method not enabled it
+            %% must 404 (enabling ldap/the master toggle does not bring it live).
+            tls_disabled_by_default_returns_404,
+            %% The method enabled + a valid, in-window CA -> 204.
+            tls_valid_ca_returns_204,
+            %% An expired CA in the resolved bundle -> 400 tls_failed.
+            tls_expired_ca_returns_400_tls_failed,
+            %% A cert-framed but malformed-base64 PEM -> 400 input_invalid (the
+            %% decode raises internally; the pipeline must not 500).
+            tls_malformed_pem_returns_400_input_invalid,
+            %% A PEM with no certificate entries -> 400 input_invalid.
+            tls_no_certs_returns_400_input_invalid,
+            %% ssl_options without cacertfile_arn -> 400 input_invalid (pure).
+            tls_missing_cacert_arn_returns_400,
+            %% cacertfile_arn referenced but no assume_role configured -> 422.
+            tls_no_assume_role_returns_422_config_conflict,
+            %% resolved CA material must not appear in the response.
+            tls_response_no_ca_material
+        ]}
+    ].
+
+%%--------------------------------------------------------------------
+%% Suite / group setup
+%%--------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    ok = inets:start(),
+    rabbit_ct_helpers:log_environment(),
+    %% Generate the CA fixtures once for the whole suite (on the CT node); the
+    %% PEM binaries are threaded to the broker-node mock via rpc per testcase.
+    ValidCaPem = gen_ca_pem(Config, "valid", "-days 2"),
+    ExpiredCaPem = gen_expired_ca_pem(Config),
+    [
+        {valid_ca_pem, ValidCaPem},
+        {expired_ca_pem, ExpiredCaPem}
+        | Config
+    ].
+
+end_per_suite(Config) ->
+    inets:stop(),
+    Config.
+
+init_per_group(tls_method, Config) ->
+    %% Feature on; the tls METHOD is left at its opt-in default (disabled) so the
+    %% disabled-by-default case sees a 404. Cases that need it enable it in
+    %% init_per_testcase. A boot-time assume_role is configured for the whole
+    %% group (the resolving cases need it); the config_conflict case unsets it.
+    setup_broker(Config, [
+        {auth_validation_enabled, true},
+        {auth_validation_max_concurrent, 1},
+        {auth_validation_max_body_size, 65536},
+        {arn_config, [{assume_role_arn, ?ROLE_ARN}]}
+    ]).
+
+end_per_group(_Group, Config) ->
+    rabbit_ct_helpers:run_teardown_steps(
+        Config,
+        rabbit_ct_broker_helpers:teardown_steps()
+    ).
+
+%%--------------------------------------------------------------------
+%% Per-testcase wiring
+%%--------------------------------------------------------------------
+
+%% The disabled-by-default case must NOT enable the method and needs no mock.
+init_per_testcase(tls_disabled_by_default_returns_404 = TC, Config) ->
+    rabbit_ct_helpers:testcase_started(Config, TC);
+%% The missing-cacert and no-assume-role cases fail before any ARN is resolved,
+%% so they need the method enabled but no resolve mock.
+init_per_testcase(tls_missing_cacert_arn_returns_400 = TC, Config) ->
+    enable_tls_method(Config),
+    rabbit_ct_helpers:testcase_started(Config, TC);
+init_per_testcase(tls_no_assume_role_returns_422_config_conflict = TC, Config) ->
+    enable_tls_method(Config),
+    %% Remove the configured assume_role so a referenced cacertfile_arn is
+    %% refused with config_conflict rather than resolved under the instance role.
+    rabbit_ct_broker_helpers:rpc(Config, 0, application, unset_env, [aws, arn_config]),
+    rabbit_ct_helpers:testcase_started(Config, TC);
+%% Every other case enables the method AND installs a resolve mock returning the
+%% appropriate fixture PEM.
+init_per_testcase(TC, Config) ->
+    enable_tls_method(Config),
+    Pem = pem_for_case(TC, Config),
+    ok = rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, mock_resolve, [Pem]),
+    rabbit_ct_helpers:testcase_started(Config, TC).
+
+end_per_testcase(tls_disabled_by_default_returns_404 = TC, Config) ->
+    rabbit_ct_helpers:testcase_finished(Config, TC);
+end_per_testcase(tls_missing_cacert_arn_returns_400 = TC, Config) ->
+    disable_methods(Config),
+    rabbit_ct_helpers:testcase_finished(Config, TC);
+end_per_testcase(tls_no_assume_role_returns_422_config_conflict = TC, Config) ->
+    disable_methods(Config),
+    %% Restore the group-level assume_role for the remaining cases.
+    rabbit_ct_broker_helpers:rpc(
+        Config, 0, application, set_env, [aws, arn_config, [{assume_role_arn, ?ROLE_ARN}]]
+    ),
+    rabbit_ct_helpers:testcase_finished(Config, TC);
+end_per_testcase(TC, Config) ->
+    ok = rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, unmock_resolve, []),
+    disable_methods(Config),
+    rabbit_ct_helpers:testcase_finished(Config, TC).
+
+%% The PEM the resolve mock should return for each resolving case.
+pem_for_case(tls_expired_ca_returns_400_tls_failed, Config) ->
+    ?config(expired_ca_pem, Config);
+pem_for_case(tls_malformed_pem_returns_400_input_invalid, _Config) ->
+    %% Cert framing with a non-base64 body: public_key:pem_decode/1 raises on
+    %% this, which the backend must catch and report as input_invalid.
+    <<"-----BEGIN CERTIFICATE-----\nnot base64 %%%\n-----END CERTIFICATE-----\n">>;
+pem_for_case(tls_no_certs_returns_400_input_invalid, _Config) ->
+    %% Well-formed PEM but no certificate entries (an RSA key only).
+    <<"-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBAKn\n-----END RSA PRIVATE KEY-----\n">>;
+pem_for_case(_TC, Config) ->
+    %% Default (valid CA) for tls_valid_ca_returns_204 / tls_response_no_ca_material.
+    ?config(valid_ca_pem, Config).
+
+%%--------------------------------------------------------------------
+%% Test cases
+%%--------------------------------------------------------------------
+
+tls_disabled_by_default_returns_404(Config) ->
+    {ok, {{_, Code, _}, _, _}} = put_request(Config, ?API, valid_body()),
+    ?assertEqual(404, Code).
+
+tls_valid_ca_returns_204(Config) ->
+    {ok, {{_, Code, _}, _Headers, ResBody}} = put_request(Config, ?API, valid_body()),
+    ?assertEqual(204, Code),
+    ?assertEqual(<<>>, iolist_to_binary(ResBody)).
+
+tls_expired_ca_returns_400_tls_failed(Config) ->
+    case ?config(expired_ca_pem, Config) of
+        skip ->
+            {skip, "openssl lacks -not_before/-not_after; expired fixture unavailable"};
+        _ ->
+            {ok, {{_, Code, _}, _, ResBody}} = put_request(Config, ?API, valid_body()),
+            ?assertEqual(400, Code),
+            ?assertMatch(#{<<"error">> := <<"tls_failed">>}, decode(ResBody))
+    end.
+
+tls_malformed_pem_returns_400_input_invalid(Config) ->
+    {ok, {{_, Code, _}, _, ResBody}} = put_request(Config, ?API, valid_body()),
+    ?assertEqual(400, Code),
+    ?assertMatch(#{<<"error">> := <<"input_invalid">>}, decode(ResBody)).
+
+tls_no_certs_returns_400_input_invalid(Config) ->
+    {ok, {{_, Code, _}, _, ResBody}} = put_request(Config, ?API, valid_body()),
+    ?assertEqual(400, Code),
+    ?assertMatch(#{<<"error">> := <<"input_invalid">>}, decode(ResBody)).
+
+tls_missing_cacert_arn_returns_400(Config) ->
+    Body = #{
+        <<"target">> => <<"listener">>,
+        <<"ssl_options">> => #{<<"verify">> => <<"verify_peer">>}
+    },
+    {ok, {{_, Code, _}, _, ResBody}} = put_request(Config, ?API, Body),
+    ?assertEqual(400, Code),
+    ?assertMatch(#{<<"error">> := <<"input_invalid">>}, decode(ResBody)).
+
+tls_no_assume_role_returns_422_config_conflict(Config) ->
+    {ok, {{_, Code, _}, _, ResBody}} = put_request(Config, ?API, valid_body()),
+    ?assertEqual(422, Code),
+    ?assertMatch(#{<<"error">> := <<"config_conflict">>}, decode(ResBody)).
+
+%% The resolved CA PEM must not appear in the response, even on success.
+tls_response_no_ca_material(Config) ->
+    Pem = ?config(valid_ca_pem, Config),
+    {ok, {{_, Code, _}, _, ResBody}} = put_request(Config, ?API, valid_body()),
+    ?assertEqual(204, Code),
+    Body = iolist_to_binary(ResBody),
+    Needle = pem_body_slice(Pem),
+    ?assertEqual(nomatch, binary:match(Body, Needle)).
+
+%%--------------------------------------------------------------------
+%% Broker-node mocks (invoked via rpc)
+%%--------------------------------------------------------------------
+
+%% Runs on the broker node. assume_role passes through; resolve_arn returns the
+%% fixture PEM. meck is loaded by setup_meck/1 in setup_broker/2.
+mock_resolve(Pem) ->
+    ok = meck:new(aws_iam, [passthrough, no_link]),
+    ok = meck:expect(aws_iam, assume_role, fun(_RoleArn, State) -> {ok, State} end),
+    ok = meck:new(aws_arn_util, [passthrough, no_link]),
+    ok = meck:expect(aws_arn_util, resolve_arn, fun(_Arn, State) -> {ok, Pem, State} end),
+    ok.
+
+unmock_resolve() ->
+    catch meck:unload(aws_arn_util),
+    catch meck:unload(aws_iam),
+    ok.
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+enable_tls_method(Config) ->
+    rabbit_ct_broker_helpers:rpc(
+        Config, 0, application, set_env, [aws, auth_validation_enabled_methods, [{<<"tls">>, true}]]
+    ).
+
+disable_methods(Config) ->
+    rabbit_ct_broker_helpers:rpc(
+        Config, 0, application, unset_env, [aws, auth_validation_enabled_methods]
+    ).
+
+valid_body() ->
+    #{
+        <<"target">> => <<"listener">>,
+        <<"ssl_options">> => #{
+            <<"cacertfile_arn">> => ?CACERT_ARN,
+            <<"verify">> => <<"verify_peer">>
+        }
+    }.
+
+setup_broker(Config0, ExtraEnv) ->
+    Config1 = rabbit_ct_helpers:set_config(Config0, [
+        {rmq_nodename_suffix, ?MODULE}
+    ]),
+    Config2 = rabbit_ct_helpers:merge_app_env(Config1, {aws, ExtraEnv}),
+    Config3 = rabbit_ct_helpers:run_setup_steps(
+        Config2,
+        rabbit_ct_broker_helpers:setup_steps()
+    ),
+    case Config3 of
+        {skip, _} = Skip ->
+            Skip;
+        _ ->
+            ok = rabbit_ct_broker_helpers:setup_meck(Config3),
+            Config3
+    end.
+
+put_request(Config, Path, BodyMap) ->
+    Body = binary_to_list(rabbit_json:encode(BodyMap)),
+    rabbit_mgmt_test_util:req(
+        Config,
+        0,
+        put,
+        Path,
+        [
+            rabbit_mgmt_test_util:auth_header("guest", "guest"),
+            {"content-type", "application/json"}
+        ],
+        Body
+    ).
+
+decode(ResBody) ->
+    case rabbit_json:try_decode(iolist_to_binary(ResBody)) of
+        {ok, Map} -> Map;
+        _ -> #{}
+    end.
+
+%% A distinctive interior slice of a PEM body, used as a no-leak check needle.
+pem_body_slice(Pem) ->
+    Lines = binary:split(Pem, <<"\n">>, [global]),
+    %% Pick a base64 body line (not a BEGIN/END marker, non-trivial length).
+    case [L || L <- Lines, byte_size(L) >= 16, binary:match(L, <<"-----">>) =:= nomatch] of
+        [Line | _] -> Line;
+        [] -> Pem
+    end.
+
+%%--------------------------------------------------------------------
+%% Certificate fixtures (openssl)
+%%--------------------------------------------------------------------
+
+%% Generate a self-signed CA PEM with the given validity flag (e.g. "-days 2").
+gen_ca_pem(Config, Name, ValidityFlag) ->
+    PrivDir = ?config(priv_dir, Config),
+    Key = filename:join(PrivDir, Name ++ "-ca-key.pem"),
+    Cert = filename:join(PrivDir, Name ++ "-ca-cert.pem"),
+    Cmd = lists:flatten(
+        io_lib:format(
+            "openssl req -x509 -newkey rsa:2048 -nodes -keyout ~ts -out ~ts "
+            "~s -subj /CN=AwsAuthValidateTls~sCA 2>/dev/null",
+            [Key, Cert, ValidityFlag, Name]
+        )
+    ),
+    _ = os:cmd(Cmd),
+    true = filelib:is_regular(Cert),
+    {ok, Pem} = file:read_file(Cert),
+    Pem.
+
+%% Generate a CA whose validity window is entirely in the past. Returns `skip'
+%% if this openssl lacks -not_before/-not_after (the CT case then skips).
+gen_expired_ca_pem(Config) ->
+    PrivDir = ?config(priv_dir, Config),
+    Key = filename:join(PrivDir, "expired-ca-key.pem"),
+    Cert = filename:join(PrivDir, "expired-ca-cert.pem"),
+    Cmd = lists:flatten(
+        io_lib:format(
+            "openssl req -x509 -newkey rsa:2048 -nodes -keyout ~ts -out ~ts "
+            "-not_before 20200101000000Z -not_after 20200102000000Z "
+            "-subj /CN=AwsAuthValidateTlsExpiredCA 2>&1",
+            [Key, Cert]
+        )
+    ),
+    Out = os:cmd(Cmd),
+    case filelib:is_regular(Cert) andalso not has_error(Out) of
+        true ->
+            {ok, Pem} = file:read_file(Cert),
+            Pem;
+        false ->
+            skip
+    end.
+
+has_error(Out) ->
+    string:find(Out, "error") =/= nomatch orelse
+        string:find(Out, "usage") =/= nomatch orelse
+        string:find(Out, "unknown option") =/= nomatch.

--- a/test/aws_auth_validate_tls_tests.erl
+++ b/test/aws_auth_validate_tls_tests.erl
@@ -1,0 +1,386 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% Unit tests for aws_auth_validate_tls: the behaviour callbacks, input
+%% validation, the assume_role guardrail, that the ARN is only resolved after
+%% the input is valid, that resolved material is not echoed, and the
+%% certificate-validity checks.
+%%
+%% This backend makes no outbound connection, so the whole validate/1 path can
+%% be driven by mocking aws_arn_util:resolve_arn and aws_iam:assume_role. The
+%% expired/not-yet-valid branches are covered both through classify_validity/3
+%% and end to end against openssl-generated fixtures.
+-module(aws_auth_validate_tls_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% Stands in for resolved ARN material; must not appear in any result term.
+%% Binary to match aws_arn_util:resolve_arn/2's return type.
+-define(SECRET, <<"secret-ca-material-should-not-appear">>).
+
+-define(CACERT_ARN, <<"arn:aws:s3:::test-ca/ca.pem">>).
+-define(ROLE_ARN, "arn:aws:iam::123456789012:role/validation").
+
+%%--------------------------------------------------------------------
+%% Behaviour callbacks
+%%--------------------------------------------------------------------
+
+tls_method_name_test() ->
+    ?assertEqual(<<"tls">>, aws_auth_validate_tls:method_name()).
+
+tls_allowed_fields_test() ->
+    Fields = aws_auth_validate_tls:allowed_fields(),
+    ?assertEqual([<<"target">>, <<"ssl_options">>], Fields).
+
+%% ARN keys live under ssl_options, not at the top level, so the registry's
+%% field filter cannot pass a top-level cacertfile_arn.
+tls_allowed_fields_excludes_arn_test() ->
+    Fields = aws_auth_validate_tls:allowed_fields(),
+    ?assertNot(lists:member(<<"cacertfile_arn">>, Fields)).
+
+%%--------------------------------------------------------------------
+%% Input validation: target
+%%--------------------------------------------------------------------
+
+tls_target_input_test_() ->
+    Ssl = #{<<"ssl_options">> => #{<<"cacertfile_arn">> => ?CACERT_ARN}},
+    [
+        %% target absent.
+        ?_assertMatch(
+            {error, input_invalid, <<"target must be", _/binary>>},
+            aws_auth_validate_tls:validate(Ssl)
+        ),
+        %% target not a known listener.
+        ?_assertMatch(
+            {error, input_invalid, <<"target must be", _/binary>>},
+            aws_auth_validate_tls:validate(Ssl#{<<"target">> => <<"amqp_client">>})
+        ),
+        %% target not a binary.
+        ?_assertMatch(
+            {error, input_invalid, <<"target must be", _/binary>>},
+            aws_auth_validate_tls:validate(Ssl#{<<"target">> => 42})
+        )
+    ].
+
+%%--------------------------------------------------------------------
+%% Input validation: ssl_options shape and values
+%%--------------------------------------------------------------------
+
+%% cacertfile_arn is required; a request with a well-formed target but no
+%% cacertfile_arn (empty or absent ssl_options) is rejected before any network.
+tls_cacert_required_test_() ->
+    [
+        ?_assertEqual(
+            {error, input_invalid, <<"ssl_options.cacertfile_arn is required">>},
+            aws_auth_validate_tls:validate(#{<<"target">> => <<"listener">>})
+        ),
+        ?_assertEqual(
+            {error, input_invalid, <<"ssl_options.cacertfile_arn is required">>},
+            aws_auth_validate_tls:validate(#{
+                <<"target">> => <<"listener">>,
+                <<"ssl_options">> => #{<<"verify">> => <<"verify_peer">>}
+            })
+        )
+    ].
+
+tls_ssl_options_shape_test_() ->
+    Base = #{<<"target">> => <<"management">>},
+    [
+        %% ssl_options not an object.
+        ?_assertEqual(
+            {error, input_invalid, <<"ssl_options must be an object">>},
+            aws_auth_validate_tls:validate(Base#{<<"ssl_options">> => <<"nope">>})
+        ),
+        %% unknown key.
+        ?_assertMatch(
+            {error, input_invalid, <<"ssl_options contains an unknown key", _/binary>>},
+            aws_auth_validate_tls:validate(Base#{
+                <<"ssl_options">> => #{
+                    <<"cacertfile_arn">> => ?CACERT_ARN,
+                    <<"sni">> => <<"example.com">>
+                }
+            })
+        )
+    ].
+
+tls_ssl_options_value_test_() ->
+    Base = #{<<"target">> => <<"listener">>},
+    Mk = fun(Extra) ->
+        aws_auth_validate_tls:validate(Base#{
+            <<"ssl_options">> => maps:merge(#{<<"cacertfile_arn">> => ?CACERT_ARN}, Extra)
+        })
+    end,
+    [
+        ?_assertEqual(
+            {error, input_invalid, <<"ssl_options.verify must be verify_peer or verify_none">>},
+            Mk(#{<<"verify">> => <<"maybe">>})
+        ),
+        ?_assertEqual(
+            {error, input_invalid, <<"ssl_options.depth must be a non-negative integer">>},
+            Mk(#{<<"depth">> => -1})
+        ),
+        ?_assertEqual(
+            {error, input_invalid, <<"ssl_options.versions must be a list of known TLS versions">>},
+            Mk(#{<<"versions">> => [<<"sslv3">>]})
+        ),
+        ?_assertEqual(
+            {error, input_invalid, <<"ssl_options.fail_if_no_peer_cert must be true or false">>},
+            Mk(#{<<"fail_if_no_peer_cert">> => <<"true">>})
+        ),
+        ?_assertEqual(
+            {error, input_invalid, <<"ssl_options.cacertfile_arn must be a non-empty string">>},
+            aws_auth_validate_tls:validate(Base#{
+                <<"ssl_options">> => #{<<"cacertfile_arn">> => <<>>}
+            })
+        )
+    ].
+
+%% A well-formed ssl_options shape gets past input validation: with no
+%% assume_role configured the remaining failure is config_conflict, not an
+%% input_invalid shape error.
+tls_well_formed_shapes_reach_guardrail_test() ->
+    application:unset_env(aws, arn_config),
+    Body = #{
+        <<"target">> => <<"management">>,
+        <<"ssl_options">> => #{
+            <<"cacertfile_arn">> => ?CACERT_ARN,
+            <<"verify">> => <<"verify_peer">>,
+            <<"fail_if_no_peer_cert">> => true,
+            <<"depth">> => 2,
+            <<"versions">> => [<<"tlsv1.3">>, <<"tlsv1.2">>]
+        }
+    },
+    ?assertMatch({error, config_conflict, _}, aws_auth_validate_tls:validate(Body)).
+
+%%--------------------------------------------------------------------
+%% assume_role guardrail and resolve ordering
+%%--------------------------------------------------------------------
+
+%% A cacertfile_arn with no assume_role configured is refused with
+%% config_conflict, and the ARN is not resolved.
+tls_no_assume_role_refused_test_() ->
+    {setup,
+        fun() ->
+            application:unset_env(aws, arn_config),
+            ok = meck:new(aws_arn_util, [passthrough]),
+            meck:expect(aws_arn_util, resolve_arn, fun(_Arn, State) -> {ok, ?SECRET, State} end)
+        end,
+        fun(_) -> meck:unload(aws_arn_util) end, fun(_) ->
+            R = aws_auth_validate_tls:validate(#{
+                <<"target">> => <<"listener">>,
+                <<"ssl_options">> => #{<<"cacertfile_arn">> => ?CACERT_ARN}
+            }),
+            [
+                ?_assertMatch(
+                    {error, config_conflict,
+                        <<"auth validation requires an assume_role", _/binary>>},
+                    R
+                ),
+                ?_assertEqual(0, meck:num_calls(aws_arn_util, resolve_arn, '_'))
+            ]
+        end}.
+
+%% A malformed request is rejected before the assume_role or ARN fetch happens.
+tls_arn_not_resolved_on_bad_input_test_() ->
+    {setup,
+        fun() ->
+            application:set_env(aws, arn_config, [{assume_role_arn, ?ROLE_ARN}]),
+            ok = meck:new(aws_iam, [no_link]),
+            ok = meck:new(aws_arn_util, [passthrough]),
+            meck:expect(aws_iam, assume_role, fun(_RoleArn, State) -> {ok, State} end),
+            meck:expect(aws_arn_util, resolve_arn, fun(_Arn, State) -> {ok, ?SECRET, State} end)
+        end,
+        fun(_) ->
+            application:unset_env(aws, arn_config),
+            catch meck:unload(aws_iam),
+            meck:unload(aws_arn_util)
+        end,
+        fun(_) ->
+            R = aws_auth_validate_tls:validate(#{
+                <<"target">> => <<"bogus">>,
+                <<"ssl_options">> => #{<<"cacertfile_arn">> => ?CACERT_ARN}
+            }),
+            [
+                ?_assertMatch({error, input_invalid, _}, R),
+                ?_assertEqual(0, meck:num_calls(aws_arn_util, resolve_arn, '_')),
+                ?_assertEqual(0, meck:num_calls(aws_iam, assume_role, '_'))
+            ]
+        end}.
+
+%%--------------------------------------------------------------------
+%% Material validation via validate/1 (resolve_arn mocked)
+%%--------------------------------------------------------------------
+
+%% A resolved PEM with no certificates maps to input_invalid.
+tls_no_certs_in_bundle_test_() ->
+    with_resolved_pem(
+        <<"-----BEGIN CERTIFICATE-----\nnot base64\n-----END CERTIFICATE-----">>, fun() ->
+            R = validate_ok_body(),
+            [
+                ?_assertMatch(
+                    {error, input_invalid,
+                        <<"cacertfile ARN did not resolve to any CA certificates">>},
+                    R
+                )
+            ]
+        end
+    ).
+
+%% An ARN resolution failure maps to input_invalid.
+tls_arn_resolve_failure_test_() ->
+    {setup, fun setup_role/0, fun cleanup_role/1, fun(_) ->
+        meck:expect(aws_arn_util, resolve_arn, fun(_Arn, _State) -> {error, not_found} end),
+        R = validate_ok_body(),
+        [
+            ?_assertEqual({error, input_invalid, <<"failed to resolve ARN">>}, R)
+        ]
+    end}.
+
+%% A valid, in-window CA bundle passes. Generated fresh so it is current.
+tls_valid_ca_returns_ok_test_() ->
+    CaPem = gen_ca_pem(),
+    with_resolved_pem(CaPem, fun() ->
+        [?_assertEqual(ok, validate_ok_body())]
+    end).
+
+%% The resolved material must not appear in the result term. ?SECRET is not a
+%% valid PEM, so this exercises the no-certs path.
+tls_secret_never_leaks_test_() ->
+    with_resolved_pem(?SECRET, fun() ->
+        R = validate_ok_body(),
+        [?_assertEqual(nomatch, string_find(R, ?SECRET))]
+    end).
+
+%%--------------------------------------------------------------------
+%% Certificate-validity classification
+%%--------------------------------------------------------------------
+
+%% classify_validity/3 covers all three branches without depending on the clock.
+tls_classify_validity_test_() ->
+    [
+        ?_assertEqual(valid, aws_auth_validate_tls:classify_validity(100, 200, 150)),
+        ?_assertEqual(valid, aws_auth_validate_tls:classify_validity(100, 200, 100)),
+        ?_assertEqual(valid, aws_auth_validate_tls:classify_validity(100, 200, 200)),
+        ?_assertEqual(not_yet_valid, aws_auth_validate_tls:classify_validity(100, 200, 99)),
+        ?_assertEqual(expired, aws_auth_validate_tls:classify_validity(100, 200, 201))
+    ].
+
+%% check_cert_validity/1 flags a real expired certificate as tls_failed, using a
+%% fixture whose validity window is entirely in the past. Skips if this openssl
+%% does not support -not_before/-not_after (classify_validity/3 still covers the
+%% logic).
+tls_expired_cert_returns_tls_failed_test() ->
+    case gen_expired_ca_pem() of
+        skip ->
+            ?debugMsg("skipping expired-cert fixture: openssl lacks -not_before/-not_after"),
+            ok;
+        CaPem ->
+            Ders = aws_auth_validate_ssl:decode_pem_cacerts(CaPem),
+            ?assertMatch(
+                {error, tls_failed, <<"the CA bundle contains an expired certificate">>},
+                aws_auth_validate_tls:check_cert_validity(Ders)
+            )
+    end.
+
+%% An unparseable DER maps to input_invalid rather than crashing.
+tls_unparseable_der_returns_bad_cert_test() ->
+    ?assertEqual(
+        {error, input_invalid, <<"a certificate in the CA bundle could not be parsed">>},
+        aws_auth_validate_tls:check_cert_validity([<<0, 1, 2, 3>>])
+    ).
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+validate_ok_body() ->
+    aws_auth_validate_tls:validate(#{
+        <<"target">> => <<"listener">>,
+        <<"ssl_options">> => #{
+            <<"cacertfile_arn">> => ?CACERT_ARN,
+            <<"verify">> => <<"verify_peer">>
+        }
+    }).
+
+%% Run Fun with a configured assume_role and resolve_arn mocked to return Pem.
+with_resolved_pem(Pem, Fun) ->
+    {setup,
+        fun() ->
+            R = setup_role(),
+            meck:expect(aws_arn_util, resolve_arn, fun(_Arn, State) -> {ok, Pem, State} end),
+            R
+        end,
+        fun cleanup_role/1, Fun}.
+
+setup_role() ->
+    application:set_env(aws, arn_config, [{assume_role_arn, ?ROLE_ARN}]),
+    ok = meck:new(aws_iam, [no_link]),
+    ok = meck:new(aws_arn_util, [passthrough]),
+    meck:expect(aws_iam, assume_role, fun(_RoleArn, State) -> {ok, State} end),
+    ok.
+
+cleanup_role(_) ->
+    application:unset_env(aws, arn_config),
+    catch meck:unload(aws_iam),
+    meck:unload(aws_arn_util).
+
+%% Scan a rendered term for a binary substring.
+string_find(Term, Needle) ->
+    string_find_bin(iolist_to_binary(io_lib:format("~p", [Term])), Needle).
+
+string_find_bin(Hay, Needle) ->
+    case binary:match(Hay, Needle) of
+        nomatch -> nomatch;
+        _ -> found
+    end.
+
+%% Generate a fresh, in-window self-signed CA PEM via openssl.
+gen_ca_pem() ->
+    Dir = tmp_dir(),
+    Key = filename:join(Dir, "ca-key.pem"),
+    Cert = filename:join(Dir, "ca-cert.pem"),
+    Cmd = lists:flatten(
+        io_lib:format(
+            "openssl req -x509 -newkey rsa:2048 -nodes -keyout ~ts -out ~ts "
+            "-days 2 -subj /CN=AwsAuthValidateTlsTestCA 2>/dev/null",
+            [Key, Cert]
+        )
+    ),
+    _ = os:cmd(Cmd),
+    {ok, Pem} = file:read_file(Cert),
+    Pem.
+
+%% Generate a self-signed CA whose validity window is entirely in the past.
+%% Returns `skip' if this openssl lacks -not_before/-not_after.
+gen_expired_ca_pem() ->
+    Dir = tmp_dir(),
+    Key = filename:join(Dir, "exp-key.pem"),
+    Cert = filename:join(Dir, "exp-cert.pem"),
+    Cmd = lists:flatten(
+        io_lib:format(
+            "openssl req -x509 -newkey rsa:2048 -nodes -keyout ~ts -out ~ts "
+            "-not_before 20200101000000Z -not_after 20200102000000Z "
+            "-subj /CN=AwsAuthValidateTlsExpiredCA 2>&1",
+            [Key, Cert]
+        )
+    ),
+    Out = os:cmd(Cmd),
+    case filelib:is_regular(Cert) andalso not has_error(Out) of
+        true ->
+            {ok, Pem} = file:read_file(Cert),
+            Pem;
+        false ->
+            skip
+    end.
+
+has_error(Out) ->
+    string:find(Out, "error") =/= nomatch orelse
+        string:find(Out, "usage") =/= nomatch orelse
+        string:find(Out, "unknown option") =/= nomatch.
+
+tmp_dir() ->
+    Base = filename:join(["/tmp", "aws_auth_validate_tls_tests"]),
+    ok = filelib:ensure_dir(filename:join(Base, "x")),
+    Base.

--- a/test/aws_auth_validate_tls_tests.erl
+++ b/test/aws_auth_validate_tls_tests.erl
@@ -213,8 +213,26 @@ tls_arn_not_resolved_on_bad_input_test_() ->
 %% Material validation via validate/1 (resolve_arn mocked)
 %%--------------------------------------------------------------------
 
-%% A resolved PEM with no certificates maps to input_invalid.
+%% A well-formed PEM that holds no certificate entries (a private key only)
+%% decodes cleanly to zero certificates (the `skip' branch) and maps to
+%% input_invalid.
 tls_no_certs_in_bundle_test_() ->
+    with_resolved_pem(
+        <<"-----BEGIN PRIVATE KEY-----\naGVsbG8=\n-----END PRIVATE KEY-----\n">>, fun() ->
+            R = validate_ok_body(),
+            [
+                ?_assertMatch(
+                    {error, input_invalid,
+                        <<"cacertfile ARN did not resolve to any CA certificates">>},
+                    R
+                )
+            ]
+        end
+    ).
+
+%% A cert-framed PEM whose body is not valid base64 makes public_key:pem_decode/1
+%% raise; the backend must catch it and map to input_invalid rather than crash.
+tls_malformed_pem_maps_to_input_invalid_test_() ->
     with_resolved_pem(
         <<"-----BEGIN CERTIFICATE-----\nnot base64\n-----END CERTIFICATE-----">>, fun() ->
             R = validate_ok_body(),


### PR DESCRIPTION
*Issue #43*

## Summary

Customers configuring SSL certificate authentication or mTLS on their Amazon MQ for RabbitMQ brokers follow these tutorials ([SSL cert](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/rabbitmq-ssl-tutorial.html), [mTLS](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/rabbitmq-mtls-tutorial.html)). Both reference a CA bundle by ARN (`aws.arns.ssl_options.cacertfile` / `aws.arns.management.ssl.cacertfile`). Today a wrong ARN or a malformed/expired CA only surfaces at broker boot, so the customer discovers it after building a keystore and running the verification script.

This adds a `tls` validation method that checks that broker-side material up front, without a restart.

## What it does

`PUT /api/aws/auth/validate/tls` with a `target` (`listener` or `management`) and `ssl_options`:

- resolves the `cacertfile_arn`,
- decodes the PEM and confirms it holds at least one well-formed CA certificate,
- checks that no certificate is expired or not yet valid,
- validates the shapes of `verify`, `fail_if_no_peer_cert`, `depth`, `versions`.

Results reuse the existing categories: `204` on success, `400 input_invalid` for bad input / an unresolvable ARN / an unparseable CA, `400 tls_failed` for an expired or not-yet-valid certificate, and `422 config_conflict` when a `cacertfile_arn` is given but no `assume_role_arn` is configured.

For the mTLS tutorial (a CA on both the AMQP and management listeners), the customer validates each with a separate call (`target: listener`, then `target: management`).

## Scope

This validates the broker-side material only; it does not perform a live handshake. A pass means the CA material is usable, not that TLS/mTLS as a whole is working. It does not cover client-certificate chaining, the common-name to user mapping, network reachability, or whether the broker is currently running this configuration. The tutorial scripts (`ssl.sh` / `mtls.sh`) remain the end-to-end check; this is a pre-flight that rules out the common CA/ARN/shape errors first.

## Notes

- The method is opt-in (disabled unless explicitly enabled), consistent with the other non-default methods.
- Unlike the ldap/http/oauth methods, this makes no outbound connection; the only network call is the ARN resolution.

## Testing

- Unit tests (`aws_auth_validate_tls_tests`): input validation, the assume_role guardrail, ordering, no-leak of resolved material, and certificate-validity logic.
- Integration tests (`aws_auth_validate_tls_SUITE`): the full HTTP pipeline against a broker node, with the ARN/assume-role boundaries mocked.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
