### PR TITLE
Expose decoded AWS error details on retry exhaustion

### DIFF
--- a/src/aws_lib.erl
+++ b/src/aws_lib.erl
@@ -830,7 +830,7 @@ api_request_with_retries(Service, Method, Path, Body, Headers, Retries, WaitTime
     %% start with `undefined' (nothing open yet, opened lazily on first attempt).
     Conn0 = seed_conn_from_state(State),
     api_request_with_retries(
-        Service, Method, Path, Body, Headers, Retries, WaitTime, State, Conn0
+        Service, Method, Path, Body, Headers, Retries, WaitTime, State, Conn0, undefined
     ).
 
 -spec api_request_with_retries(
@@ -842,18 +842,24 @@ api_request_with_retries(Service, Method, Path, Body, Headers, Retries, WaitTime
     Retries :: integer(),
     WaitTime :: integer(),
     State :: aws_state(),
-    Conn :: aws_lib_httpc:conn() | undefined
+    Conn :: aws_lib_httpc:conn() | undefined,
+    LastError :: result_error() | undefined
 ) ->
     {ok, list(), aws_state()} | {error, term()}.
 api_request_with_retries(
-    _Service, _Method, _Path, _Body, _Headers, Retries, _WaitTime, _State, Conn
+    _Service, _Method, _Path, _Body, _Headers, Retries, _WaitTime, _State, Conn, LastError
 ) when
     Retries =< 0
 ->
     close_if_open(Conn),
     ?LOG_ERROR("Request to AWS service has failed after ~b retries", [?MAX_RETRIES]),
-    {error, "AWS service is unavailable"};
-api_request_with_retries(Service, Method, Path, Body, Headers, Retries, WaitTime, State0, Conn0) ->
+    %% Surface the last attempt's decoded AWS error so the caller can act on the
+    %% service error code (throttling vs invalid parameter vs access denied)
+    %% rather than a generic string (issue #82).
+    {error, exhausted_error(LastError)};
+api_request_with_retries(
+    Service, Method, Path, Body, Headers, Retries, WaitTime, State0, Conn0, LastError
+) ->
     case ensure_credentials_valid(State0) of
         {ok, State1} ->
             {Result, Conn1} =
@@ -863,7 +869,7 @@ api_request_with_retries(Service, Method, Path, Body, Headers, Retries, WaitTime
                     ?LOG_DEBUG("AWS request: ~ts~nResponse: ~tp", [Path, Payload]),
                     State3 = finish_conn_success(Conn1, State2),
                     {ok, Payload, State3};
-                {error, Message, Response} ->
+                {error, Message, Response} = Error ->
                     %% Message may be a status string (from format_response/1
                     %% on an HTTP error) or a tuple such as
                     %% {gun_open_failed, Reason} on a connection failure, so
@@ -882,14 +888,54 @@ api_request_with_retries(Service, Method, Path, Body, Headers, Retries, WaitTime
                     %% perform_request_reuse/8 hands back a live connection after
                     %% an HTTP-level error (reused on the next attempt) or
                     %% `undefined' after a transport failure (reopened next attempt).
+                    %% Carry the most informative error forward so retry
+                    %% exhaustion can return it: a decoded service-error body from
+                    %% an earlier attempt is kept even if a later attempt fails at
+                    %% the transport level with no body.
                     api_request_with_retries(
-                        Service, Method, Path, Body, Headers, Retries - 1, WaitTime, State1, Conn1
+                        Service,
+                        Method,
+                        Path,
+                        Body,
+                        Headers,
+                        Retries - 1,
+                        WaitTime,
+                        State1,
+                        Conn1,
+                        keep_informative_error(LastError, Error)
                     )
             end;
         {error, Reason} ->
             close_if_open(Conn0),
             {error, {credentials, Reason}}
     end.
+
+%% Keep the more informative of two retry errors: an error carrying a decoded
+%% AWS error body (an HTTP 4xx/5xx) wins over one without (a transport failure,
+%% which format_response/1 shapes as {error, _, undefined}). This preserves a
+%% service error seen on an earlier attempt when a later attempt fails at the
+%% transport level, so retry exhaustion still surfaces the useful detail.
+keep_informative_error(_LastError, {error, _Message, {_Headers, _Body}} = NewError) ->
+    %% The new error has a decoded body: it is at least as informative.
+    NewError;
+keep_informative_error({error, _Message, {_Headers, _Body}} = LastError, _NewError) ->
+    %% The new error has no body but a prior one did: keep the prior error.
+    LastError;
+keep_informative_error(_LastError, NewError) ->
+    NewError.
+
+%% Build the caller-facing error at retry exhaustion. When an attempt produced a
+%% decoded AWS error body (an HTTP 4xx/5xx), surface that body under
+%% `service_error' so the caller can inspect the AWS error code. A transport
+%% failure carries no body (or there was no attempt), so fall back to a generic
+%% reason. The decoded body is a proplist for JSON/XML responses but may be a
+%% raw binary for other content types, hence the list()|binary() element.
+-spec exhausted_error(result_error() | undefined) ->
+    {service_error, list() | binary()} | {service_error, retries_exhausted}.
+exhausted_error({error, _Message, {_Headers, DecodedBody}}) ->
+    {service_error, DecodedBody};
+exhausted_error(_) ->
+    {service_error, retries_exhausted}.
 
 %% Perform one request attempt on a reusable connection. Opens a connection when
 %% none is carried (or the carried one targets a different host) and reuses the

--- a/test/aws_lib_tests.erl
+++ b/test/aws_lib_tests.erl
@@ -637,8 +637,86 @@ api_get_request_test_() ->
                     fun(_Pid, _, _) -> {error, "network error"} end
                 ),
 
+                %% A transport failure carries no decoded body, so retry
+                %% exhaustion reports the generic reason.
                 Result = aws_lib:api_get_request("AWS", "API", State),
-                ?assertEqual({error, "AWS service is unavailable"}, Result),
+                ?assertEqual({error, {service_error, retries_exhausted}}, Result),
+                meck:validate(gun)
+            end},
+            {"a persistent HTTP error surfaces the decoded AWS error body", fun() ->
+                State0 = set_test_credentials("ExpiredKey", "ExpiredAccessKey", undefined, {
+                    {3016, 4, 1}, {12, 0, 0}
+                }),
+                {ok, State} = aws_lib:set_region("us-east-1", State0),
+
+                meck:expect(gun, open, fun(_, _, _) -> {ok, spawn(fun() -> ok end)} end),
+                meck:expect(gun, close, fun(_) -> ok end),
+                meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
+                meck:expect(gun, get, fun(_Pid, _Path, _Headers) -> nofin end),
+                %% Every attempt returns an HTTP 400 with a decoded JSON error
+                %% body; after retries are exhausted the caller must receive that
+                %% decoded body under service_error, not a generic string.
+                meck:expect(gun, await, fun(_Pid, _, _) ->
+                    {response, nofin, 400, [{<<"content-type">>, <<"application/json">>}]}
+                end),
+                meck:expect(gun, await_body, fun(_Pid, _, _) ->
+                    {ok, <<
+                        "{\"Error\": {\"Code\": \"ThrottlingException\", "
+                        "\"Message\": \"Rate exceeded\"}}"
+                    >>}
+                end),
+
+                Result = aws_lib:api_get_request("AWS", "API", State),
+                ?assertEqual(
+                    {error,
+                        {service_error, [
+                            {"Error", [
+                                {"Code", "ThrottlingException"},
+                                {"Message", "Rate exceeded"}
+                            ]}
+                        ]}},
+                    Result
+                ),
+                meck:validate(gun)
+            end},
+            {"a decoded error survives a later transport failure", fun() ->
+                State0 = set_test_credentials("ExpiredKey", "ExpiredAccessKey", undefined, {
+                    {3016, 4, 1}, {12, 0, 0}
+                }),
+                {ok, State} = aws_lib:set_region("us-east-1", State0),
+
+                meck:expect(gun, open, fun(_, _, _) -> {ok, spawn(fun() -> ok end)} end),
+                meck:expect(gun, close, fun(_) -> ok end),
+                meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
+                meck:expect(gun, get, fun(_Pid, _Path, _Headers) -> nofin end),
+                %% The first attempt returns an HTTP 400 with a decoded error
+                %% body; every later attempt fails at the transport level (no
+                %% body). Retry exhaustion must still surface the decoded body
+                %% from the first attempt, not the bodiless transport error.
+                meck:expect(
+                    gun,
+                    await,
+                    3,
+                    meck:seq([
+                        {response, nofin, 400, [{<<"content-type">>, <<"application/json">>}]},
+                        {error, "network error"},
+                        {error, "network error"},
+                        {error, "network error"},
+                        {error, "network error"}
+                    ])
+                ),
+                meck:expect(gun, await_body, fun(_Pid, _, _) ->
+                    {ok, <<"{\"Error\": {\"Code\": \"InvalidParameterValue\"}}">>}
+                end),
+
+                Result = aws_lib:api_get_request("AWS", "API", State),
+                ?assertEqual(
+                    {error,
+                        {service_error, [
+                            {"Error", [{"Code", "InvalidParameterValue"}]}
+                        ]}},
+                    Result
+                ),
                 meck:validate(gun)
             end},
             {"AWS service API request succeeded after a transient error", fun() ->
@@ -696,7 +774,7 @@ api_get_request_test_() ->
                 meck:expect(gun, close, fun(_) -> ok end),
 
                 Result = aws_lib:api_get_request("AWS", "API", State),
-                ?assertEqual({error, "AWS service is unavailable"}, Result),
+                ?assertEqual({error, {service_error, retries_exhausted}}, Result),
                 meck:validate(gun)
             end},
             {"gun:await_up failure re-enters the retry loop rather than raising", fun() ->
@@ -712,7 +790,7 @@ api_get_request_test_() ->
                 meck:expect(gun, await_up, fun(_, _) -> {error, timeout} end),
 
                 Result = aws_lib:api_get_request("AWS", "API", State),
-                ?assertEqual({error, "AWS service is unavailable"}, Result),
+                ?assertEqual({error, {service_error, retries_exhausted}}, Result),
                 meck:validate(gun)
             end}
         ]


### PR DESCRIPTION
Fixes #82.

`api_get_request/3` and `api_post_request/5` discarded the decoded error body when a request failed after all retries, returning the generic `{error, "AWS service is unavailable"}`. Callers could not tell a throttling error from an invalid parameter or an access-denied error, even though `format_response/1` had already decoded the AWS error body inside the retry loop.

## What changed

Thread the last attempt's error through the retry loop and, at exhaustion, return the decoded AWS error to the caller:

- `{error, {service_error, DecodedBody}}` when an attempt produced a decoded AWS error body (an HTTP 4xx/5xx)
- `{error, {service_error, retries_exhausted}}` for a transport failure that carried no body

The tagged 2-tuple keeps the value compatible with every caller's existing `{error, _}` match, so `aws_s3`, `aws_sms`, `aws_acm_pca`, `aws_iam`, and `instance_volumes` are unaffected.

### Keep the most informative error

A decoded service-error body from an earlier attempt is kept even if a later attempt fails at the transport level with no body, so a transient connection blip on the final attempt does not mask a real service error (for example a `ThrottlingException` seen on attempt 1 survives a network drop on attempt 2).

The decoded body is a proplist for JSON and XML responses but may be a raw binary for other content types, which the spec reflects.

## Scope

This is the retry-exhaustion half of the issue. Returning non-retriable errors immediately with their full context depends on response classification (#80) and is left for when that lands.

## Testing

- new unit tests: a persistent HTTP error surfaces the decoded AWS error body; a decoded error survives a later transport failure (both proven non-vacuous); the three existing transport-failure cases now assert `retries_exhausted`
- full eunit suite passes (524); dialyzer at the pre-existing baseline with no new warnings; xref clean
