### PR TITLE
Support AWS_ENDPOINT_URL override for local development

### DIFF
--- a/src/aws_lib.erl
+++ b/src/aws_lib.erl
@@ -230,7 +230,9 @@ open_connection(Service, Options, State0) ->
 
     Host = endpoint_host(Region, Service),
     Port = 443,
-    case aws_lib_httpc:open(Host, Port, gun_open_opts(Port, Options)) of
+    %% The legacy two-step API always targets the real AWS endpoint over TLS; it
+    %% does not honour the endpoint-url override (see endpoint/4).
+    case aws_lib_httpc:open(Host, Port, gun_open_opts(tls, Options)) of
         {ok, Conn} ->
             {ok, {Conn, Service}, State1};
         {error, _Reason} = Error ->
@@ -530,10 +532,33 @@ prepare_signed_request(Service, Method, Headers, Path, Body, Options, Host, Stat
     Service :: string(),
     Path :: string()
 ) -> string().
+%% @doc Construct the request URI for the service, region, and path.
+%%
+%% An explicit `Host' (the request/8 Endpoint parameter) always wins and is used
+%% verbatim over HTTPS, preserving the pre-existing behaviour. Otherwise, when an
+%% ``AWS_ENDPOINT_URL``/``AWS_ENDPOINT_URL_<SERVICE>`` override is configured for
+%% local development, the request targets that base URL (its scheme, host, and
+%% port), with the AWS request path appended. With no explicit host and no
+%% override, the request targets the standard regional HTTPS endpoint.
+%% @end
 endpoint(Region, undefined, Service, Path) ->
-    lists:flatten(["https://", endpoint_host(Region, Service), Path]);
+    case aws_lib_config:endpoint_url(Service) of
+        undefined ->
+            lists:flatten(["https://", endpoint_host(Region, Service), Path]);
+        Override ->
+            lists:flatten([strip_trailing_slash(Override), Path])
+    end;
 endpoint(_, Host, _, Path) ->
     lists:flatten(["https://", Host, Path]).
+
+%% Drop a single trailing slash from an endpoint-URL override so joining it with
+%% a request path (which always starts with "/") does not produce a double slash.
+strip_trailing_slash(Url) ->
+    case lists:reverse(Url) of
+        [$/ | Rest] -> lists:reverse(Rest);
+        _ -> Url
+    end.
+
 %% @doc Construct the endpoint hostname for the request based upon the service
 %%      and region.
 %% @end
@@ -968,7 +993,7 @@ perform_request_reuse(Service, Method, Headers, Path, Body, Options, State0, Con
                     Host = aws_lib_uri:host(Uri),
                     Port = aws_lib_uri:port(Uri),
                     Target = aws_lib_uri:target(Uri),
-                    OpenOpts = (gun_open_opts(Port, Options1))#{retry => 0},
+                    OpenOpts = (gun_open_opts(aws_lib_uri:transport(Uri), Options1))#{retry => 0},
                     case ensure_open(ConnSlot0, Host, Port, OpenOpts) of
                         {ok, Conn1} ->
                             Timeout = proplists:get_value(
@@ -1061,7 +1086,7 @@ gun_request(Method, URI, Headers, Body, Options) ->
             Port = aws_lib_uri:port(Uri),
             %% target/1 carries the query: Path is the Gun request line.
             Path = aws_lib_uri:target(Uri),
-            OpenOpts = gun_open_opts(Port, Options),
+            OpenOpts = gun_open_opts(aws_lib_uri:transport(Uri), Options),
             Response = aws_lib_httpc:request(
                 Host, Port, Method, Path, Headers, Body, OpenOpts
             ),
@@ -1070,10 +1095,13 @@ gun_request(Method, URI, Headers, Body, Options) ->
             format_response(Error)
     end.
 
-%% Build aws_lib_httpc open options from the request Options and target port:
-%% derive Gun protocols from the requested HTTP version, use TLS on port 443,
-%% and thread the connect and request timeouts through.
-gun_open_opts(Port, Options) ->
+%% Build aws_lib_httpc open options from the request Options and Transport:
+%% derive Gun protocols from the requested HTTP version, use the given transport
+%% (TLS or plain TCP), and thread the connect and request timeouts through. The
+%% transport is scheme-driven (see aws_lib_uri:transport/1) rather than derived
+%% from the port, so an https endpoint on a non-443 port still uses TLS and an
+%% http override stays plaintext.
+gun_open_opts(Transport, Options) when Transport =:= tls; Transport =:= tcp ->
     HttpVersion = proplists:get_value(version, Options, "HTTP/1.1"),
     Protocols =
         case HttpVersion of
@@ -1083,11 +1111,6 @@ gun_open_opts(Port, Options) ->
             "HTTP/1.0" -> [http];
             % Default: try HTTP/2, fallback to HTTP/1.1
             _ -> [http2, http]
-        end,
-    Transport =
-        if
-            Port == 443 -> tls;
-            true -> tcp
         end,
     #{
         transport => Transport,

--- a/src/aws_lib_config.erl
+++ b/src/aws_lib_config.erl
@@ -21,7 +21,8 @@
     instance_id/1,
     load_imdsv2_token/0,
     instance_metadata_request_headers/1,
-    region/1
+    region/1,
+    endpoint_url/1
 ]).
 
 %% Export all for unit tests
@@ -168,6 +169,42 @@ region(Profile, Config) ->
         _ ->
             {ok, ?DEFAULT_REGION, Config}
     end.
+
+-spec endpoint_url(Service :: string()) -> string() | undefined.
+%% @doc Return the endpoint-URL override for the given AWS service, or
+%%      `undefined' when none is configured. This matches the AWS CLI v2 and
+%%      official SDK convention for local-development endpoints (LocalStack,
+%%      moto, and similar): the per-service ``AWS_ENDPOINT_URL_<SERVICE>``
+%%      variable takes precedence over the global ``AWS_ENDPOINT_URL``.
+%%
+%%      The service name is upper-cased and its hyphens are replaced with
+%%      underscores to form the variable suffix, so the "acm-pca" service maps
+%%      to ``AWS_ENDPOINT_URL_ACM_PCA``.
+%% @end
+endpoint_url(Service) ->
+    case os:getenv("AWS_ENDPOINT_URL_" ++ service_env_suffix(Service)) of
+        Value when is_list(Value), Value =/= "" ->
+            Value;
+        _ ->
+            case os:getenv("AWS_ENDPOINT_URL") of
+                Value when is_list(Value), Value =/= "" -> Value;
+                _ -> undefined
+            end
+    end.
+
+%% Map a service name to the AWS_ENDPOINT_URL_<SERVICE> variable suffix:
+%% upper-cased with hyphens turned into underscores (e.g. "acm-pca" ->
+%% "ACM_PCA"), matching the AWS SDK convention.
+service_env_suffix(Service) ->
+    string:uppercase(
+        lists:map(
+            fun
+                ($-) -> $_;
+                (C) -> C
+            end,
+            Service
+        )
+    ).
 
 -spec instance_id(aws_config()) -> {'ok', string(), aws_config()} | {'error', 'undefined'}.
 %% @doc Return the instance ID from the EC2 metadata service.

--- a/src/aws_lib_uri.erl
+++ b/src/aws_lib_uri.erl
@@ -16,6 +16,7 @@
     parse/1,
     host/1,
     port/1,
+    transport/1,
     path/1,
     query/1,
     target/1,
@@ -66,6 +67,20 @@ default_port("https") -> 443;
 default_port("http") -> 80;
 %% Fall back to HTTPS for any other scheme, matching the plugin's HTTPS default.
 default_port(_) -> 443.
+
+-spec transport(uri()) -> tls | tcp.
+%% @doc The Gun transport implied by the scheme: `https' (and any unknown
+%% scheme, matching the plugin's HTTPS default) uses TLS, `http' uses plain TCP.
+%% Scheme-driven rather than port-driven, so an https endpoint on a non-443 port
+%% still uses TLS and an http endpoint on any port stays plaintext.
+%% @end
+transport(#{scheme := Scheme}) ->
+    transport_for_scheme(string:lowercase(unicode:characters_to_list(Scheme)));
+transport(_) ->
+    tls.
+
+transport_for_scheme("http") -> tcp;
+transport_for_scheme(_) -> tls.
 
 -spec path(uri()) -> string().
 %% @doc The path component as a list string, with an empty path normalized to

--- a/test/aws_lib_config_tests.erl
+++ b/test/aws_lib_config_tests.erl
@@ -13,6 +13,57 @@ mock_gun_imdsv2_failure() ->
 
 -include("aws_lib.hrl").
 
+%% endpoint_url/1 resolves the local-development endpoint override: the
+%% per-service AWS_ENDPOINT_URL_<SERVICE> variable takes precedence over the
+%% global AWS_ENDPOINT_URL, and the service name maps to the suffix by
+%% upper-casing and turning hyphens into underscores. The foreach clears both
+%% variables before and after each case so they never leak between tests.
+endpoint_url_test_() ->
+    Clear = fun() ->
+        os:unsetenv("AWS_ENDPOINT_URL"),
+        os:unsetenv("AWS_ENDPOINT_URL_S3"),
+        os:unsetenv("AWS_ENDPOINT_URL_SECRETSMANAGER"),
+        os:unsetenv("AWS_ENDPOINT_URL_ACM_PCA")
+    end,
+    {foreach,
+        fun() ->
+            Clear(),
+            ok
+        end,
+        fun(_) ->
+            Clear(),
+            ok
+        end,
+        [
+            {"undefined when no override is set", fun() ->
+                ?assertEqual(undefined, aws_lib_config:endpoint_url("s3"))
+            end},
+            {"the global override applies to any service", fun() ->
+                os:putenv("AWS_ENDPOINT_URL", "http://localhost:4566"),
+                ?assertEqual("http://localhost:4566", aws_lib_config:endpoint_url("s3")),
+                ?assertEqual(
+                    "http://localhost:4566", aws_lib_config:endpoint_url("secretsmanager")
+                )
+            end},
+            {"a per-service override wins over the global one", fun() ->
+                os:putenv("AWS_ENDPOINT_URL", "http://localhost:4566"),
+                os:putenv("AWS_ENDPOINT_URL_S3", "http://localhost:9000"),
+                ?assertEqual("http://localhost:9000", aws_lib_config:endpoint_url("s3")),
+                %% A service without its own override still falls back to the global.
+                ?assertEqual(
+                    "http://localhost:4566", aws_lib_config:endpoint_url("secretsmanager")
+                )
+            end},
+            {"the service name maps hyphens to underscores", fun() ->
+                os:putenv("AWS_ENDPOINT_URL_ACM_PCA", "http://localhost:4567"),
+                ?assertEqual("http://localhost:4567", aws_lib_config:endpoint_url("acm-pca"))
+            end},
+            {"an empty override value is treated as unset", fun() ->
+                os:putenv("AWS_ENDPOINT_URL", ""),
+                ?assertEqual(undefined, aws_lib_config:endpoint_url("s3"))
+            end}
+        ]}.
+
 config_file_test_() ->
     [
         {"from environment variable", fun() ->

--- a/test/aws_lib_tests.erl
+++ b/test/aws_lib_tests.erl
@@ -80,6 +80,7 @@ endpoint_test_() ->
             )
         end},
         {"unspecified", fun() ->
+            os:unsetenv("AWS_ENDPOINT_URL"),
             Region = "us-east-3",
             Service = "dynamodb",
             Path = "/",
@@ -88,6 +89,61 @@ endpoint_test_() ->
             ?assertEqual(
                 Expectation, aws_lib:endpoint(Region, Host, Service, Path)
             )
+        end}
+    ].
+
+%% With no explicit host, endpoint/4 honours the AWS_ENDPOINT_URL override so
+%% requests can target a local development endpoint. The override's scheme, host,
+%% and port are used, with the AWS request path appended, and a trailing slash on
+%% the override is not doubled up with the path.
+endpoint_override_test_() ->
+    Region = "us-east-1",
+    Service = "s3",
+    Path = "/bucket/key",
+    {foreach,
+        fun() ->
+            os:unsetenv("AWS_ENDPOINT_URL"),
+            os:unsetenv("AWS_ENDPOINT_URL_S3"),
+            ok
+        end,
+        fun(_) ->
+            os:unsetenv("AWS_ENDPOINT_URL"),
+            os:unsetenv("AWS_ENDPOINT_URL_S3"),
+            ok
+        end,
+        [
+            {"global override sets scheme, host, and port", fun() ->
+                os:putenv("AWS_ENDPOINT_URL", "http://localhost:4566"),
+                ?assertEqual(
+                    "http://localhost:4566/bucket/key",
+                    aws_lib:endpoint(Region, undefined, Service, Path)
+                )
+            end},
+            {"a trailing slash on the override is not doubled", fun() ->
+                os:putenv("AWS_ENDPOINT_URL", "http://localhost:4566/"),
+                ?assertEqual(
+                    "http://localhost:4566/bucket/key",
+                    aws_lib:endpoint(Region, undefined, Service, Path)
+                )
+            end},
+            {"an explicit host still wins over the override", fun() ->
+                os:putenv("AWS_ENDPOINT_URL", "http://localhost:4566"),
+                ?assertEqual(
+                    "https://myhost:9/bucket/key",
+                    aws_lib:endpoint(Region, "myhost:9", Service, Path)
+                )
+            end}
+        ]}.
+
+%% gun_open_opts/2 takes the transport verbatim (scheme-driven upstream), so the
+%% resulting Gun options carry TLS or plain TCP as given.
+gun_open_opts_transport_test_() ->
+    [
+        {"tls transport", fun() ->
+            ?assertMatch(#{transport := tls}, aws_lib:gun_open_opts(tls, []))
+        end},
+        {"tcp transport", fun() ->
+            ?assertMatch(#{transport := tcp}, aws_lib:gun_open_opts(tcp, []))
         end}
     ].
 
@@ -578,6 +634,10 @@ api_get_request_test_() ->
             setup(),
             meck:new(gun, []),
             meck:new(aws_lib_config, []),
+            %% aws_lib_config is a strict mock here; endpoint/4 consults
+            %% endpoint_url/1, so it must be expected. No override: target the
+            %% default AWS endpoint.
+            meck:expect(aws_lib_config, endpoint_url, fun(_) -> undefined end),
             [gun, aws_lib_config]
         end,
         fun(Mods) ->
@@ -806,6 +866,10 @@ connection_reuse_across_retries_test_() ->
             setup(),
             meck:new(gun, []),
             meck:new(aws_lib_config, []),
+            %% aws_lib_config is a strict mock here; endpoint/4 consults
+            %% endpoint_url/1, so it must be expected. No override: target the
+            %% default AWS endpoint.
+            meck:expect(aws_lib_config, endpoint_url, fun(_) -> undefined end),
             [gun, aws_lib_config]
         end,
         fun(Mods) ->

--- a/test/aws_lib_uri_tests.erl
+++ b/test/aws_lib_uri_tests.erl
@@ -56,6 +56,31 @@ target_test_() ->
         end}
     ].
 
+%% transport/1 derives the Gun transport from the scheme (not the port), so an
+%% https endpoint on a non-standard port still uses TLS and an http override
+%% stays plaintext.
+transport_test_() ->
+    [
+        {"https uses TLS transport", fun() ->
+            {ok, U} = aws_lib_uri:parse("https://s3.amazonaws.com/bucket/key"),
+            ?assertEqual(tls, aws_lib_uri:transport(U))
+        end},
+        {"http uses TCP transport", fun() ->
+            {ok, U} = aws_lib_uri:parse("http://localhost:4566/bucket/key"),
+            ?assertEqual(4566, aws_lib_uri:port(U)),
+            ?assertEqual(tcp, aws_lib_uri:transport(U))
+        end},
+        {"https on a non-443 port still uses TLS", fun() ->
+            {ok, U} = aws_lib_uri:parse("https://localhost:8443/x"),
+            ?assertEqual(8443, aws_lib_uri:port(U)),
+            ?assertEqual(tls, aws_lib_uri:transport(U))
+        end},
+        {"a mixed-case scheme is handled", fun() ->
+            {ok, U} = aws_lib_uri:parse("HTTPS://EXAMPLE.COM/x"),
+            ?assertEqual(tls, aws_lib_uri:transport(U))
+        end}
+    ].
+
 %% Malformed input must return an error tuple, never crash (issue #100).
 parse_malformed_test_() ->
     [


### PR DESCRIPTION
Fixes #84.

`aws_lib` hardcoded `https://` for all AWS endpoints and derived the connection transport from the port (443 meant TLS, anything else meant plain TCP). There was no way to point the client at a local development endpoint such as LocalStack or moto without going through the `request/8` `Endpoint` parameter, and an https endpoint on a non-443 port would have been opened over plain TCP.

## What changed

### Endpoint override

`aws_lib_config:endpoint_url/1` resolves the override from the environment following the AWS CLI v2 and SDK convention: the per-service `AWS_ENDPOINT_URL_<SERVICE>` variable takes precedence over the global `AWS_ENDPOINT_URL`. The service name is upper-cased with hyphens turned into underscores, so `acm-pca` maps to `AWS_ENDPOINT_URL_ACM_PCA`. An empty value is treated as unset.

`endpoint/4` consults the override when the caller passes no explicit host: the override supplies the scheme, host, and port, with the AWS request path appended (a trailing slash on the override is not doubled with the path). An explicit `request/8` `Endpoint` still wins, and with no override the request targets the standard regional HTTPS endpoint, so existing callers are unaffected.

The override is resolved per request rather than cached in the state, because a single `aws_state()` is threaded across several services during the boot ARN-resolution pass, and caching one service's endpoint would leak it to the others.

### Scheme-driven transport

The Gun transport is now scheme-driven instead of port-driven. `aws_lib_uri:transport/1` maps `http` to plain TCP and `https` (and any other scheme, matching the plugin's HTTPS default) to TLS, and `gun_open_opts` takes the transport directly. This corrects the latent case of an https endpoint on a non-443 port, which the old port-based rule would have opened over plain TCP.

## Behaviour notes for the reviewer

- **One-shot and existing callers are unaffected**: with no override configured, `endpoint/4` builds the same regional HTTPS URL as before, and real AWS endpoints (always https/443) resolve to the same TLS transport
- **STS / assume_role and the S3 / Secrets Manager / ACM PCA leaves all honour the override** consistently, because they route through `endpoint/4`
- **IMDS is intentionally not overridable**: the instance-metadata URLs stay hardcoded to `169.254.169.254`
- **The legacy two-step `open_connection` API keeps targeting the real AWS endpoint over TLS** and does not honour the override (it is a candidate for removal in #108)

## Testing

- new unit tests: env-var precedence (per-service over global, empty-as-unset, hyphen mapping), scheme-driven transport (including https on a non-443 port and a mixed-case scheme), and `endpoint/4` with an override (scheme/host/port applied, trailing slash not doubled, explicit host still wins)
- full eunit suite passes; dialyzer at the pre-existing baseline with no new warnings; xref clean

## Related

- #136 tracks an end-to-end multi-ARN boot CT test; this override is what would let that harness point at a local endpoint without mocking the HTTP layer
