### PR TITLE
Classify AWS responses and stop retrying non-retriable errors

### DIFF
--- a/include/aws_lib.hrl
+++ b/include/aws_lib.hrl
@@ -163,10 +163,12 @@
     | {ok, {status_code(), body()}}
     | {error, term()}.
 
--type result_ok() :: {ok, {ResponseHeaders :: headers(), Response :: list()}}.
+%% The response payload is the decoded body: a proplist for JSON/XML content
+%% types, or the raw binary when the body could not be decoded.
+-type result_ok() :: {ok, {ResponseHeaders :: headers(), Response :: list() | binary()}}.
 -type result_error() ::
     {'error', Message :: reason_phrase(),
-        {ResponseHeaders :: headers(), Response :: list()} | undefined}
+        {ResponseHeaders :: headers(), Response :: list() | binary()} | undefined}
     | {'error', {credentials, Reason :: string()}}
     | {'error', string()}.
 -type result() :: result_ok() | result_error().

--- a/include/aws_lib.hrl
+++ b/include/aws_lib.hrl
@@ -158,11 +158,6 @@
 }).
 -type request() :: #request{}.
 
--type httpc_result() ::
-    {ok, {status_line(), headers(), body()}}
-    | {ok, {status_code(), body()}}
-    | {error, term()}.
-
 %% The response payload is the decoded body: a proplist for JSON/XML content
 %% types, or the raw binary when the body could not be decoded.
 -type result_ok() :: {ok, {ResponseHeaders :: headers(), Response :: list() | binary()}}.

--- a/src/aws_acm_pca.erl
+++ b/src/aws_acm_pca.erl
@@ -8,7 +8,7 @@
 -export([fetch_certificate/3]).
 
 -spec fetch_certificate(string(), string(), aws_lib:aws_state()) ->
-    {ok, binary(), aws_lib:aws_state()} | {error, term()}.
+    {ok, binary(), aws_lib:aws_state()} | {error, term(), aws_lib:aws_state()}.
 fetch_certificate(CaArn, Region, State) ->
     {ok, State1} = aws_lib:set_region(Region, State),
     RequestBody = rabbit_json:encode(#{
@@ -30,8 +30,8 @@ make_request(RequestBody, Headers, State) ->
                 {"Certificate", Certificate} ->
                     {ok, rabbit_data_coercion:to_utf8_binary(Certificate), State1};
                 false ->
-                    {error, no_certificate}
+                    {error, no_certificate, State1}
             end;
-        {error, _} = Error ->
+        {error, _Reason, _State1} = Error ->
             Error
     end.

--- a/src/aws_arn_config.erl
+++ b/src/aws_arn_config.erl
@@ -112,8 +112,8 @@ run_arn_handlers([{Mod, Arn, SchemaKey, Args} | Rest], State) ->
                 {error, _} = Error ->
                     {error, Error, State1}
             end;
-        {error, _} = Error ->
-            {error, get_resolve_arn_error(Arn, SchemaKey, Error), State}
+        {error, Reason, State1} ->
+            {error, get_resolve_arn_error(Arn, SchemaKey, {error, Reason}), State1}
     end.
 
 get_resolve_arn_error(Arn, SchemaKey, {error, E} = Error) ->

--- a/src/aws_arn_config_oauth2.erl
+++ b/src/aws_arn_config_oauth2.erl
@@ -26,8 +26,8 @@ run(_KeyStr, providers_https_cacertfile, OAuth2Map, State) when is_map(OAuth2Map
                     Error ->
                         throw(apply_error(MapKey, Arn, Error))
                 end;
-            Error ->
-                throw(resolve_error(MapKey, Arn, Error))
+            {error, Reason, _StateAcc1} ->
+                throw(resolve_error(MapKey, Arn, {error, Reason}))
         end
     end,
     try

--- a/src/aws_arn_util.erl
+++ b/src/aws_arn_util.erl
@@ -12,7 +12,7 @@
 -endif.
 
 -spec resolve_arn(string(), aws_lib:aws_state()) ->
-    {ok, binary(), aws_lib:aws_state()} | {error, term()}.
+    {ok, binary(), aws_lib:aws_state()} | {error, term(), aws_lib:aws_state()}.
 resolve_arn(Arn, State) ->
     case parse_arn(Arn) of
         {ok, #{service := "s3", resource := Resource}} ->
@@ -23,9 +23,9 @@ resolve_arn(Arn, State) ->
             aws_acm_pca:fetch_certificate(Arn, Region, State);
         {ok, #{service := Service}} ->
             Reason = unsupported_service,
-            {error, {Reason, Service}};
-        {error, _} = Error ->
-            Error
+            {error, {Reason, Service}, State};
+        {error, Reason} ->
+            {error, Reason, State}
     end.
 
 -spec parse_arn(string()) -> {ok, map()} | {error, term()}.

--- a/src/aws_auth_validate_ssl.erl
+++ b/src/aws_auth_validate_ssl.erl
@@ -175,7 +175,7 @@ resolve_arn(_Arn, none) ->
 resolve_arn(Arn, State) when is_binary(Arn) ->
     case aws_arn_util:resolve_arn(binary_to_list(Arn), State) of
         {ok, Data, _State1} -> {ok, Data};
-        {error, _} = Error -> Error
+        {error, Reason, _State1} -> {error, Reason}
     end.
 
 %%--------------------------------------------------------------------

--- a/src/aws_iam.erl
+++ b/src/aws_iam.erl
@@ -47,6 +47,9 @@ make_request(Body, Headers, State) ->
     case aws_lib:api_post_request("sts", "/", Body, Headers, State) of
         {ok, ResponseBody, State1} ->
             parse_assume_role_response(ResponseBody, State1);
-        Error ->
-            Error
+        {error, Reason, _State1} ->
+            %% assume_role/2 runs before connection reuse is enabled (one-shot
+            %% mode), so there is no connection to hand back; collapse the error
+            %% to a 2-tuple and keep this module's public contract unchanged.
+            {error, Reason}
     end.

--- a/src/aws_lib.erl
+++ b/src/aws_lib.erl
@@ -847,6 +847,14 @@ api_request_with_retries(
                             %% reuse mode the connection is handed back for the
                             %% next request; in one-shot mode finish_conn/2 closes
                             %% it.
+                            %% Log at ERROR level so log-level alerting still sees
+                            %% a permanent failure: before issue #80 short-circuited
+                            %% the retry loop, this failure would have exhausted the
+                            %% retries and reached the ?LOG_ERROR clause above.
+                            ?LOG_ERROR(
+                                "Request to AWS service has failed with a permanent error: ~tp",
+                                [Message]
+                            ),
                             State3 = finish_conn(Conn1, State1),
                             {error, exhausted_error(Error), State3};
                         retriable ->

--- a/src/aws_lib.erl
+++ b/src/aws_lib.erl
@@ -968,7 +968,11 @@ perform_request_reuse(Service, Method, Headers, Path, Body, Options, State0, Con
                     {aws_lib_response:format_response(Error), ConnSlot0, retriable}
             end;
         {error, _} = Error ->
-            {Error, ConnSlot0, retriable}
+            %% Shape the 2-tuple error through format_response/1 into the
+            %% 3-tuple result the retry loop matches on; returning the raw
+            %% {error, Reason} here would raise a case_clause in
+            %% api_request_with_retries/10.
+            {aws_lib_response:format_response(Error), ConnSlot0, retriable}
     end.
 
 %% Attach the connection slot and retry verdict to carry forward based on the

--- a/src/aws_lib.erl
+++ b/src/aws_lib.erl
@@ -28,7 +28,6 @@
     local_time/0,
     api_get_request/3,
     api_post_request/5,
-    status_text/1,
     open_connection/2, open_connection/3,
     close_connection/1,
     direct_request/7,
@@ -616,37 +615,6 @@ do_refresh_credentials(State0) ->
             {error, Reason}
     end.
 
--spec format_response(Response :: httpc_result()) -> result().
-%% @doc Format the httpc response result, returning the request result data
-%% structure. The response body will attempt to be decoded by invoking the
-%% maybe_decode_body/2 method.
-%% @end
-%% Any 2xx is a success. Every other status (3xx redirects we do not follow,
-%% 4xx, 5xx) is an error: gun is not configured to follow redirects, so a 3xx
-%% is a request we could not complete.
-format_response({ok, {{_Version, StatusCode, _Message}, Headers, Body}}) when
-    StatusCode >= 200, StatusCode < 300
-->
-    {ok, {Headers, maybe_decode_body(get_content_type(Headers), Body)}};
-format_response({ok, {{_Version, _StatusCode, Message}, Headers, Body}}) ->
-    {error, Message, {Headers, maybe_decode_body(get_content_type(Headers), Body)}};
-format_response({error, Reason}) ->
-    {error, Reason, undefined}.
-
--spec get_content_type(Headers :: headers()) -> {Type :: string(), Subtype :: string()}.
-%% @doc Fetch the content type from the headers and return it as a tuple of
-%%      {Type, Subtype}.
-%% @end
-get_content_type(Headers) ->
-    Value =
-        case proplists:get_value(<<"content-type">>, Headers, undefined) of
-            undefined ->
-                proplists:get_value(<<"Content-Type">>, Headers, "text/xml");
-            Other ->
-                Other
-        end,
-    parse_content_type(Value).
-
 -spec expired_credentials(Expiration :: calendar:datetime()) -> boolean().
 %% @doc Indicates whether the given expiration is at or within the refresh
 %% buffer window. Credentials are treated as expired a few minutes before they
@@ -671,47 +639,6 @@ expired_credentials(Expiration) ->
 %% @end
 local_time() ->
     calendar:universal_time().
-
--spec maybe_decode_body(ContentType :: {nonempty_string(), nonempty_string()}, Body :: body()) ->
-    list() | body().
-%% @doc Attempt to decode the response body by its MIME
-%% @end
-maybe_decode_body(_, <<>>) ->
-    <<>>;
-maybe_decode_body({"application", Subtype}, Body) ->
-    case is_json_subtype(Subtype) of
-        true -> aws_lib_json:decode(Body);
-        false -> maybe_decode_xml(Subtype, Body)
-    end;
-maybe_decode_body({_, Subtype}, Body) ->
-    maybe_decode_xml(Subtype, Body).
-
-maybe_decode_xml("xml", Body) ->
-    aws_lib_xml:parse(Body);
-maybe_decode_xml(_Subtype, Body) ->
-    Body.
-
-%% Recognise the JSON subtypes AWS services return. Covers plain `json', every
-%% AWS JSON protocol version (`x-amz-json-1.0', `x-amz-json-1.1', and any future
-%% `x-amz-json-*'), and the RFC 6839 structured `+json' suffix. Secrets Manager
-%% and other services use the JSON 1.1 protocol, so matching only 1.0/plain left
-%% those responses undecoded (issue #99).
-is_json_subtype("json") ->
-    true;
-is_json_subtype("x-amz-json-" ++ _Version) ->
-    true;
-is_json_subtype(Subtype) ->
-    lists:suffix("+json", Subtype).
-
--spec parse_content_type(ContentType :: string()) -> {Type :: string(), Subtype :: string()}.
-%% @doc parse a content type string returning a tuple of type/subtype
-%% @end
-parse_content_type(ContentType) when is_binary(ContentType) ->
-    parse_content_type(binary_to_list(ContentType));
-parse_content_type(ContentType) ->
-    Parts = string:tokens(ContentType, ";"),
-    [Type, Subtype] = string:tokens(lists:nth(1, Parts), "/"),
-    {Type, Subtype}.
 
 -spec expired_imdsv2_token('undefined' | imdsv2token()) -> boolean().
 %% @doc Determine whether or not an Imdsv2Token has expired.
@@ -887,7 +814,7 @@ api_request_with_retries(
 ) ->
     case ensure_credentials_valid(State0) of
         {ok, State1} ->
-            {Result, Conn1} =
+            {Result, Conn1, Verdict} =
                 perform_request_reuse(Service, Method, Headers, Path, Body, [], State1, Conn0),
             case Result of
                 {ok, {_Headers, Payload}, State2} ->
@@ -908,27 +835,40 @@ api_request_with_retries(
                         _ ->
                             ok
                     end,
-                    ?LOG_WARNING("Will retry AWS request, remaining retries: ~b", [Retries]),
-                    timer:sleep(WaitTime),
-                    %% perform_request_reuse/8 hands back a live connection after
-                    %% an HTTP-level error (reused on the next attempt) or
-                    %% `undefined' after a transport failure (reopened next attempt).
-                    %% Carry the most informative error forward so retry
-                    %% exhaustion can return it: a decoded service-error body from
-                    %% an earlier attempt is kept even if a later attempt fails at
-                    %% the transport level with no body.
-                    api_request_with_retries(
-                        Service,
-                        Method,
-                        Path,
-                        Body,
-                        Headers,
-                        Retries - 1,
-                        WaitTime,
-                        State1,
-                        Conn1,
-                        keep_informative_error(LastError, Error)
-                    )
+                    case Verdict of
+                        not_retriable ->
+                            %% A 4xx client error that will not succeed on retry
+                            %% (issue #80): close the connection and return the
+                            %% decoded error to the caller immediately rather than
+                            %% burning the remaining retries.
+                            close_if_open(Conn1),
+                            {error, exhausted_error(Error)};
+                        retriable ->
+                            ?LOG_WARNING(
+                                "Will retry AWS request, remaining retries: ~b", [Retries]
+                            ),
+                            timer:sleep(WaitTime),
+                            %% perform_request_reuse/8 hands back a live connection
+                            %% after an HTTP-level error (reused on the next
+                            %% attempt) or `undefined' after a transport failure
+                            %% (reopened next attempt). Carry the most informative
+                            %% error forward so retry exhaustion can return it: a
+                            %% decoded service-error body from an earlier attempt
+                            %% is kept even if a later attempt fails at the
+                            %% transport level with no body.
+                            api_request_with_retries(
+                                Service,
+                                Method,
+                                Path,
+                                Body,
+                                Headers,
+                                Retries - 1,
+                                WaitTime,
+                                State1,
+                                Conn1,
+                                keep_informative_error(LastError, Error)
+                            )
+                    end
             end;
         {error, Reason} ->
             close_if_open(Conn0),
@@ -983,7 +923,8 @@ exhausted_error(_) ->
 ) ->
     {
         {ok, {headers(), term()}, aws_state()} | result_error(),
-        {aws_lib_httpc:conn(), string(), inet:port_number()} | undefined
+        {aws_lib_httpc:conn(), string(), inet:port_number()} | undefined,
+        retriable | not_retriable
     }.
 perform_request_reuse(Service, Method, Headers, Path, Body, Options, State0, ConnSlot0) ->
     case prepare_signed_request(Service, Method, Headers, Path, Body, Options, undefined, State0) of
@@ -1002,29 +943,47 @@ perform_request_reuse(Service, Method, Headers, Path, Body, Options, State0, Con
                             Response = aws_lib_httpc:request(
                                 Conn1, Method, Target, SignedHeaders, Body, Timeout
                             ),
+                            %% Classify from the raw response (it still carries
+                            %% the numeric status) and the formatted result (it
+                            %% carries the body decoded once by
+                            %% format_response/1).
+                            Formatted = aws_lib_response:format_response(Response),
                             classify_reuse_response(
-                                format_response(Response), State1, {Conn1, Host, Port}
+                                Formatted,
+                                aws_lib_response:classify_response(Response, Formatted),
+                                State1,
+                                {Conn1, Host, Port}
                             );
                         {error, Reason} ->
-                            {format_response({error, Reason}), undefined}
+                            {
+                                aws_lib_response:format_response({error, Reason}),
+                                undefined,
+                                retriable
+                            }
                     end;
                 {error, _Reason} = Error ->
-                    {format_response(Error), ConnSlot0}
+                    %% A malformed URI never becomes valid on retry, but it is not
+                    %% an AWS response either; preserve the pre-existing retry
+                    %% behaviour by treating it as retriable.
+                    {aws_lib_response:format_response(Error), ConnSlot0, retriable}
             end;
         {error, _} = Error ->
-            {Error, ConnSlot0}
+            {Error, ConnSlot0, retriable}
     end.
 
-%% Attach the connection slot to carry forward based on the request outcome:
-%% success or an HTTP-level error leaves the connection intact; a transport
-%% failure (format_response/1's {error, _, undefined}) makes it unusable.
-classify_reuse_response({ok, Result}, State, ConnSlot) ->
-    {{ok, Result, State}, ConnSlot};
-classify_reuse_response({error, _Reason, undefined} = Err, _State, {Conn, _, _}) ->
+%% Attach the connection slot and retry verdict to carry forward based on the
+%% request outcome: success or an HTTP-level error leaves the connection intact;
+%% a transport failure (format_response/1's {error, _, undefined}) makes it
+%% unusable. The verdict from classify_response/1 rides through unchanged; a
+%% success is always reported as retriable but the caller ignores the verdict on
+%% the success branch.
+classify_reuse_response({ok, Result}, Verdict, State, ConnSlot) ->
+    {{ok, Result, State}, ConnSlot, Verdict};
+classify_reuse_response({error, _Reason, undefined} = Err, Verdict, _State, {Conn, _, _}) ->
     aws_lib_httpc:close(Conn),
-    {Err, undefined};
-classify_reuse_response({error, _Message, _Payload} = Err, _State, ConnSlot) ->
-    {Err, ConnSlot}.
+    {Err, undefined, Verdict};
+classify_reuse_response({error, _Message, _Payload} = Err, Verdict, _State, ConnSlot) ->
+    {Err, ConnSlot, Verdict}.
 
 %% Return a usable connection to Host:Port. If the carried slot targets the same
 %% host, reuse it; if it targets a different host (cross-service boot pass),
@@ -1090,9 +1049,9 @@ gun_request(Method, URI, Headers, Body, Options) ->
             Response = aws_lib_httpc:request(
                 Host, Port, Method, Path, Headers, Body, OpenOpts
             ),
-            format_response(Response);
+            aws_lib_response:format_response(Response);
         {error, _Reason} = Error ->
-            format_response(Error)
+            aws_lib_response:format_response(Error)
     end.
 
 %% Build aws_lib_httpc open options from the request Options and Transport:
@@ -1124,16 +1083,6 @@ create_uri(Host, Path) when is_list(Path) ->
 create_uri(Host, {Bucket, Key}) ->
     "https://" ++ Bucket ++ "." ++ Host ++ "/" ++ Key.
 
-status_text(200) -> "OK";
-status_text(206) -> "Partial Content";
-status_text(400) -> "Bad Request";
-status_text(401) -> "Unauthorized";
-status_text(403) -> "Forbidden";
-status_text(404) -> "Not Found";
-status_text(416) -> "Range Not Satisfiable";
-status_text(500) -> "Internal Server Error";
-status_text(Code) -> integer_to_list(Code).
-
 -spec direct_gun_request(
     Conn :: aws_lib_httpc:conn(),
     Method :: method(),
@@ -1151,7 +1100,7 @@ direct_gun_request(Conn, Method, {_, Path}, Headers, Body, Options) ->
 direct_gun_request(Conn, Method, Path, Headers, Body, Options) ->
     Timeout = proplists:get_value(timeout, Options, ?DEFAULT_API_TIMEOUT),
     Response = aws_lib_httpc:request(Conn, Method, Path, Headers, Body, Timeout),
-    format_response(Response).
+    aws_lib_response:format_response(Response).
 
 -spec parse_volumes_response(term()) -> {'ok', volumes_list()} | {'error', 'parse_error'}.
 %% @doc Parse the DescribeVolumes XML response into a list of volume information.

--- a/src/aws_lib.erl
+++ b/src/aws_lib.erl
@@ -693,7 +693,7 @@ ensure_imdsv2_token_valid(State0) ->
     Service :: string(),
     Path :: path(),
     State :: aws_state()
-) -> {ok, list(), aws_state()} | {error, term()}.
+) -> {ok, list(), aws_state()} | {error, term(), aws_state()}.
 %% @doc Invoke an API call to an AWS service.
 %% @end
 api_get_request(Service, Path, State) ->
@@ -715,7 +715,7 @@ api_get_request(Service, Path, State) ->
     Body :: body(),
     Headers :: headers(),
     State :: aws_state()
-) -> {ok, list(), aws_state()} | {error, term()}.
+) -> {ok, list(), aws_state()} | {error, term(), aws_state()}.
 %% @doc Perform a HTTP Post request to the AWS API for the specified service. The
 %%      response will automatically be decoded if it is either in JSON or XML
 %%      format.
@@ -750,8 +750,8 @@ instance_volumes(State0 = #aws_state{config = Config0}) ->
                         Error ->
                             Error
                     end;
-                Error ->
-                    Error
+                {error, Reason, _State1} ->
+                    {error, Reason}
             end;
         Error ->
             Error
@@ -771,7 +771,7 @@ instance_volumes(State0 = #aws_state{config = Config0}) ->
     WaitTime :: integer(),
     State :: aws_state()
 ) ->
-    {ok, list(), aws_state()} | {error, term()}.
+    {ok, list(), aws_state()} | {error, term(), aws_state()}.
 %% @doc Invoke an API call to an AWS service with retries.
 %% @end
 api_request_with_retries(Service, Method, Path, Body, Headers, Retries, WaitTime, State) ->
@@ -797,18 +797,21 @@ api_request_with_retries(Service, Method, Path, Body, Headers, Retries, WaitTime
     Conn :: aws_lib_httpc:conn() | undefined,
     LastError :: result_error() | undefined
 ) ->
-    {ok, list(), aws_state()} | {error, term()}.
+    {ok, list(), aws_state()} | {error, term(), aws_state()}.
 api_request_with_retries(
-    _Service, _Method, _Path, _Body, _Headers, Retries, _WaitTime, _State, Conn, LastError
+    _Service, _Method, _Path, _Body, _Headers, Retries, _WaitTime, State, Conn, LastError
 ) when
     Retries =< 0
 ->
-    close_if_open(Conn),
     ?LOG_ERROR("Request to AWS service has failed after ~b retries", [?MAX_RETRIES]),
+    %% Reconcile the carried connection into the returned state: in reuse mode a
+    %% still-live connection is handed back, a transport-dropped one (undefined)
+    %% clears the slot; in one-shot mode it is closed.
+    State1 = finish_conn(Conn, State),
     %% Surface the last attempt's decoded AWS error so the caller can act on the
     %% service error code (throttling vs invalid parameter vs access denied)
     %% rather than a generic string (issue #82).
-    {error, exhausted_error(LastError)};
+    {error, exhausted_error(LastError), State1};
 api_request_with_retries(
     Service, Method, Path, Body, Headers, Retries, WaitTime, State0, Conn0, LastError
 ) ->
@@ -819,7 +822,7 @@ api_request_with_retries(
             case Result of
                 {ok, {_Headers, Payload}, State2} ->
                     ?LOG_DEBUG("AWS request: ~ts~nResponse: ~tp", [Path, Payload]),
-                    State3 = finish_conn_success(Conn1, State2),
+                    State3 = finish_conn(Conn1, State2),
                     {ok, Payload, State3};
                 {error, Message, Response} = Error ->
                     %% Message may be a status string (from format_response/1
@@ -838,11 +841,14 @@ api_request_with_retries(
                     case Verdict of
                         not_retriable ->
                             %% A 4xx client error that will not succeed on retry
-                            %% (issue #80): close the connection and return the
-                            %% decoded error to the caller immediately rather than
-                            %% burning the remaining retries.
-                            close_if_open(Conn1),
-                            {error, exhausted_error(Error)};
+                            %% (issue #80): return the decoded error to the caller
+                            %% immediately rather than burning the remaining
+                            %% retries. The exchange completed cleanly, so in
+                            %% reuse mode the connection is handed back for the
+                            %% next request; in one-shot mode finish_conn/2 closes
+                            %% it.
+                            State3 = finish_conn(Conn1, State1),
+                            {error, exhausted_error(Error), State3};
                         retriable ->
                             ?LOG_WARNING(
                                 "Will retry AWS request, remaining retries: ~b", [Retries]
@@ -871,8 +877,8 @@ api_request_with_retries(
                     end
             end;
         {error, Reason} ->
-            close_if_open(Conn0),
-            {error, {credentials, Reason}}
+            State1 = finish_conn(Conn0, State0),
+            {error, {credentials, Reason}, State1}
     end.
 
 %% Keep the more informative of two retry errors: an error carrying a decoded
@@ -1017,13 +1023,23 @@ seed_conn_from_state(#aws_state{reuse_conn = none}) ->
 seed_conn_from_state(#aws_state{reuse_conn = ConnSlot}) ->
     ConnSlot.
 
-%% On success: in reuse mode, write the live connection back into the state so
-%% the next api_*_request call in the same unit of work reuses it. In one-shot
-%% mode (reuse_conn = undefined), close the connection.
-finish_conn_success(ConnSlot, #aws_state{reuse_conn = undefined} = State) ->
+%% Reconcile the retry loop's connection slot into the returned state at every
+%% terminal path (success, a not_retriable error, retry exhaustion, a
+%% credentials failure). In one-shot mode (reuse_conn = undefined), close the
+%% connection. In reuse mode, write a still-live slot back into the state so the
+%% next api_*_request call in the same unit of work reuses it; a transport
+%% failure left `undefined', so record `none' (reuse mode, no connection) rather
+%% than `undefined' (which would silently drop the state out of reuse mode).
+%% Handing back a connection after a cleanly completed 4xx keeps the reuse slot
+%% in sync with reality: the connection is as usable as after a 2xx, and the
+%% caller's state no longer references a connection this call already closed
+%% (issue #80).
+finish_conn(ConnSlot, #aws_state{reuse_conn = undefined} = State) ->
     close_if_open(ConnSlot),
     State;
-finish_conn_success(ConnSlot, State) ->
+finish_conn(undefined, State) ->
+    State#aws_state{reuse_conn = none};
+finish_conn(ConnSlot, State) ->
     State#aws_state{reuse_conn = ConnSlot}.
 
 %% Add the state's AWS API timeout to the request options unless the caller

--- a/src/aws_lib_config.erl
+++ b/src/aws_lib_config.erl
@@ -833,8 +833,6 @@ maybe_get_role_from_instance_metadata_with_conn(ConnPid, Config) ->
             Error
     end.
 
-%% -spec parse_az_response(httpc_result()) ->
-%%     {ok, Region :: string()} | {error, Reason :: atom()}.
 %% @doc Parse the response from the Availability Zone query to the
 %%      Instance Metadata service, returning the Region if successful.
 %% end.

--- a/src/aws_lib_httpc.erl
+++ b/src/aws_lib_httpc.erl
@@ -110,7 +110,7 @@ request(Conn, Method, Path, Headers, Body, Timeout) ->
         case gun:await(Conn, StreamRef, Timeout) of
             {response, fin, Status, RespHeaders} ->
                 {ok, {
-                    {http_version, Status, aws_lib_response:status_text(Status)}, RespHeaders, <<>>
+                    {http_version, Status, status_text(Status)}, RespHeaders, <<>>
                 }};
             {response, nofin, Status, RespHeaders} ->
                 %% await_body/3 can return {error, timeout} (and other {error, _}
@@ -119,7 +119,7 @@ request(Conn, Method, Path, Headers, Body, Timeout) ->
                 case gun:await_body(Conn, StreamRef, Timeout) of
                     {ok, RespBody} ->
                         {ok, {
-                            {http_version, Status, aws_lib_response:status_text(Status)},
+                            {http_version, Status, status_text(Status)},
                             RespHeaders,
                             RespBody
                         }};
@@ -204,3 +204,17 @@ do_gun_request(Conn, patch, Path, Headers, Body) ->
     gun:patch(Conn, Path, Headers, Body, #{});
 do_gun_request(Conn, options, Path, Headers, _Body) ->
     gun:options(Conn, Path, Headers, #{}).
+
+%% The reason phrase for a status code, used to build the status line Gun does
+%% not carry. Response construction, so it lives here alongside the rest of the
+%% response/0 shaping rather than in aws_lib_response, which only interprets a
+%% response.
+status_text(200) -> "OK";
+status_text(206) -> "Partial Content";
+status_text(400) -> "Bad Request";
+status_text(401) -> "Unauthorized";
+status_text(403) -> "Forbidden";
+status_text(404) -> "Not Found";
+status_text(416) -> "Range Not Satisfiable";
+status_text(500) -> "Internal Server Error";
+status_text(Code) -> integer_to_list(Code).

--- a/src/aws_lib_httpc.erl
+++ b/src/aws_lib_httpc.erl
@@ -20,9 +20,9 @@
 %% handle.
 -module(aws_lib_httpc).
 
--export([open/3, request/6, request/7, close/1]).
+-export([open/3, request/6, request/7, close/1, response_status/1]).
 
--export_type([conn/0]).
+-export_type([conn/0, response/0]).
 
 -include("aws_lib.hrl").
 
@@ -46,7 +46,7 @@
 }.
 
 %% The response tuple this module produces, consumed by
-%% aws_lib:format_response/1 and the metadata-service callers. NOTE: the first
+%% aws_lib_response:format_response/1 and the metadata-service callers. NOTE: the first
 %% status-line element is the literal atom `http_version', not an
 %% http_version() string -- this is the shape the plugin has always built, so it
 %% is typed as-is rather than as aws_lib.hrl's status_line() (whose first element
@@ -100,7 +100,7 @@ open(Host, Port, Opts) ->
 %% @doc Issue one request on an existing connection and read the full response.
 %% Headers are normalized to binaries; the await/await_body dance is performed
 %% here so its error handling lives in one place. Returns the status-line-shaped
-%% tuple aws_lib:format_response/1 accepts, or {error, Reason} for any transport
+%% tuple aws_lib_response:format_response/1 accepts, or {error, Reason} for any transport
 %% or body-read failure (including a raise, which is caught).
 %% @end
 request(Conn, Method, Path, Headers, Body, Timeout) ->
@@ -109,7 +109,9 @@ request(Conn, Method, Path, Headers, Body, Timeout) ->
         StreamRef = do_gun_request(Conn, Method, Path, HeadersBin, Body),
         case gun:await(Conn, StreamRef, Timeout) of
             {response, fin, Status, RespHeaders} ->
-                {ok, {{http_version, Status, aws_lib:status_text(Status)}, RespHeaders, <<>>}};
+                {ok, {
+                    {http_version, Status, aws_lib_response:status_text(Status)}, RespHeaders, <<>>
+                }};
             {response, nofin, Status, RespHeaders} ->
                 %% await_body/3 can return {error, timeout} (and other {error, _}
                 %% reasons); surface it cleanly rather than letting a hard match
@@ -117,7 +119,7 @@ request(Conn, Method, Path, Headers, Body, Timeout) ->
                 case gun:await_body(Conn, StreamRef, Timeout) of
                     {ok, RespBody} ->
                         {ok, {
-                            {http_version, Status, aws_lib:status_text(Status)},
+                            {http_version, Status, aws_lib_response:status_text(Status)},
                             RespHeaders,
                             RespBody
                         }};
@@ -131,6 +133,19 @@ request(Conn, Method, Path, Headers, Body, Timeout) ->
         _:Error ->
             {error, Error}
     end.
+
+-spec response_status(response()) -> {http, status_code()} | transport_error.
+%% @doc The status of a response/0: `{http, StatusCode}' for a completed HTTP
+%% exchange, or `transport_error' for a transport-level failure that never
+%% produced a status line. Lives here, where the response/0 shape is built, so
+%% callers classify the outcome without matching the raw tuple (whose status
+%% line uses the literal atom `http_version', a shape a caller-side match on the
+%% aws_lib.hrl status_line() type cannot see as inhabited).
+%% @end
+response_status({ok, {{http_version, StatusCode, _Reason}, _Headers, _Body}}) ->
+    {http, StatusCode};
+response_status({error, _Reason}) ->
+    transport_error.
 
 -spec request(
     Host :: string(),

--- a/src/aws_lib_response.erl
+++ b/src/aws_lib_response.erl
@@ -1,0 +1,242 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% Interprets AWS HTTP responses: shaping the raw aws_lib_httpc:response()
+%% into the plugin's result() (format_response/1), decoding bodies by content
+%% type, and classifying a failed response as retriable or not (issue #80).
+%% aws_lib_httpc owns the request lifecycle and produces the raw response;
+%% this module owns what the response MEANS. aws_lib's retry loop consumes
+%% both.
+-module(aws_lib_response).
+
+-export([
+    format_response/1,
+    classify_response/2,
+    get_content_type/1,
+    maybe_decode_body/2,
+    parse_content_type/1,
+    status_text/1
+]).
+
+-include("aws_lib.hrl").
+
+%% Substring markers, matched case-insensitively, that identify a throttling
+%% error code. This is botocore's _THROTTLED_ERROR_CODES
+%% (botocore/retries/standard.py) collapsed into lowercase substrings:
+%% `throttl' covers Throttling, ThrottlingException, ThrottledException,
+%% RequestThrottledException, RequestThrottled, and EC2ThrottledException;
+%% `limitexceeded' covers RequestLimitExceeded, BandwidthLimitExceeded, and
+%% LimitExceededException; the rest map one to one.
+-define(THROTTLING_MARKERS, [
+    <<"throttl">>,
+    <<"toomanyrequests">>,
+    <<"provisionedthroughputexceeded">>,
+    <<"limitexceeded">>,
+    <<"transactioninprogress">>,
+    <<"slowdown">>,
+    <<"priorrequestnotcomplete">>
+]).
+
+%% The body fields an AWS error document carries its error code under:
+%% `__type' or `code' for the JSON protocols (Smithy awsJson1.0/1.1 specs) and
+%% `Code' for XML error documents (Smithy awsQuery spec). The JSON protocols
+%% also allow the code to arrive in the X-Amzn-Errortype header instead, which
+%% classify_status/2 consults separately.
+-define(ERROR_CODE_KEYS, ["__type", "Code", "code"]).
+
+-define(ERRORTYPE_HEADER, <<"x-amzn-errortype">>).
+
+-spec format_response(Response :: aws_lib_httpc:response()) -> result().
+%% @doc Format the httpc response result, returning the request result data
+%% structure. The response body will attempt to be decoded by invoking the
+%% maybe_decode_body/2 method.
+%% @end
+%% Any 2xx is a success. Every other status (3xx redirects we do not follow,
+%% 4xx, 5xx) is an error: gun is not configured to follow redirects, so a 3xx
+%% is a request we could not complete.
+format_response({ok, {{_Version, StatusCode, _Message}, Headers, Body}}) when
+    StatusCode >= 200, StatusCode < 300
+->
+    {ok, {Headers, maybe_decode_body(get_content_type(Headers), Body)}};
+format_response({ok, {{_Version, _StatusCode, Message}, Headers, Body}}) ->
+    {error, Message, {Headers, maybe_decode_body(get_content_type(Headers), Body)}};
+format_response({error, Reason}) ->
+    {error, Reason, undefined}.
+
+-spec classify_response(Response :: aws_lib_httpc:response(), Formatted :: result()) ->
+    retriable | not_retriable.
+%% @doc Decide whether a failed request should be retried (issue #80). Retry on
+%% 5xx server errors, on HTTP 429, on throttling responses (a throttling error
+%% code in the error body or the X-Amzn-Errortype header), and on transport
+%% failures (a timeout, a dropped socket). Other 4xx client errors (bad
+%% request, not found, access denied) will not succeed on retry, so return
+%% them to the caller immediately. Takes the raw response (whose status line
+%% format_response/1 collapses into a reason phrase) alongside its
+%% already-formatted result (whose body format_response/1 already decoded), so
+%% the body is decoded exactly once per response. The two arguments must come
+%% from the same response.
+classify_response(Response, Formatted) ->
+    classify_status(aws_lib_httpc:response_status(Response), Formatted).
+
+-spec classify_status({http, integer()} | transport_error, result()) ->
+    retriable | not_retriable.
+classify_status({http, StatusCode}, _Formatted) when StatusCode >= 200, StatusCode < 300 ->
+    %% A success is never retried; the verdict is ignored on the success branch,
+    %% but the function stays total.
+    retriable;
+classify_status({http, StatusCode}, _Formatted) when StatusCode >= 500 ->
+    retriable;
+classify_status({http, 429}, _Formatted) ->
+    retriable;
+classify_status({http, StatusCode}, {error, _Message, {Headers, Decoded}}) when
+    StatusCode >= 400
+->
+    %% An HTTP-level error always formats to {error, Message, {Headers, Body}},
+    %% so the decoded body is available here.
+    case is_throttling_error(Headers, Decoded) of
+        true -> retriable;
+        false -> not_retriable
+    end;
+classify_status({http, _StatusCode}, _Formatted) ->
+    %% 3xx (redirects we do not follow) and any other unclassified status: not a
+    %% success and not obviously transient, so return it to the caller.
+    not_retriable;
+classify_status(transport_error, _Formatted) ->
+    %% A transport-level failure (timeout, closed socket, connection refused);
+    %% these are transient, so retry.
+    retriable.
+
+%% Decide whether an error response indicates throttling. The error code is
+%% taken from the X-Amzn-Errortype header when present alongside the values
+%% stored under the AWS error-code body keys; matching the error code rather
+%% than the whole body keeps a marker inside a message or resource name from
+%% triggering a retry. A body that could not be decoded (still a raw binary)
+%% falls back to a substring search of the raw bytes.
+-spec is_throttling_error(headers(), list() | body()) -> boolean().
+is_throttling_error(Headers, Body) when is_binary(Body) ->
+    lists:any(fun contains_throttling_marker/1, errortype_header_values(Headers) ++ [Body]);
+is_throttling_error(Headers, Decoded) ->
+    Candidates = errortype_header_values(Headers) ++ error_code_values(Decoded),
+    lists:any(fun contains_throttling_marker/1, Candidates).
+
+%% The X-Amzn-Errortype header values, compared case-insensitively on the
+%% header name since HTTP/1.1 servers may vary its casing.
+errortype_header_values(Headers) ->
+    [Value || {Name, Value} <- Headers, is_errortype_header(Name)].
+
+is_errortype_header(Name) ->
+    try string:lowercase(rabbit_data_coercion:to_utf8_binary(Name)) of
+        ?ERRORTYPE_HEADER -> true;
+        _ -> false
+    catch
+        _:_ -> false
+    end.
+
+%% Collect the values stored under AWS error-code keys anywhere in a decoded
+%% body (a nested proplist with string keys).
+error_code_values([{Key, Value} | T]) ->
+    error_code_values_for(Key, Value) ++ error_code_values(T);
+error_code_values([_ | T]) ->
+    error_code_values(T);
+error_code_values(_) ->
+    [].
+
+error_code_values_for(Key, Value) ->
+    case lists:member(Key, ?ERROR_CODE_KEYS) of
+        true when is_list(Value); is_binary(Value) ->
+            [Value];
+        true ->
+            [];
+        false ->
+            %% Descend into a nested proplist; a plain string value yields
+            %% nothing.
+            error_code_values(Value)
+    end.
+
+%% Case-insensitive substring match of the throttling markers against an error
+%% code or a raw body. to_utf8_binary/1 keeps multi-byte codepoints intact
+%% where a bare iolist_to_binary/1 would fail on non-latin1 input; a value that
+%% is not chardata at all (e.g. a nested proplist under an error-code key)
+%% makes it throw, which simply means "not throttling".
+contains_throttling_marker(Value) ->
+    try string:lowercase(rabbit_data_coercion:to_utf8_binary(Value)) of
+        Text when is_binary(Text) ->
+            lists:any(
+                fun(Marker) -> binary:match(Text, Marker) =/= nomatch end,
+                ?THROTTLING_MARKERS
+            );
+        _ ->
+            false
+    catch
+        _:_ ->
+            false
+    end.
+
+-spec get_content_type(Headers :: headers()) -> {Type :: string(), Subtype :: string()}.
+%% @doc Fetch the content type from the headers and return it as a tuple of
+%%      {Type, Subtype}.
+%% @end
+get_content_type(Headers) ->
+    Value =
+        case proplists:get_value(<<"content-type">>, Headers, undefined) of
+            undefined ->
+                proplists:get_value(<<"Content-Type">>, Headers, "text/xml");
+            Other ->
+                Other
+        end,
+    parse_content_type(Value).
+
+-spec maybe_decode_body(ContentType :: {nonempty_string(), nonempty_string()}, Body :: body()) ->
+    list() | body().
+%% @doc Attempt to decode the response body by its MIME
+%% @end
+maybe_decode_body(_, <<>>) ->
+    <<>>;
+maybe_decode_body({"application", Subtype}, Body) ->
+    case is_json_subtype(Subtype) of
+        true -> aws_lib_json:decode(Body);
+        false -> maybe_decode_xml(Subtype, Body)
+    end;
+maybe_decode_body({_, Subtype}, Body) ->
+    maybe_decode_xml(Subtype, Body).
+
+maybe_decode_xml("xml", Body) ->
+    aws_lib_xml:parse(Body);
+maybe_decode_xml(_Subtype, Body) ->
+    Body.
+
+%% Recognise the JSON subtypes AWS services return. Covers plain `json', every
+%% AWS JSON protocol version (`x-amz-json-1.0', `x-amz-json-1.1', and any future
+%% `x-amz-json-*'), and the RFC 6839 structured `+json' suffix. Secrets Manager
+%% and other services use the JSON 1.1 protocol, so matching only 1.0/plain left
+%% those responses undecoded (issue #99).
+is_json_subtype("json") ->
+    true;
+is_json_subtype("x-amz-json-" ++ _Version) ->
+    true;
+is_json_subtype(Subtype) ->
+    lists:suffix("+json", Subtype).
+
+-spec parse_content_type(ContentType :: string()) -> {Type :: string(), Subtype :: string()}.
+%% @doc parse a content type string returning a tuple of type/subtype
+%% @end
+parse_content_type(ContentType) when is_binary(ContentType) ->
+    parse_content_type(binary_to_list(ContentType));
+parse_content_type(ContentType) ->
+    Parts = string:tokens(ContentType, ";"),
+    [Type, Subtype] = string:tokens(lists:nth(1, Parts), "/"),
+    {Type, Subtype}.
+
+%% The reason phrase for a status code, used by aws_lib_httpc to build the
+%% status line Gun does not carry.
+status_text(200) -> "OK";
+status_text(206) -> "Partial Content";
+status_text(400) -> "Bad Request";
+status_text(401) -> "Unauthorized";
+status_text(403) -> "Forbidden";
+status_text(404) -> "Not Found";
+status_text(416) -> "Range Not Satisfiable";
+status_text(500) -> "Internal Server Error";
+status_text(Code) -> integer_to_list(Code).

--- a/src/aws_lib_response.erl
+++ b/src/aws_lib_response.erl
@@ -115,11 +115,18 @@ classify_status(transport_error, _Formatted) ->
 %% taken from the X-Amzn-Errortype header when present alongside the values
 %% stored under the AWS error-code body keys; matching the error code rather
 %% than the whole body keeps a marker inside a message or resource name from
-%% triggering a retry. A body that could not be decoded (still a raw binary)
-%% falls back to a substring search of the raw bytes.
+%% triggering a retry. A body that could not be decoded (still a raw binary,
+%% e.g. text/plain or text/html) carries no structured error code, so only its
+%% X-Amzn-Errortype header is consulted: substring-searching the raw bytes
+%% would retry a permanent error whenever an unrelated 4xx page (a proxy or ALB
+%% error page) happened to contain a marker such as `throttl'. A genuinely
+%% transient failure with such a body is still retried via the 5xx or 429
+%% status rules in classify_status/2.
 -spec is_throttling_error(headers(), list() | body()) -> boolean().
 is_throttling_error(Headers, Body) when is_binary(Body) ->
-    lists:any(fun contains_throttling_marker/1, errortype_header_values(Headers) ++ [Body]);
+    %% Body itself is not consulted: an undecodable body carries no structured
+    %% error code, so classification rests on the header and the status rules.
+    lists:any(fun contains_throttling_marker/1, errortype_header_values(Headers));
 is_throttling_error(Headers, Decoded) ->
     Candidates = errortype_header_values(Headers) ++ error_code_values(Decoded),
     lists:any(fun contains_throttling_marker/1, Candidates).

--- a/src/aws_lib_response.erl
+++ b/src/aws_lib_response.erl
@@ -136,11 +136,9 @@ errortype_header_values(Headers) ->
     [Value || {Name, Value} <- Headers, is_errortype_header(Name)].
 
 is_errortype_header(Name) ->
-    try string:lowercase(rabbit_data_coercion:to_utf8_binary(Name)) of
-        ?ERRORTYPE_HEADER -> true;
+    case safe_lowercase(Name) of
+        {ok, ?ERRORTYPE_HEADER} -> true;
         _ -> false
-    catch
-        _:_ -> false
     end.
 
 %% Collect the values stored under AWS error-code keys anywhere in a decoded
@@ -165,22 +163,29 @@ error_code_values_for(Key, Value) ->
     end.
 
 %% Case-insensitive substring match of the throttling markers against an error
-%% code or a raw body. to_utf8_binary/1 keeps multi-byte codepoints intact
-%% where a bare iolist_to_binary/1 would fail on non-latin1 input; a value that
-%% is not chardata at all (e.g. a nested proplist under an error-code key)
-%% makes it throw, which simply means "not throttling".
+%% code or a raw body. A value that is not chardata (e.g. a nested proplist
+%% under an error-code key) fails to coerce and is treated as "not throttling".
 contains_throttling_marker(Value) ->
-    try string:lowercase(rabbit_data_coercion:to_utf8_binary(Value)) of
-        Text when is_binary(Text) ->
+    case safe_lowercase(Value) of
+        {ok, Text} ->
             lists:any(
                 fun(Marker) -> binary:match(Text, Marker) =/= nomatch end,
                 ?THROTTLING_MARKERS
             );
-        _ ->
+        error ->
             false
+    end.
+
+%% Lowercase a value for case-insensitive comparison, returning `{ok, Binary}'
+%% or `error' when it is not chardata. to_utf8_binary/1 keeps multi-byte
+%% codepoints intact where a bare iolist_to_binary/1 would fail on non-latin1
+%% input; a value that is not chardata at all makes it throw, which the catch
+%% turns into `error'. string:lowercase/1 on a binary always returns a binary.
+safe_lowercase(Value) ->
+    try
+        {ok, string:lowercase(rabbit_data_coercion:to_utf8_binary(Value))}
     catch
-        _:_ ->
-            false
+        _:_ -> error
     end.
 
 -spec get_content_type(Headers :: headers()) -> {Type :: string(), Subtype :: string()}.

--- a/src/aws_lib_response.erl
+++ b/src/aws_lib_response.erl
@@ -22,13 +22,15 @@
 
 -include("aws_lib.hrl").
 
-%% Substring markers, matched case-insensitively, that identify a throttling
-%% error code. This is botocore's _THROTTLED_ERROR_CODES
-%% (botocore/retries/standard.py) collapsed into lowercase substrings:
-%% `throttl' covers Throttling, ThrottlingException, ThrottledException,
-%% RequestThrottledException, RequestThrottled, and EC2ThrottledException;
-%% `limitexceeded' covers RequestLimitExceeded, BandwidthLimitExceeded, and
-%% LimitExceededException; the rest map one to one.
+%% Substring markers, matched case-insensitively, that identify an error code
+%% botocore retries: its _THROTTLED_ERROR_CODES together with its
+%% _TRANSIENT_ERROR_CODES (botocore/retries/standard.py), collapsed into
+%% lowercase substrings. `throttl' covers Throttling, ThrottlingException,
+%% ThrottledException, RequestThrottledException, RequestThrottled, and
+%% EC2ThrottledException; `limitexceeded' covers RequestLimitExceeded,
+%% BandwidthLimitExceeded, and LimitExceededException; `requesttimeout' covers
+%% the transient RequestTimeout and RequestTimeoutException;
+%% `priorrequestnotcomplete' appears in both lists; the rest map one to one.
 -define(THROTTLING_MARKERS, [
     <<"throttl">>,
     <<"toomanyrequests">>,
@@ -36,6 +38,7 @@
     <<"limitexceeded">>,
     <<"transactioninprogress">>,
     <<"slowdown">>,
+    <<"requesttimeout">>,
     <<"priorrequestnotcomplete">>
 ]).
 

--- a/src/aws_lib_response.erl
+++ b/src/aws_lib_response.erl
@@ -204,7 +204,7 @@ get_content_type(Headers) ->
 
 -spec maybe_decode_body(ContentType :: {nonempty_string(), nonempty_string()}, Body :: body()) ->
     list() | body().
-%% @doc Attempt to decode the response body by its MIME
+%% @doc Attempt to decode the response body according to its MIME content type.
 %% @end
 maybe_decode_body(_, <<>>) ->
     <<>>;
@@ -234,7 +234,7 @@ is_json_subtype(Subtype) ->
     lists:suffix("+json", Subtype).
 
 -spec parse_content_type(ContentType :: string()) -> {Type :: string(), Subtype :: string()}.
-%% @doc parse a content type string returning a tuple of type/subtype
+%% @doc Parse a content type string, returning a tuple of the type and subtype.
 %% @end
 parse_content_type(ContentType) when is_binary(ContentType) ->
     parse_content_type(binary_to_list(ContentType));

--- a/src/aws_lib_response.erl
+++ b/src/aws_lib_response.erl
@@ -16,8 +16,7 @@
     classify_response/2,
     get_content_type/1,
     maybe_decode_body/2,
-    parse_content_type/1,
-    status_text/1
+    parse_content_type/1
 ]).
 
 -include("aws_lib.hrl").
@@ -238,15 +237,3 @@ parse_content_type(ContentType) ->
     Parts = string:tokens(ContentType, ";"),
     [Type, Subtype] = string:tokens(lists:nth(1, Parts), "/"),
     {Type, Subtype}.
-
-%% The reason phrase for a status code, used by aws_lib_httpc to build the
-%% status line Gun does not carry.
-status_text(200) -> "OK";
-status_text(206) -> "Partial Content";
-status_text(400) -> "Bad Request";
-status_text(401) -> "Unauthorized";
-status_text(403) -> "Forbidden";
-status_text(404) -> "Not Found";
-status_text(416) -> "Range Not Satisfiable";
-status_text(500) -> "Internal Server Error";
-status_text(Code) -> integer_to_list(Code).

--- a/src/aws_s3.erl
+++ b/src/aws_s3.erl
@@ -8,7 +8,7 @@
 -export([fetch_object/2]).
 
 -spec fetch_object(string(), aws_lib:aws_state()) ->
-    {ok, binary(), aws_lib:aws_state()} | {error, term()}.
+    {ok, binary(), aws_lib:aws_state()} | {error, term(), aws_lib:aws_state()}.
 fetch_object(Resource, State) ->
     %% Note: splits on the first / only
     %% https://www.erlang.org/doc/apps/stdlib/string.html#split/2
@@ -17,6 +17,6 @@ fetch_object(Resource, State) ->
     case aws_lib:api_get_request("s3", Path, State) of
         {ok, _Body, _State1} = Response ->
             Response;
-        {error, _} = Error ->
+        {error, _Reason, _State1} = Error ->
             Error
     end.

--- a/src/aws_sms.erl
+++ b/src/aws_sms.erl
@@ -8,7 +8,7 @@
 -export([fetch_secret/3]).
 
 -spec fetch_secret(string(), string(), aws_lib:aws_state()) ->
-    {ok, binary(), aws_lib:aws_state()} | {error, term()}.
+    {ok, binary(), aws_lib:aws_state()} | {error, term(), aws_lib:aws_state()}.
 fetch_secret(Arn, Region, State) ->
     {ok, State1} = aws_lib:set_region(Region, State),
     RequestBody = rabbit_json:encode(#{
@@ -27,10 +27,10 @@ make_request(RequestBody, Headers, State) ->
             case find_secret(ResponseBody) of
                 {ok, Secret} ->
                     {ok, Secret, State1};
-                {error, _} = Error ->
-                    Error
+                {error, Reason} ->
+                    {error, Reason, State1}
             end;
-        {error, _} = Error ->
+        {error, _Reason, _State1} = Error ->
             Error
     end.
 

--- a/test/aws_acm_pca_tests.erl
+++ b/test/aws_acm_pca_tests.erl
@@ -12,7 +12,7 @@
 %% End-to-end guard for the ACM Private CA response path (issue #131).
 %%
 %% ACM-PCA replies with the `application/x-amz-json-1.1' content type, which
-%% aws_lib:maybe_decode_body/2 now decodes into a string-keyed proplist (since
+%% aws_lib_response:maybe_decode_body/2 now decodes into a string-keyed proplist (since
 %% #99). These cases mock gun so the real api_post_request path runs, then
 %% assert fetch_certificate/3 returns the certificate without a second decode.
 %% Before the fix a second rabbit_json:decode ran on the proplist and crashed

--- a/test/aws_acm_pca_tests.erl
+++ b/test/aws_acm_pca_tests.erl
@@ -60,4 +60,4 @@ missing_certificate_reports_error() ->
     end),
     Arn = "arn:aws:acm-pca:us-east-1:1:certificate-authority/ca",
     Result = aws_acm_pca:fetch_certificate(Arn, "us-east-1", state()),
-    ?assertEqual({error, no_certificate}, Result).
+    ?assertMatch({error, no_certificate, _State}, Result).

--- a/test/aws_arn_config_tests.erl
+++ b/test/aws_arn_config_tests.erl
@@ -192,9 +192,9 @@ resolved_state_propagates_across_arns() ->
 %% A resolve_arn/2 error stops the handler chain at that ARN: the remaining
 %% ARN is never resolved and the error is wrapped for the failing key.
 resolve_arn_error_short_circuits() ->
-    ok = meck:expect(aws_arn_util, resolve_arn, fun(Arn, _State) ->
+    ok = meck:expect(aws_arn_util, resolve_arn, fun(Arn, State) ->
         case Arn of
-            "arn:aws:s3:::b/first" -> {error, not_found};
+            "arn:aws:s3:::b/first" -> {error, not_found, State};
             _ -> erlang:error(second_arn_should_not_resolve)
         end
     end),
@@ -267,7 +267,7 @@ self_resolving_handler_state_propagates() ->
 %% produces) rather than leaking a bare, context-free error. Exercises the real
 %% aws_arn_config_oauth2:run/4, mocking only the ARN resolution it calls.
 self_resolving_handler_error_has_context() ->
-    ok = meck:expect(aws_arn_util, resolve_arn, fun(_Arn, _State) -> {error, not_found} end),
+    ok = meck:expect(aws_arn_util, resolve_arn, fun(_Arn, State) -> {error, not_found, State} end),
     Result = aws_arn_config_oauth2:run(
         the_key, providers_https_cacertfile, #{<<"0">> => <<"arn:x">>}, aws_lib:new()
     ),

--- a/test/aws_auth_validate_ldap_SUITE.erl
+++ b/test/aws_auth_validate_ldap_SUITE.erl
@@ -204,8 +204,8 @@ mock_resolve_arn(?BIND_PW_ARN, State) ->
     {ok, list_to_binary(?BIND_PW), State};
 mock_resolve_arn(?WRONG_PW_ARN, State) ->
     {ok, <<"definitely-wrong">>, State};
-mock_resolve_arn(_Other, _State) ->
-    {error, not_found}.
+mock_resolve_arn(_Other, State) ->
+    {error, not_found, State}.
 
 %%--------------------------------------------------------------------
 %% Functional tests

--- a/test/aws_auth_validate_tests.erl
+++ b/test/aws_auth_validate_tests.erl
@@ -542,7 +542,7 @@ assume_role_configured_threads_assumed_credentials() ->
     end),
     ok = meck:expect(aws_arn_util, resolve_arn, fun(_Arn, State) ->
         Self ! {resolve_key, assume_role_test_access_key(State)},
-        {error, stop_here}
+        {error, stop_here, State}
     end),
     ?assertMatch({error, input_invalid, _}, aws_auth_validate_ldap:validate(base_body(#{}))),
     ?assertEqual(1, meck:num_calls(aws_iam, assume_role, '_')),
@@ -683,7 +683,7 @@ cacert_arn_resolution_test_() ->
                 %% Password ARN resolves; CA-cert ARN does not.
                 meck:expect(aws_arn_util, resolve_arn, fun(Arn, State) ->
                     case lists:prefix("arn:aws:cacert", Arn) of
-                        true -> {error, not_found};
+                        true -> {error, not_found, State};
                         false -> {ok, <<"pw">>, State}
                     end
                 end),

--- a/test/aws_auth_validate_tls_tests.erl
+++ b/test/aws_auth_validate_tls_tests.erl
@@ -249,7 +249,7 @@ tls_malformed_pem_maps_to_input_invalid_test_() ->
 %% An ARN resolution failure maps to input_invalid.
 tls_arn_resolve_failure_test_() ->
     {setup, fun setup_role/0, fun cleanup_role/1, fun(_) ->
-        meck:expect(aws_arn_util, resolve_arn, fun(_Arn, _State) -> {error, not_found} end),
+        meck:expect(aws_arn_util, resolve_arn, fun(_Arn, State) -> {error, not_found, State} end),
         R = validate_ok_body(),
         [
             ?_assertEqual({error, input_invalid, <<"failed to resolve ARN">>}, R)

--- a/test/aws_lib_httpc_tests.erl
+++ b/test/aws_lib_httpc_tests.erl
@@ -113,7 +113,7 @@ request_on_conn_test_() ->
             end},
             {"the method selects the matching gun function", fun() ->
                 meck:expect(gun, put, fun(_, _, _, _, _) -> stream end),
-                %% 200 is in aws_lib:status_text/1's table, so its reason phrase
+                %% 200 is in aws_lib_response:status_text/1's table, so its reason phrase
                 %% is a known string; this also exercises the put/5 dispatch.
                 meck:expect(gun, await, fun(_, _, _) -> {response, fin, 200, []} end),
                 ?assertEqual(

--- a/test/aws_lib_httpc_tests.erl
+++ b/test/aws_lib_httpc_tests.erl
@@ -113,7 +113,7 @@ request_on_conn_test_() ->
             end},
             {"the method selects the matching gun function", fun() ->
                 meck:expect(gun, put, fun(_, _, _, _, _) -> stream end),
-                %% 200 is in aws_lib_response:status_text/1's table, so its reason phrase
+                %% 200 is in status_text/1's table, so its reason phrase
                 %% is a known string; this also exercises the put/5 dispatch.
                 meck:expect(gun, await, fun(_, _, _) -> {response, fin, 200, []} end),
                 ?assertEqual(

--- a/test/aws_lib_response_tests.erl
+++ b/test/aws_lib_response_tests.erl
@@ -115,15 +115,33 @@ classify_response_test_() ->
             >>,
             ?assertEqual(not_retriable, Classify(Resp(400, <<"application/json">>, Body)))
         end},
-        {"an undecodable body falls back to a raw substring match", fun() ->
+        {"an undecodable body is not substring-searched for markers", fun() ->
+            %% An undecodable body (text/plain, text/html) carries no structured
+            %% error code, so a marker in its text must not trigger a retry: a
+            %% proxy or ALB 4xx error page containing `throttl' is a permanent
+            %% error, not throttling.
             ?assertEqual(
-                retriable,
+                not_retriable,
                 Classify(Resp(400, <<"text/plain">>, <<"Throttling: rate exceeded">>))
             ),
             ?assertEqual(
                 not_retriable,
                 Classify(Resp(400, <<"text/plain">>, <<"no such resource">>))
             )
+        end},
+        {"an undecodable body is retriable via its X-Amzn-Errortype header", fun() ->
+            %% The status rules aside, an undecodable body still retries when the
+            %% throttling code arrives in the X-Amzn-Errortype header.
+            Response =
+                {ok, {
+                    {http_version, 400, "msg"},
+                    [
+                        {<<"content-type">>, <<"text/plain">>},
+                        {<<"X-Amzn-Errortype">>, <<"ThrottlingException">>}
+                    ],
+                    <<"Throttling: rate exceeded">>
+                }},
+            ?assertEqual(retriable, Classify(Response))
         end},
         {"a non-string value under an error-code key does not crash", fun() ->
             %% An object under `code' is collected as a candidate value; it is

--- a/test/aws_lib_response_tests.erl
+++ b/test/aws_lib_response_tests.erl
@@ -45,7 +45,9 @@ classify_response_test_() ->
         end},
         {"the botocore throttling code families are covered", fun() ->
             %% One representative per marker family from botocore's
-            %% _THROTTLED_ERROR_CODES.
+            %% _THROTTLED_ERROR_CODES, plus the transient codes from its
+            %% _TRANSIENT_ERROR_CODES (RequestTimeout, RequestTimeoutException,
+            %% PriorRequestNotComplete) that botocore also retries.
             Codes = [
                 "TooManyRequestsException",
                 "ProvisionedThroughputExceededException",
@@ -53,6 +55,8 @@ classify_response_test_() ->
                 "BandwidthLimitExceeded",
                 "RequestThrottled",
                 "SlowDown",
+                "RequestTimeout",
+                "RequestTimeoutException",
                 "PriorRequestNotComplete"
             ],
             lists:foreach(

--- a/test/aws_lib_response_tests.erl
+++ b/test/aws_lib_response_tests.erl
@@ -1,0 +1,280 @@
+-module(aws_lib_response_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% classify_response/2 decides retriability from the raw httpc result and its
+%% formatted counterpart (issue #80): 5xx and 429 and throttling error codes
+%% and transport errors are retriable; other 4xx and unfollowed 3xx are not.
+classify_response_test_() ->
+    Resp = fun(Status, ContentType, Body) ->
+        {ok, {{http_version, Status, "msg"}, [{<<"content-type">>, ContentType}], Body}}
+    end,
+    Classify = fun(Response) ->
+        aws_lib_response:classify_response(
+            Response, aws_lib_response:format_response(Response)
+        )
+    end,
+    [
+        {"5xx is retriable", fun() ->
+            ?assertEqual(retriable, Classify(Resp(503, <<"text/xml">>, <<>>)))
+        end},
+        {"429 is retriable", fun() ->
+            ?assertEqual(retriable, Classify(Resp(429, <<"text/xml">>, <<>>)))
+        end},
+        {"a plain 4xx is not retriable", fun() ->
+            ?assertEqual(
+                not_retriable,
+                Classify(
+                    Resp(400, <<"application/json">>, <<"{\"__type\": \"InvalidParameterValue\"}">>)
+                )
+            )
+        end},
+        {"a 4xx throttling error code is retriable", fun() ->
+            ?assertEqual(
+                retriable,
+                Classify(
+                    Resp(400, <<"application/json">>, <<"{\"__type\": \"ThrottlingException\"}">>)
+                )
+            ),
+            ?assertEqual(
+                retriable,
+                Classify(
+                    Resp(400, <<"application/json">>, <<"{\"__type\": \"RequestLimitExceeded\"}">>)
+                )
+            )
+        end},
+        {"the botocore throttling code families are covered", fun() ->
+            %% One representative per marker family from botocore's
+            %% _THROTTLED_ERROR_CODES.
+            Codes = [
+                "TooManyRequestsException",
+                "ProvisionedThroughputExceededException",
+                "TransactionInProgressException",
+                "BandwidthLimitExceeded",
+                "RequestThrottled",
+                "SlowDown",
+                "PriorRequestNotComplete"
+            ],
+            lists:foreach(
+                fun(Code) ->
+                    Body = iolist_to_binary(["{\"__type\": \"", Code, "\"}"]),
+                    ?assertEqual(
+                        retriable,
+                        Classify(Resp(400, <<"application/json">>, Body))
+                    )
+                end,
+                Codes
+            )
+        end},
+        {"a namespaced throttling code matches case-insensitively", fun() ->
+            %% Some services prefix the __type with a namespace and vary the
+            %% casing; the marker match is a case-insensitive substring of the
+            %% error code.
+            ?assertEqual(
+                retriable,
+                Classify(
+                    Resp(
+                        400,
+                        <<"application/json">>,
+                        <<"{\"__type\": \"com.amazonaws.dynamodb#throttlingException\"}">>
+                    )
+                )
+            )
+        end},
+        {"an XML error document Code is matched", fun() ->
+            Body = <<
+                "<ErrorResponse><Error><Code>Throttling</Code>"
+                "<Message>Rate exceeded</Message></Error></ErrorResponse>"
+            >>,
+            ?assertEqual(retriable, Classify(Resp(400, <<"text/xml">>, Body)))
+        end},
+        {"an X-Amzn-Errortype header is consulted", fun() ->
+            %% The JSON protocols allow the error type to arrive only in the
+            %% X-Amzn-Errortype header (Smithy awsJson1.1 spec).
+            Response =
+                {ok, {
+                    {http_version, 400, "msg"},
+                    [
+                        {<<"content-type">>, <<"application/json">>},
+                        {<<"X-Amzn-Errortype">>, <<"ThrottlingException">>}
+                    ],
+                    <<"{\"message\": \"Rate exceeded\"}">>
+                }},
+            ?assertEqual(retriable, Classify(Response))
+        end},
+        {"a throttling marker outside the error code does not retry", fun() ->
+            %% A marker inside a message or resource name must not trigger a
+            %% retry; only the error-code fields are consulted.
+            Body = <<
+                "{\"__type\": \"ValidationException\","
+                " \"message\": \"resource arn:aws:sns:us-east-1:1:ThrottlingAlarm\"}"
+            >>,
+            ?assertEqual(not_retriable, Classify(Resp(400, <<"application/json">>, Body)))
+        end},
+        {"an undecodable body falls back to a raw substring match", fun() ->
+            ?assertEqual(
+                retriable,
+                Classify(Resp(400, <<"text/plain">>, <<"Throttling: rate exceeded">>))
+            ),
+            ?assertEqual(
+                not_retriable,
+                Classify(Resp(400, <<"text/plain">>, <<"no such resource">>))
+            )
+        end},
+        {"a non-string value under an error-code key does not crash", fun() ->
+            %% An object under `code' is collected as a candidate value; it is
+            %% not chardata, so the marker match rejects it instead of raising.
+            Body = <<"{\"code\": {\"inner\": \"Throttling\"}, \"other\": 1}">>,
+            ?assertEqual(not_retriable, Classify(Resp(400, <<"application/json">>, Body)))
+        end},
+        {"a 403 access-denied is not retriable", fun() ->
+            ?assertEqual(
+                not_retriable,
+                Classify(Resp(403, <<"application/json">>, <<"{\"__type\": \"AccessDenied\"}">>))
+            )
+        end},
+        {"an unfollowed 3xx is not retriable", fun() ->
+            ?assertEqual(not_retriable, Classify(Resp(302, <<"text/xml">>, <<>>)))
+        end},
+        {"a transport error is retriable", fun() ->
+            ?assertEqual(retriable, Classify({error, timeout}))
+        end},
+        {"a 2xx success stays total", fun() ->
+            ?assertEqual(retriable, Classify(Resp(200, <<"application/json">>, <<"{}">>)))
+        end}
+    ].
+
+format_response_test_() ->
+    [
+        {"ok", fun() ->
+            Response =
+                {ok, {
+                    {"HTTP/1.1", 200, "Ok"},
+                    [{<<"Content-Type">>, <<"text/xml">>}],
+                    "<test>Value</test>"
+                }},
+            Expectation = {ok, {[{<<"Content-Type">>, <<"text/xml">>}], [{"test", "Value"}]}},
+            ?assertEqual(Expectation, aws_lib_response:format_response(Response))
+        end},
+        {"error", fun() ->
+            Response =
+                {ok, {
+                    {"HTTP/1.1", 500, "Internal Server Error"},
+                    [{"Content-Type", "text/xml"}],
+                    "<error>Boom</error>"
+                }},
+            Expectation =
+                {error, "Internal Server Error",
+                    {[{"Content-Type", "text/xml"}], [{"error", "Boom"}]}},
+            ?assertEqual(Expectation, aws_lib_response:format_response(Response))
+        end},
+        {"201 Created is a success", fun() ->
+            Response =
+                {ok, {
+                    {"HTTP/1.1", 201, "Created"},
+                    [{<<"Content-Type">>, <<"text/xml">>}],
+                    "<test>Value</test>"
+                }},
+            Expectation = {ok, {[{<<"Content-Type">>, <<"text/xml">>}], [{"test", "Value"}]}},
+            ?assertEqual(Expectation, aws_lib_response:format_response(Response))
+        end},
+        {"204 No Content is a success", fun() ->
+            Response =
+                {ok, {
+                    {"HTTP/1.1", 204, "No Content"},
+                    [],
+                    <<>>
+                }},
+            Expectation = {ok, {[], <<>>}},
+            ?assertEqual(Expectation, aws_lib_response:format_response(Response))
+        end},
+        {"3xx redirect is an error (gun does not follow redirects)", fun() ->
+            Response =
+                {ok, {
+                    {"HTTP/1.1", 302, "Found"},
+                    [{<<"content-type">>, <<"text/plain">>}],
+                    <<"moved">>
+                }},
+            Expectation = {error, "Found", {[{<<"content-type">>, <<"text/plain">>}], <<"moved">>}},
+            ?assertEqual(Expectation, aws_lib_response:format_response(Response))
+        end}
+    ].
+
+get_content_type_test_() ->
+    [
+        {"from headers caps", fun() ->
+            Headers = [{"Content-Type", "text/xml"}],
+            Expectation = {"text", "xml"},
+            ?assertEqual(Expectation, aws_lib_response:get_content_type(Headers))
+        end},
+        {"from headers lower", fun() ->
+            Headers = [{"content-type", "text/xml"}],
+            Expectation = {"text", "xml"},
+            ?assertEqual(Expectation, aws_lib_response:get_content_type(Headers))
+        end}
+    ].
+
+maybe_decode_body_test_() ->
+    [
+        {"application/x-amz-json-1.0", fun() ->
+            ContentType = {"application", "x-amz-json-1.0"},
+            Body = "{\"test\": true}",
+            Expectation = [{"test", true}],
+            ?assertEqual(Expectation, aws_lib_response:maybe_decode_body(ContentType, Body))
+        end},
+        {"application/x-amz-json-1.1", fun() ->
+            %% The JSON 1.1 protocol (e.g. Secrets Manager) must decode too (#99).
+            ContentType = {"application", "x-amz-json-1.1"},
+            Body = "{\"test\": true}",
+            Expectation = [{"test", true}],
+            ?assertEqual(Expectation, aws_lib_response:maybe_decode_body(ContentType, Body))
+        end},
+        {"application/json", fun() ->
+            ContentType = {"application", "json"},
+            Body = "{\"test\": true}",
+            Expectation = [{"test", true}],
+            ?assertEqual(Expectation, aws_lib_response:maybe_decode_body(ContentType, Body))
+        end},
+        {"application/*+json structured suffix", fun() ->
+            ContentType = {"application", "vnd.api+json"},
+            Body = "{\"test\": true}",
+            Expectation = [{"test", true}],
+            ?assertEqual(Expectation, aws_lib_response:maybe_decode_body(ContentType, Body))
+        end},
+        {"text/xml", fun() ->
+            ContentType = {"text", "xml"},
+            Body = "<test><node>value</node></test>",
+            Expectation = [{"test", [{"node", "value"}]}],
+            ?assertEqual(Expectation, aws_lib_response:maybe_decode_body(ContentType, Body))
+        end},
+        {"text/html [unsupported]", fun() ->
+            ContentType = {"text", "html"},
+            Body = "<html><head></head><body></body></html>",
+            ?assertEqual(Body, aws_lib_response:maybe_decode_body(ContentType, Body))
+        end},
+        {"application/octet-stream is not decoded", fun() ->
+            %% A non-JSON application/* subtype must fall through undecoded, not
+            %% be treated as JSON.
+            ContentType = {"application", "octet-stream"},
+            Body = <<"raw bytes">>,
+            ?assertEqual(Body, aws_lib_response:maybe_decode_body(ContentType, Body))
+        end}
+    ].
+
+parse_content_type_test_() ->
+    [
+        {"application/x-amz-json-1.0", fun() ->
+            Expectation = {"application", "x-amz-json-1.0"},
+            ?assertEqual(
+                Expectation, aws_lib_response:parse_content_type("application/x-amz-json-1.0")
+            )
+        end},
+        {"application/xml", fun() ->
+            Expectation = {"application", "xml"},
+            ?assertEqual(Expectation, aws_lib_response:parse_content_type("application/xml"))
+        end},
+        {"text/xml;charset=UTF-8", fun() ->
+            Expectation = {"text", "xml"},
+            ?assertEqual(Expectation, aws_lib_response:parse_content_type("text/xml"))
+        end}
+    ].

--- a/test/aws_lib_tests.erl
+++ b/test/aws_lib_tests.erl
@@ -270,76 +270,6 @@ expired_credentials_test_() ->
         ]
     }.
 
-format_response_test_() ->
-    [
-        {"ok", fun() ->
-            Response =
-                {ok, {
-                    {"HTTP/1.1", 200, "Ok"},
-                    [{<<"Content-Type">>, <<"text/xml">>}],
-                    "<test>Value</test>"
-                }},
-            Expectation = {ok, {[{<<"Content-Type">>, <<"text/xml">>}], [{"test", "Value"}]}},
-            ?assertEqual(Expectation, aws_lib:format_response(Response))
-        end},
-        {"error", fun() ->
-            Response =
-                {ok, {
-                    {"HTTP/1.1", 500, "Internal Server Error"},
-                    [{"Content-Type", "text/xml"}],
-                    "<error>Boom</error>"
-                }},
-            Expectation =
-                {error, "Internal Server Error",
-                    {[{"Content-Type", "text/xml"}], [{"error", "Boom"}]}},
-            ?assertEqual(Expectation, aws_lib:format_response(Response))
-        end},
-        {"201 Created is a success", fun() ->
-            Response =
-                {ok, {
-                    {"HTTP/1.1", 201, "Created"},
-                    [{<<"Content-Type">>, <<"text/xml">>}],
-                    "<test>Value</test>"
-                }},
-            Expectation = {ok, {[{<<"Content-Type">>, <<"text/xml">>}], [{"test", "Value"}]}},
-            ?assertEqual(Expectation, aws_lib:format_response(Response))
-        end},
-        {"204 No Content is a success", fun() ->
-            Response =
-                {ok, {
-                    {"HTTP/1.1", 204, "No Content"},
-                    [],
-                    <<>>
-                }},
-            Expectation = {ok, {[], <<>>}},
-            ?assertEqual(Expectation, aws_lib:format_response(Response))
-        end},
-        {"3xx redirect is an error (gun does not follow redirects)", fun() ->
-            Response =
-                {ok, {
-                    {"HTTP/1.1", 302, "Found"},
-                    [{<<"content-type">>, <<"text/plain">>}],
-                    <<"moved">>
-                }},
-            Expectation = {error, "Found", {[{<<"content-type">>, <<"text/plain">>}], <<"moved">>}},
-            ?assertEqual(Expectation, aws_lib:format_response(Response))
-        end}
-    ].
-
-get_content_type_test_() ->
-    [
-        {"from headers caps", fun() ->
-            Headers = [{"Content-Type", "text/xml"}],
-            Expectation = {"text", "xml"},
-            ?assertEqual(Expectation, aws_lib:get_content_type(Headers))
-        end},
-        {"from headers lower", fun() ->
-            Headers = [{"content-type", "text/xml"}],
-            Expectation = {"text", "xml"},
-            ?assertEqual(Expectation, aws_lib:get_content_type(Headers))
-        end}
-    ].
-
 has_credentials_test_() ->
     {
         foreach,
@@ -374,69 +304,6 @@ local_time_test_() ->
             end}
         ]
     }.
-
-maybe_decode_body_test_() ->
-    [
-        {"application/x-amz-json-1.0", fun() ->
-            ContentType = {"application", "x-amz-json-1.0"},
-            Body = "{\"test\": true}",
-            Expectation = [{"test", true}],
-            ?assertEqual(Expectation, aws_lib:maybe_decode_body(ContentType, Body))
-        end},
-        {"application/x-amz-json-1.1", fun() ->
-            %% The JSON 1.1 protocol (e.g. Secrets Manager) must decode too (#99).
-            ContentType = {"application", "x-amz-json-1.1"},
-            Body = "{\"test\": true}",
-            Expectation = [{"test", true}],
-            ?assertEqual(Expectation, aws_lib:maybe_decode_body(ContentType, Body))
-        end},
-        {"application/json", fun() ->
-            ContentType = {"application", "json"},
-            Body = "{\"test\": true}",
-            Expectation = [{"test", true}],
-            ?assertEqual(Expectation, aws_lib:maybe_decode_body(ContentType, Body))
-        end},
-        {"application/*+json structured suffix", fun() ->
-            ContentType = {"application", "vnd.api+json"},
-            Body = "{\"test\": true}",
-            Expectation = [{"test", true}],
-            ?assertEqual(Expectation, aws_lib:maybe_decode_body(ContentType, Body))
-        end},
-        {"text/xml", fun() ->
-            ContentType = {"text", "xml"},
-            Body = "<test><node>value</node></test>",
-            Expectation = [{"test", [{"node", "value"}]}],
-            ?assertEqual(Expectation, aws_lib:maybe_decode_body(ContentType, Body))
-        end},
-        {"text/html [unsupported]", fun() ->
-            ContentType = {"text", "html"},
-            Body = "<html><head></head><body></body></html>",
-            ?assertEqual(Body, aws_lib:maybe_decode_body(ContentType, Body))
-        end},
-        {"application/octet-stream is not decoded", fun() ->
-            %% A non-JSON application/* subtype must fall through undecoded, not
-            %% be treated as JSON.
-            ContentType = {"application", "octet-stream"},
-            Body = <<"raw bytes">>,
-            ?assertEqual(Body, aws_lib:maybe_decode_body(ContentType, Body))
-        end}
-    ].
-
-parse_content_type_test_() ->
-    [
-        {"application/x-amz-json-1.0", fun() ->
-            Expectation = {"application", "x-amz-json-1.0"},
-            ?assertEqual(Expectation, aws_lib:parse_content_type("application/x-amz-json-1.0"))
-        end},
-        {"application/xml", fun() ->
-            Expectation = {"application", "xml"},
-            ?assertEqual(Expectation, aws_lib:parse_content_type("application/xml"))
-        end},
-        {"text/xml;charset=UTF-8", fun() ->
-            Expectation = {"text", "xml"},
-            ?assertEqual(Expectation, aws_lib:parse_content_type("text/xml"))
-        end}
-    ].
 
 perform_request_test_() ->
     {
@@ -737,6 +604,75 @@ api_get_request_test_() ->
                         ]}},
                     Result
                 ),
+                meck:validate(gun)
+            end},
+            {"a non-retriable 4xx returns immediately without burning retries", fun() ->
+                State0 = set_test_credentials("ExpiredKey", "ExpiredAccessKey", undefined, {
+                    {3016, 4, 1}, {12, 0, 0}
+                }),
+                {ok, State} = aws_lib:set_region("us-east-1", State0),
+
+                meck:expect(gun, open, fun(_, _, _) -> {ok, spawn(fun() -> ok end)} end),
+                meck:expect(gun, close, fun(_) -> ok end),
+                meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
+                meck:expect(gun, get, fun(_Pid, _Path, _Headers) -> nofin end),
+                %% A 400 with a non-throttling error code is not retriable
+                %% (issue #80): the request must be made exactly once and the
+                %% decoded error returned to the caller immediately.
+                meck:expect(gun, await, fun(_Pid, _, _) ->
+                    {response, nofin, 400, [{<<"content-type">>, <<"application/json">>}]}
+                end),
+                meck:expect(gun, await_body, fun(_Pid, _, _) ->
+                    {ok, <<"{\"Error\": {\"Code\": \"InvalidParameterValue\"}}">>}
+                end),
+
+                Result = aws_lib:api_get_request("AWS", "API", State),
+                ?assertEqual(
+                    {error,
+                        {service_error, [
+                            {"Error", [{"Code", "InvalidParameterValue"}]}
+                        ]}},
+                    Result
+                ),
+                %% Exactly one attempt: not retried.
+                ?assertEqual(1, meck:num_calls(gun, await, '_')),
+                meck:validate(gun)
+            end},
+            {"a throttling 4xx is retried rather than returned immediately", fun() ->
+                State0 = set_test_credentials("ExpiredKey", "ExpiredAccessKey", undefined, {
+                    {3016, 4, 1}, {12, 0, 0}
+                }),
+                {ok, State} = aws_lib:set_region("us-east-1", State0),
+
+                meck:expect(gun, open, fun(_, _, _) -> {ok, spawn(fun() -> ok end)} end),
+                meck:expect(gun, close, fun(_) -> ok end),
+                meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
+                meck:expect(gun, get, fun(_Pid, _Path, _Headers) -> nofin end),
+                %% A 400 whose body indicates throttling is retriable: the first
+                %% attempt throttles, the second succeeds.
+                meck:expect(
+                    gun,
+                    await,
+                    3,
+                    meck:seq([
+                        {response, nofin, 400, [{<<"content-type">>, <<"application/json">>}]},
+                        {response, nofin, 200, [{<<"content-type">>, <<"application/json">>}]}
+                    ])
+                ),
+                meck:expect(
+                    gun,
+                    await_body,
+                    3,
+                    meck:seq([
+                        {ok, <<"{\"__type\": \"ThrottlingException\"}">>},
+                        {ok, <<"{\"data\": \"value\"}">>}
+                    ])
+                ),
+
+                Result = aws_lib:api_get_request("AWS", "API", State),
+                ?assertMatch({ok, [{"data", "value"}], _State}, Result),
+                %% Two attempts: throttling was retried.
+                ?assertEqual(2, meck:num_calls(gun, await, '_')),
                 meck:validate(gun)
             end},
             {"a decoded error survives a later transport failure", fun() ->

--- a/test/aws_lib_tests.erl
+++ b/test/aws_lib_tests.erl
@@ -724,16 +724,18 @@ api_get_request_test_() ->
                 meck:expect(gun, close, fun(_) -> ok end),
                 meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
                 meck:expect(gun, get, fun(_Pid, _Path, _Headers) -> nofin end),
-                %% The first attempt returns an HTTP 400 with a decoded error
-                %% body; every later attempt fails at the transport level (no
-                %% body). Retry exhaustion must still surface the decoded body
-                %% from the first attempt, not the bodiless transport error.
+                %% The first attempt returns a retriable HTTP 503 with a decoded
+                %% error body; every later attempt fails at the transport level
+                %% (no body). The 503 keeps the loop retrying so the transport
+                %% failures are consumed, exercising keep_informative_error/2:
+                %% retry exhaustion must still surface the decoded body from the
+                %% first attempt, not the bodiless transport error.
                 meck:expect(
                     gun,
                     await,
                     3,
                     meck:seq([
-                        {response, nofin, 400, [{<<"content-type">>, <<"application/json">>}]},
+                        {response, nofin, 503, [{<<"content-type">>, <<"application/json">>}]},
                         {error, "network error"},
                         {error, "network error"},
                         {error, "network error"},
@@ -741,18 +743,21 @@ api_get_request_test_() ->
                     ])
                 ),
                 meck:expect(gun, await_body, fun(_Pid, _, _) ->
-                    {ok, <<"{\"Error\": {\"Code\": \"InvalidParameterValue\"}}">>}
+                    {ok, <<"{\"Error\": {\"Code\": \"InternalError\"}}">>}
                 end),
 
                 Result = aws_lib:api_get_request("AWS", "API", State),
                 ?assertMatch(
                     {error,
                         {service_error, [
-                            {"Error", [{"Code", "InvalidParameterValue"}]}
+                            {"Error", [{"Code", "InternalError"}]}
                         ]},
                         _State},
                     Result
                 ),
+                %% All attempts are consumed: the initial 503 plus the four
+                %% transport failures across the retry budget.
+                ?assertEqual(?MAX_RETRIES, meck:num_calls(gun, await, '_')),
                 meck:validate(gun)
             end},
             {"AWS service API request succeeded after a transient error", fun() ->

--- a/test/aws_lib_tests.erl
+++ b/test/aws_lib_tests.erl
@@ -441,6 +441,43 @@ perform_request_test_() ->
         ]
     }.
 
+signing_failure_retries_test_() ->
+    {
+        foreach,
+        fun() ->
+            setup(),
+            meck:new(aws_lib_sign, [passthrough]),
+            [aws_lib_sign]
+        end,
+        fun(Mods) ->
+            teardown(ok),
+            meck:unload(Mods)
+        end,
+        [
+            {
+                "a signing failure exhausts retries instead of crashing",
+                fun() ->
+                    State0 = set_test_credentials(
+                        "AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+                    ),
+                    {ok, State} = aws_lib:set_region("us-east-1", State0),
+                    %% A signing failure makes prepare_signed_request/8 return a
+                    %% 2-tuple {error, Reason}; the retry loop must shape it into
+                    %% the 3-tuple result it matches on rather than raising a
+                    %% case_clause (issue #80 review).
+                    meck:expect(aws_lib_sign, headers, fun(_Request, _BodyHash) ->
+                        {error, {malformed_uri, "bad"}}
+                    end),
+                    Result = aws_lib:api_request_with_retries(
+                        "ec2", get, "/", "", [], 1, 0, State
+                    ),
+                    ?assertEqual({error, {service_error, retries_exhausted}}, Result),
+                    meck:validate(aws_lib_sign)
+                end
+            }
+        ]
+    }.
+
 sign_headers_test_() ->
     {
         foreach,

--- a/test/aws_lib_tests.erl
+++ b/test/aws_lib_tests.erl
@@ -471,7 +471,7 @@ signing_failure_retries_test_() ->
                     Result = aws_lib:api_request_with_retries(
                         "ec2", get, "/", "", [], 1, 0, State
                     ),
-                    ?assertEqual({error, {service_error, retries_exhausted}}, Result),
+                    ?assertMatch({error, {service_error, retries_exhausted}, _State}, Result),
                     meck:validate(aws_lib_sign)
                 end
             }
@@ -604,7 +604,7 @@ api_get_request_test_() ->
                 %% A transport failure carries no decoded body, so retry
                 %% exhaustion reports the generic reason.
                 Result = aws_lib:api_get_request("AWS", "API", State),
-                ?assertEqual({error, {service_error, retries_exhausted}}, Result),
+                ?assertMatch({error, {service_error, retries_exhausted}, _State}, Result),
                 meck:validate(gun)
             end},
             {"a persistent HTTP error surfaces the decoded AWS error body", fun() ->
@@ -631,14 +631,15 @@ api_get_request_test_() ->
                 end),
 
                 Result = aws_lib:api_get_request("AWS", "API", State),
-                ?assertEqual(
+                ?assertMatch(
                     {error,
                         {service_error, [
                             {"Error", [
                                 {"Code", "ThrottlingException"},
                                 {"Message", "Rate exceeded"}
                             ]}
-                        ]}},
+                        ]},
+                        _State},
                     Result
                 ),
                 meck:validate(gun)
@@ -664,11 +665,12 @@ api_get_request_test_() ->
                 end),
 
                 Result = aws_lib:api_get_request("AWS", "API", State),
-                ?assertEqual(
+                ?assertMatch(
                     {error,
                         {service_error, [
                             {"Error", [{"Code", "InvalidParameterValue"}]}
-                        ]}},
+                        ]},
+                        _State},
                     Result
                 ),
                 %% Exactly one attempt: not retried.
@@ -743,11 +745,12 @@ api_get_request_test_() ->
                 end),
 
                 Result = aws_lib:api_get_request("AWS", "API", State),
-                ?assertEqual(
+                ?assertMatch(
                     {error,
                         {service_error, [
                             {"Error", [{"Code", "InvalidParameterValue"}]}
-                        ]}},
+                        ]},
+                        _State},
                     Result
                 ),
                 meck:validate(gun)
@@ -807,7 +810,7 @@ api_get_request_test_() ->
                 meck:expect(gun, close, fun(_) -> ok end),
 
                 Result = aws_lib:api_get_request("AWS", "API", State),
-                ?assertEqual({error, {service_error, retries_exhausted}}, Result),
+                ?assertMatch({error, {service_error, retries_exhausted}, _State}, Result),
                 meck:validate(gun)
             end},
             {"gun:await_up failure re-enters the retry loop rather than raising", fun() ->
@@ -823,7 +826,7 @@ api_get_request_test_() ->
                 meck:expect(gun, await_up, fun(_, _) -> {error, timeout} end),
 
                 Result = aws_lib:api_get_request("AWS", "API", State),
-                ?assertEqual({error, {service_error, retries_exhausted}}, Result),
+                ?assertMatch({error, {service_error, retries_exhausted}, _State}, Result),
                 meck:validate(gun)
             end}
         ]
@@ -1013,6 +1016,44 @@ connection_reuse_across_retries_test_() ->
                     {open_opts, Opts} -> ?assertEqual(0, maps:get(retry, Opts))
                 after 1000 -> ?assert(false)
                 end,
+                Conn ! stop,
+                meck:validate(gun)
+            end},
+            {"a not_retriable 4xx in reuse mode hands the connection back", fun() ->
+                State0 = set_test_credentials("ExpiredKey", "ExpiredAccessKey", undefined, {
+                    {3016, 4, 1}, {12, 0, 0}
+                }),
+                {ok, State1} = aws_lib:set_region("us-east-1", State0),
+                %% Reuse mode: the connection after a cleanly completed 4xx is as
+                %% usable as after a 2xx, so it must be handed back in the state's
+                %% reuse_conn rather than closed (issue #80 review).
+                State = aws_lib:enable_connection_reuse(State1),
+
+                Conn = spawn(fun() ->
+                    receive
+                        stop -> ok
+                    end
+                end),
+                meck:expect(gun, open, fun(_, _, _) -> {ok, Conn} end),
+                meck:expect(gun, close, fun(_) -> ok end),
+                meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
+                meck:expect(gun, get, fun(_Pid, _Path, _Headers) -> nofin end),
+                %% A 400 with a non-throttling error code is not retriable.
+                meck:expect(gun, await, fun(_Pid, _, _) ->
+                    {response, nofin, 400, [{<<"content-type">>, <<"application/json">>}]}
+                end),
+                meck:expect(gun, await_body, fun(_Pid, _, _) ->
+                    {ok, <<"{\"Error\": {\"Code\": \"InvalidParameterValue\"}}">>}
+                end),
+
+                {error, {service_error, _}, StateOut} = aws_lib:api_get_request(
+                    "AWS", "API", State
+                ),
+                %% Exactly one attempt: not retried.
+                ?assertEqual(1, meck:num_calls(gun, await, '_')),
+                %% The connection was handed back, not closed.
+                ?assertEqual(0, meck:num_calls(gun, close, '_')),
+                ?assertMatch({Conn, _Host, _Port}, StateOut#aws_state.reuse_conn),
                 Conn ! stop,
                 meck:validate(gun)
             end}

--- a/test/aws_sms_tests.erl
+++ b/test/aws_sms_tests.erl
@@ -72,4 +72,4 @@ missing_secret_reports_error() ->
     Result = aws_sms:fetch_secret(
         "arn:aws:secretsmanager:us-east-1:1:secret:s", "us-east-1", state()
     ),
-    ?assertEqual({error, no_secret_value}, Result).
+    ?assertMatch({error, no_secret_value, _State}, Result).

--- a/test/aws_sms_tests.erl
+++ b/test/aws_sms_tests.erl
@@ -12,7 +12,7 @@
 %% End-to-end guard for the Secrets Manager response path (issue #131).
 %%
 %% Secrets Manager replies with the `application/x-amz-json-1.1' content
-%% type, which aws_lib:maybe_decode_body/2 now decodes into a string-keyed
+%% type, which aws_lib_response:maybe_decode_body/2 now decodes into a string-keyed
 %% proplist (since #99). These cases mock gun so the real api_post_request
 %% path runs, then assert fetch_secret/3 returns the secret without a second
 %% decode. Before the fix a second rabbit_json:decode ran on the proplist and


### PR DESCRIPTION
Closes #80.

Stacked on #138 (`feature/expose-aws-error-details`); only the top commit is new here.

The retry loop in `api_request_with_retries` treated every failure the same: an access-denied or invalid-parameter 4xx burned all five retries with backoff before the caller saw the error, even though repeating the request could never succeed.

This PR classifies each failed response as `retriable` or `not_retriable` and returns non-retriable errors to the caller immediately:

- 5xx, HTTP 429, throttling error codes, and transport failures are retriable
- other 4xx client errors and unfollowed 3xx redirects are not

Throttling detection inspects the error code fields of the decoded body (`__type`/`code` for the JSON protocols, `Code` for XML error documents, per the Smithy protocol specs) and the `X-Amzn-Errortype` header rather than substring-matching the whole body, so a marker inside a message or resource name does not trigger a retry. The marker list collapses botocore's `_THROTTLED_ERROR_CODES` into case-insensitive substrings. An undecodable body falls back to a raw substring search.

Response interpretation moves into a new `aws_lib_response` module: `format_response/1`, `classify_response/2`, `maybe_decode_body/2`, `get_content_type/1`, `parse_content_type/1`, and `status_text/1` move out of `aws_lib`, which keeps the retry loop. `aws_lib_httpc` produces the raw response, `aws_lib_response` decides what it means, and a new `response_status/1` accessor reports the outcome without callers matching the raw tuple. `perform_request_reuse` formats the response once and passes the result to both consumers, so the body is decoded exactly once per response.

Verification: 541 eunit tests pass, `xref` clean, `dialyzer` clean in all touched files, `erlfmt` applied.
