### PR TITLE
Guard HTTP validation divergence against real auth backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ define PROJECT_ENV
 endef
 
 DEPS = rabbit_common rabbit rabbitmq_management gun
-TEST_DEPS = meck proper rabbitmq_ct_helpers rabbitmq_ct_client_helpers rabbitmq_auth_backend_ldap
+TEST_DEPS = meck proper rabbitmq_ct_helpers rabbitmq_ct_client_helpers rabbitmq_auth_backend_ldap rabbitmq_auth_backend_http
 LOCAL_DEPS = crypto inets ssl xmerl public_key eldap
 
 PLT_APPS = rabbit

--- a/src/aws_auth_validate_http.erl
+++ b/src/aws_auth_validate_http.erl
@@ -689,7 +689,14 @@ with_default_sni(SslOpts, Host) ->
 %% fields rabbit_auth_backend_http sends so a conformant server returns a 2xx
 %% (allow or deny) rather than a 400 for missing params. The username is an
 %% obvious placeholder so an operator reading their auth-server logs can see it
-%% was a validation probe, not a real login attempt.
+%% was a validation probe, not a real login attempt. The authz paths carry a
+%% `tags' field (empty for the tagless probe user), matching what upstream's
+%% check_vhost_access/check_resource_access/check_topic_access always send via
+%% join_tags/1; a server that requires the field must still see it.
+%%
+%% NOTE: the parity test feeds params_for/1 to both sides, so it proves the two
+%% ENCODERS agree but cannot catch this field set drifting from upstream's; keep
+%% these lists in step with the fields those upstream functions send by hand.
 query_for(Key) ->
     uri_string:compose_query(params_for(Key)).
 
@@ -699,14 +706,20 @@ query_for(Key) ->
 params_for(<<"user_path">>) ->
     [{"username", ?PROBE_USER}];
 params_for(<<"vhost_path">>) ->
-    [{"username", ?PROBE_USER}, {"vhost", ?PROBE_VHOST}, {"ip", "127.0.0.1"}];
+    [
+        {"username", ?PROBE_USER},
+        {"vhost", ?PROBE_VHOST},
+        {"ip", "127.0.0.1"},
+        {"tags", ""}
+    ];
 params_for(<<"resource_path">>) ->
     [
         {"username", ?PROBE_USER},
         {"vhost", ?PROBE_VHOST},
         {"resource", "queue"},
         {"name", "validation-probe"},
-        {"permission", "read"}
+        {"permission", "read"},
+        {"tags", ""}
     ];
 params_for(<<"topic_path">>) ->
     [
@@ -715,6 +728,7 @@ params_for(<<"topic_path">>) ->
         {"resource", "topic"},
         {"name", "validation-probe"},
         {"permission", "read"},
+        {"tags", ""},
         {"routing_key", "#"}
     ].
 

--- a/src/aws_auth_validate_http.erl
+++ b/src/aws_auth_validate_http.erl
@@ -608,11 +608,13 @@ is_tls_error(Term) ->
 %% echo the body: a mismatch returns the fixed ?REASON_ENDPOINT.
 %%
 %% Grammar (mirrors rabbit_auth_backend_http's own parsing in
-%% user_login_authentication/2 (authn) and req/2 (authz), which lowercase the
-%% trimmed body then match):
-%%   * user_path (authn): exactly `deny', or anything beginning with `allow'
-%%     (an `allow' optionally followed by space-separated tags).
-%%   * vhost/resource/topic_path (authz): exactly `allow' or `deny'.
+%% user_login_authentication/2 (authn) and req/2 (authz)). Both match a raw
+%% `"deny " ++ Reason' body before lowercasing the trimmed body and matching
+%% the bare verdicts, so a well-formed deny may carry a human-readable reason:
+%%   * user_path (authn): `deny' (optionally followed by whitespace and a
+%%     reason), or `allow' (optionally followed by space-separated tags).
+%%   * vhost/resource/topic_path (authz): exactly `allow', or `deny' (optionally
+%%     followed by whitespace and a reason).
 classify_response(Key, Body) ->
     case response_matches_contract(Key, normalize_resp(Body)) of
         true -> ok;
@@ -627,24 +629,30 @@ normalize_resp(Body) when is_binary(Body) ->
 normalize_resp(_) ->
     <<>>.
 
-%% user_path authenticates, so it accepts allow-with-tags (prefix match), the
-%% same as the real backend's `"allow" ++ Rest' clause. The authz paths only
-%% ever return a bare allow/deny.
+%% user_path authenticates, so it accepts allow-with-tags, the same as the real
+%% backend's `"allow" ++ Rest' clause. Both authn and authz accept a `deny' that
+%% carries a reason, mirroring the backend's `"deny " ++ Reason' clause. The
+%% authz paths never return allow-with-tags, so allow must be bare there.
 response_matches_contract(<<"user_path">>, Resp) ->
-    Resp =:= <<"deny">> orelse is_allow_prefix(Resp);
+    is_keyword_prefix(<<"deny">>, Resp) orelse is_keyword_prefix(<<"allow">>, Resp);
 response_matches_contract(_AuthzPath, Resp) ->
-    Resp =:= <<"allow">> orelse Resp =:= <<"deny">>.
+    Resp =:= <<"allow">> orelse is_keyword_prefix(<<"deny">>, Resp).
 
-%% True when Resp is `allow' or `allow' followed by a whitespace-delimited tag
-%% list (e.g. `allow administrator management'). A bare `allowxyz' is rejected:
-%% the real backend tolerates it, but for a config-validation signal we want the
+%% True when Resp is exactly Keyword, or Keyword followed by a whitespace-
+%% delimited remainder (an `allow' tag list, or a `deny' reason). A near-miss
+%% like `allowxyz' or `denied' is rejected: the real backend tolerates a bare
+%% `"allow" ++ Rest', but for a config-validation signal we require the
 %% canonical separator so a near-miss body is flagged rather than waved through.
-is_allow_prefix(<<"allow">>) ->
-    true;
-is_allow_prefix(<<"allow", Sep, _/binary>>) ->
-    Sep =:= $\s orelse Sep =:= $\t;
-is_allow_prefix(_) ->
-    false.
+is_keyword_prefix(Keyword, Resp) ->
+    KwSize = byte_size(Keyword),
+    case Resp of
+        Keyword ->
+            true;
+        <<Keyword:KwSize/binary, Sep, _/binary>> ->
+            Sep =:= $\s orelse Sep =:= $\t;
+        _ ->
+            false
+    end.
 
 %% Build the httpc Request tuple for the configured method. For GET the query
 %% goes in the URL; for POST it is a form-encoded body, matching

--- a/src/aws_auth_validate_http.erl
+++ b/src/aws_auth_validate_http.erl
@@ -78,7 +78,9 @@
     build_client_ssl_opts/1,
     classify_http_error/1,
     is_tls_error/1,
-    classify_response/2
+    classify_response/2,
+    query_for/1,
+    params_for/1
 ]).
 -endif.
 
@@ -603,10 +605,11 @@ is_tls_error(Term) ->
 %% endpoint speaks the auth protocol. We only fail when the body matches
 %% NEITHER allow nor deny, which means the configured path points at something
 %% that is not an auth backend (the false-pass this guard closes). We never
-%% echo the body (R4): a mismatch returns the fixed ?REASON_ENDPOINT.
+%% echo the body: a mismatch returns the fixed ?REASON_ENDPOINT.
 %%
-%% Grammar (mirrors rabbit_auth_backend_http:parse_resp/1, which does
-%% string:to_lower(string:strip(Body)) then matches):
+%% Grammar (mirrors rabbit_auth_backend_http's own parsing in
+%% user_login_authentication/2 (authn) and req/2 (authz), which lowercase the
+%% trimmed body then match):
 %%   * user_path (authn): exactly `deny', or anything beginning with `allow'
 %%     (an `allow' optionally followed by space-separated tags).
 %%   * vhost/resource/topic_path (authz): exactly `allow' or `deny'.

--- a/test/aws_auth_validate_http_parity_tests.erl
+++ b/test/aws_auth_validate_http_parity_tests.erl
@@ -143,6 +143,14 @@ join_tags_parity_test_() ->
 %% exported pure functions, so this pins our classify_response/2 against that
 %% grammar directly. If someone loosens or tightens our parser, this flags it
 %% against the contract we are mirroring.
+%%
+%% LIMITATION: unlike the query-encoding tests above, this side is NOT
+%% differential. The Ok/Bad corpora below are a hand-written restatement of the
+%% upstream grammar, not a call into upstream, so an upstream change to the
+%% allow/deny parsing does NOT fail these tests. When bumping the RabbitMQ
+%% dependency, re-read user_login_authentication/2 and req/2 and re-sync these
+%% corpora by hand. A durable fix would require upstream to export a pure
+%% response-parsing predicate to assert against directly.
 
 %% authn (user_path): `deny'[ reason...] or `allow'[ tags...] succeed; anything
 %% else fails.

--- a/test/aws_auth_validate_http_parity_tests.erl
+++ b/test/aws_auth_validate_http_parity_tests.erl
@@ -63,28 +63,54 @@ query_encoding_parity_test_() ->
             ]
     end.
 
-%% Spot-check the encoding on the characters most likely to diverge (space,
-%% slash, reserved), independent of the fixed probe params, so a regression is
-%% attributable to encoding rather than to a params change.
+%% Spot-check the encoding of individual special characters, independent of the
+%% fixed probe params, so a regression is attributable to encoding rather than to
+%% a params change. uri_string:compose_query/1 is the encoder query_for/1
+%% delegates to, so this compares the two encoders directly.
+%%
+%% Two groups, because the encoders agree byte-for-byte on most characters but
+%% not all:
+%%   * AGREE -- space (both `+'), `/', `#', and reserved `&'/`=' encode
+%%     identically, so byte equality holds and pins that no regression appears.
+%%   * DIVERGE-BUT-SAFE -- `~' (upstream leaves literal, compose_query emits
+%%     %7E) and `*' (upstream emits %2A, compose_query leaves literal) differ in
+%%     bytes but decode to the same character, so a conformant auth server that
+%%     percent-decodes reads the same param either way. Asserting byte equality
+%%     here would be wrong; assert post-decode (semantic) equivalence instead,
+%%     which is the property that actually matters on the wire.
 query_encoding_special_chars_test_() ->
     case upstream_q_usable() of
         false ->
             [];
         true ->
-            Params = [
+            Agree = [
                 [{"username", "a b"}],
                 [{"name", "a/b"}],
                 [{"vhost", "/"}],
                 [{"routing_key", "#"}],
                 [{"k", "a&b=c"}]
             ],
+            DivergeButSafe = [
+                [{"k", "tilde~x"}],
+                [{"k", "star*x"}]
+            ],
             [
                 {
-                    lists:flatten(io_lib:format("~p", [P])),
+                    "byte parity: " ++ lists:flatten(io_lib:format("~p", [P])),
                     ?_assertEqual(?UPSTREAM:q(P), uri_string:compose_query(P))
                 }
-             || P <- Params
-            ]
+             || P <- Agree
+            ] ++
+                [
+                    {
+                        "decode parity: " ++ lists:flatten(io_lib:format("~p", [P])),
+                        ?_assertEqual(
+                            uri_string:dissect_query(?UPSTREAM:q(P)),
+                            uri_string:dissect_query(uri_string:compose_query(P))
+                        )
+                    }
+                 || P <- DivergeButSafe
+                ]
     end.
 
 %%--------------------------------------------------------------------

--- a/test/aws_auth_validate_http_parity_tests.erl
+++ b/test/aws_auth_validate_http_parity_tests.erl
@@ -193,32 +193,28 @@ response_grammar_authz_test_() ->
 path_keys() ->
     [<<"user_path">>, <<"vhost_path">>, <<"resource_path">>, <<"topic_path">>].
 
-%% rabbit_auth_backend_http:q/1 depends on rabbit_http_util:quote_plus and
-%% rabbit_data_coercion. Across the RMQ-version CI matrix those are not always
-%% loaded in the bare eunit node; if they are missing q/1 throws undef and the
-%% parity check would fail spuriously. Probe q/1 only for CALLABILITY (it runs
-%% and returns a string), not for a specific encoding: pinning the expected
-%% output here would make an upstream encoding change flip this guard to false
-%% and skip the parity test, silently disabling the one check that exists to
-%% catch encoding drift. With only a callability guard, such drift fails the
-%% differential assertion instead.
 upstream_q_usable() ->
-    code:ensure_loaded(?UPSTREAM) =/= {error, nofile} andalso
-        erlang:function_exported(?UPSTREAM, q, 1) andalso
-        try
-            is_list(?UPSTREAM:q([{"k", "a b"}]))
-        catch
-            _:_ -> false
-        end.
+    upstream_callable(q, [{"k", "a b"}]).
 
-%% Callability guard only, for the same reason as upstream_q_usable/0: pinning
-%% the expected output would skip the parity test on the very drift it exists to
-%% catch.
 upstream_join_tags_usable() ->
+    upstream_callable(join_tags, [a, b]).
+
+%% True when ?UPSTREAM:Fun can be called with SampleArgs and returns a string.
+%% rabbit_auth_backend_http:q/1 depends on rabbit_http_util:quote_plus and
+%% rabbit_data_coercion, which across the RMQ-version CI matrix are not always
+%% loaded in the bare eunit node; if a dep is missing the function throws undef
+%% and the parity check would fail spuriously, so skip it then.
+%%
+%% The probe checks CALLABILITY (it runs and returns a string), not a specific
+%% output: pinning the expected value would make an upstream behaviour change
+%% flip this guard to false and skip the parity test, silently disabling the one
+%% check that exists to catch that drift. With only a callability guard, such
+%% drift fails the differential assertion instead.
+upstream_callable(Fun, SampleArgs) ->
     code:ensure_loaded(?UPSTREAM) =/= {error, nofile} andalso
-        erlang:function_exported(?UPSTREAM, join_tags, 1) andalso
+        erlang:function_exported(?UPSTREAM, Fun, 1) andalso
         try
-            is_list(?UPSTREAM:join_tags([a, b]))
+            is_list(?UPSTREAM:Fun(SampleArgs))
         catch
             _:_ -> false
         end.

--- a/test/aws_auth_validate_http_parity_tests.erl
+++ b/test/aws_auth_validate_http_parity_tests.erl
@@ -162,22 +162,29 @@ path_keys() ->
 %% rabbit_auth_backend_http:q/1 depends on rabbit_http_util:quote_plus and
 %% rabbit_data_coercion. Across the RMQ-version CI matrix those are not always
 %% loaded in the bare eunit node; if they are missing q/1 throws undef and the
-%% parity check would fail spuriously. Probe q/1 with a known input and only run
-%% the differential tests when it produces the expected encoding.
+%% parity check would fail spuriously. Probe q/1 only for CALLABILITY (it runs
+%% and returns a string), not for a specific encoding: pinning the expected
+%% output here would make an upstream encoding change flip this guard to false
+%% and skip the parity test, silently disabling the one check that exists to
+%% catch encoding drift. With only a callability guard, such drift fails the
+%% differential assertion instead.
 upstream_q_usable() ->
     code:ensure_loaded(?UPSTREAM) =/= {error, nofile} andalso
         erlang:function_exported(?UPSTREAM, q, 1) andalso
         try
-            ?UPSTREAM:q([{"k", "a b"}]) =:= "k=a+b"
+            is_list(?UPSTREAM:q([{"k", "a b"}]))
         catch
             _:_ -> false
         end.
 
+%% Callability guard only, for the same reason as upstream_q_usable/0: pinning
+%% the expected output would skip the parity test on the very drift it exists to
+%% catch.
 upstream_join_tags_usable() ->
     code:ensure_loaded(?UPSTREAM) =/= {error, nofile} andalso
         erlang:function_exported(?UPSTREAM, join_tags, 1) andalso
         try
-            ?UPSTREAM:join_tags([a, b]) =:= "a b"
+            is_list(?UPSTREAM:join_tags([a, b]))
         catch
             _:_ -> false
         end.

--- a/test/aws_auth_validate_http_parity_tests.erl
+++ b/test/aws_auth_validate_http_parity_tests.erl
@@ -111,22 +111,27 @@ join_tags_parity_test_() ->
 %%--------------------------------------------------------------------
 %%
 %% The broker's allow/deny parsing is inline in user_login_authentication/2
-%% (authn: bare `deny', or `allow' + space-separated tags) and req/2 (authz:
-%% bare `allow' / `deny'), both after lowercasing the trimmed body. Those are
-%% not exported pure functions, so this pins our classify_response/2 against
-%% that grammar directly. If someone loosens or tightens our parser, this flags
-%% it against the contract we are mirroring.
+%% (authn: a raw `"deny " ++ Reason', then bare `deny', or `allow' +
+%% space-separated tags) and req/2 (authz: a raw `"deny " ++ Reason', then bare
+%% `allow' / `deny'), both after lowercasing the trimmed body. Those are not
+%% exported pure functions, so this pins our classify_response/2 against that
+%% grammar directly. If someone loosens or tightens our parser, this flags it
+%% against the contract we are mirroring.
 
-%% authn (user_path): `deny' or `allow'[ tags...] succeed; anything else fails.
+%% authn (user_path): `deny'[ reason...] or `allow'[ tags...] succeed; anything
+%% else fails.
 response_grammar_authn_test_() ->
     Ok = [
         <<"allow">>,
         <<"allow administrator">>,
         <<"allow a b c">>,
         <<"deny">>,
+        %% a deny may carry a reason, mirroring the broker's `"deny " ++ Reason'
+        <<"deny insufficient permissions">>,
         %% trimming + case-insensitivity, as the broker lowercases the trimmed body
         <<"  ALLOW  ">>,
-        <<"Deny">>
+        <<"Deny">>,
+        <<"DENY too bad">>
     ],
     Bad = [<<"allowed">>, <<"allowxyz">>, <<"denied">>, <<"maybe">>, <<>>, <<"allow-tag">>],
     [?_assertEqual(ok, ?BACKEND:classify_response(<<"user_path">>, B)) || B <- Ok] ++
@@ -135,11 +140,11 @@ response_grammar_authn_test_() ->
          || B <- Bad
         ].
 
-%% authz (vhost/resource/topic_path): only bare `allow' / `deny' succeed; the
-%% allow-with-tags form is authn-only and must NOT be accepted here.
+%% authz (vhost/resource/topic_path): bare `allow', or `deny'[ reason...],
+%% succeed; the allow-with-tags form is authn-only and must NOT be accepted here.
 response_grammar_authz_test_() ->
     Keys = [<<"vhost_path">>, <<"resource_path">>, <<"topic_path">>],
-    Ok = [<<"allow">>, <<"deny">>, <<"  ALLOW ">>],
+    Ok = [<<"allow">>, <<"deny">>, <<"deny not allowed here">>, <<"  ALLOW ">>],
     Bad = [<<"allow administrator">>, <<"allowed">>, <<"maybe">>, <<>>],
     [?_assertEqual(ok, ?BACKEND:classify_response(K, B)) || K <- Keys, B <- Ok] ++
         [

--- a/test/aws_auth_validate_http_parity_tests.erl
+++ b/test/aws_auth_validate_http_parity_tests.erl
@@ -4,7 +4,7 @@
 %% -*- mode: erlang; -*-
 
 %% Parity tests between the HTTP validation backend and the real
-%% rabbit_auth_backend_http it validates.
+%% rabbit_auth_backend_http that it validates.
 %%
 %% The validation backend does not reimplement an upstream parser (unlike the
 %% LDAP query DSL), so there is no single equal-both-implementations check like
@@ -44,8 +44,8 @@
 %% For every probe path type, the query string our backend sends must encode
 %% byte-for-byte the same as rabbit_auth_backend_http:q/1 given the same params.
 %% If upstream ever changes its encoding (e.g. space as %20 instead of +, or a
-%% different escaping of `/'), the probe would send params a conformant auth
-%% server parses differently and this fails.
+%% different escaping of `/'), the probe would send params that a conformant
+%% auth server parses differently and this fails.
 query_encoding_parity_test_() ->
     case upstream_q_usable() of
         false ->

--- a/test/aws_auth_validate_http_parity_tests.erl
+++ b/test/aws_auth_validate_http_parity_tests.erl
@@ -1,0 +1,178 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% Parity tests between the HTTP validation backend and the real
+%% rabbit_auth_backend_http it validates.
+%%
+%% The validation backend does not reimplement an upstream parser (unlike the
+%% LDAP query DSL), so there is no single equal-both-implementations check like
+%% aws_auth_validate_tests:parity_test_/0. What it DOES do is build request
+%% queries and interpret allow/deny responses the same way the real backend
+%% does, mirroring that contract by hand. These tests pin the parts of that
+%% contract that upstream exposes, so a change in rabbit_auth_backend_http that
+%% would make the probe diverge from a real broker request is caught here rather
+%% than silently.
+%%
+%% What is checked:
+%%   * query encoding parity -- the probe's per-path query strings encode
+%%     identically to rabbit_auth_backend_http:q/1 (the exported query builder
+%%     the broker uses). This is a true differential test: both are run on the
+%%     same params and asserted equal.
+%%   * tag-join parity -- join_tags/1 is referenced by the authz query shape.
+%%   * response-grammar contract -- our classify_response/2 accepts exactly the
+%%     allow/deny forms the broker's own parsing accepts, and rejects the rest.
+%%     The broker's parsing is inline in user_login_authentication/2 and req/2
+%%     (not an exported pure function), so this side is asserted against the
+%%     documented grammar rather than by calling upstream directly.
+%%
+%% Like the LDAP parity tests, the differential checks run only when upstream is
+%% actually usable in this node (the module and its deps loaded); otherwise they
+%% skip rather than fail spuriously across the RMQ-version CI matrix.
+-module(aws_auth_validate_http_parity_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(BACKEND, aws_auth_validate_http).
+-define(UPSTREAM, rabbit_auth_backend_http).
+
+%%--------------------------------------------------------------------
+%% Query-encoding parity (differential: our query_for vs upstream q/1)
+%%--------------------------------------------------------------------
+
+%% For every probe path type, the query string our backend sends must encode
+%% byte-for-byte the same as rabbit_auth_backend_http:q/1 given the same params.
+%% If upstream ever changes its encoding (e.g. space as %20 instead of +, or a
+%% different escaping of `/'), the probe would send params a conformant auth
+%% server parses differently and this fails.
+query_encoding_parity_test_() ->
+    case upstream_q_usable() of
+        false ->
+            [];
+        true ->
+            [
+                {
+                    "query_for(" ++ binary_to_list(Key) ++ ") == upstream q/1",
+                    ?_assertEqual(
+                        ?UPSTREAM:q(?BACKEND:params_for(Key)),
+                        ?BACKEND:query_for(Key)
+                    )
+                }
+             || Key <- path_keys()
+            ]
+    end.
+
+%% Spot-check the encoding on the characters most likely to diverge (space,
+%% slash, reserved), independent of the fixed probe params, so a regression is
+%% attributable to encoding rather than to a params change.
+query_encoding_special_chars_test_() ->
+    case upstream_q_usable() of
+        false ->
+            [];
+        true ->
+            Params = [
+                [{"username", "a b"}],
+                [{"name", "a/b"}],
+                [{"vhost", "/"}],
+                [{"routing_key", "#"}],
+                [{"k", "a&b=c"}]
+            ],
+            [
+                {
+                    lists:flatten(io_lib:format("~p", [P])),
+                    ?_assertEqual(?UPSTREAM:q(P), uri_string:compose_query(P))
+                }
+             || P <- Params
+            ]
+    end.
+
+%%--------------------------------------------------------------------
+%% Tag-join parity (join_tags/1 is exported upstream)
+%%--------------------------------------------------------------------
+
+join_tags_parity_test_() ->
+    case upstream_join_tags_usable() of
+        false ->
+            [];
+        true ->
+            [
+                ?_assertEqual("", ?UPSTREAM:join_tags([])),
+                ?_assertEqual("administrator", ?UPSTREAM:join_tags([administrator])),
+                ?_assertEqual(
+                    "administrator management",
+                    ?UPSTREAM:join_tags([administrator, management])
+                )
+            ]
+    end.
+
+%%--------------------------------------------------------------------
+%% Response-grammar contract (our classify_response vs the documented grammar)
+%%--------------------------------------------------------------------
+%%
+%% The broker's allow/deny parsing is inline in user_login_authentication/2
+%% (authn: bare `deny', or `allow' + space-separated tags) and req/2 (authz:
+%% bare `allow' / `deny'), both after lowercasing the trimmed body. Those are
+%% not exported pure functions, so this pins our classify_response/2 against
+%% that grammar directly. If someone loosens or tightens our parser, this flags
+%% it against the contract we are mirroring.
+
+%% authn (user_path): `deny' or `allow'[ tags...] succeed; anything else fails.
+response_grammar_authn_test_() ->
+    Ok = [
+        <<"allow">>,
+        <<"allow administrator">>,
+        <<"allow a b c">>,
+        <<"deny">>,
+        %% trimming + case-insensitivity, as the broker lowercases the trimmed body
+        <<"  ALLOW  ">>,
+        <<"Deny">>
+    ],
+    Bad = [<<"allowed">>, <<"allowxyz">>, <<"denied">>, <<"maybe">>, <<>>, <<"allow-tag">>],
+    [?_assertEqual(ok, ?BACKEND:classify_response(<<"user_path">>, B)) || B <- Ok] ++
+        [
+            ?_assertMatch({error, auth_failed, _}, ?BACKEND:classify_response(<<"user_path">>, B))
+         || B <- Bad
+        ].
+
+%% authz (vhost/resource/topic_path): only bare `allow' / `deny' succeed; the
+%% allow-with-tags form is authn-only and must NOT be accepted here.
+response_grammar_authz_test_() ->
+    Keys = [<<"vhost_path">>, <<"resource_path">>, <<"topic_path">>],
+    Ok = [<<"allow">>, <<"deny">>, <<"  ALLOW ">>],
+    Bad = [<<"allow administrator">>, <<"allowed">>, <<"maybe">>, <<>>],
+    [?_assertEqual(ok, ?BACKEND:classify_response(K, B)) || K <- Keys, B <- Ok] ++
+        [
+            ?_assertMatch({error, auth_failed, _}, ?BACKEND:classify_response(K, B))
+         || K <- Keys, B <- Bad
+        ].
+
+%%--------------------------------------------------------------------
+%% Corpus + upstream-usable guards
+%%--------------------------------------------------------------------
+
+path_keys() ->
+    [<<"user_path">>, <<"vhost_path">>, <<"resource_path">>, <<"topic_path">>].
+
+%% rabbit_auth_backend_http:q/1 depends on rabbit_http_util:quote_plus and
+%% rabbit_data_coercion. Across the RMQ-version CI matrix those are not always
+%% loaded in the bare eunit node; if they are missing q/1 throws undef and the
+%% parity check would fail spuriously. Probe q/1 with a known input and only run
+%% the differential tests when it produces the expected encoding.
+upstream_q_usable() ->
+    code:ensure_loaded(?UPSTREAM) =/= {error, nofile} andalso
+        erlang:function_exported(?UPSTREAM, q, 1) andalso
+        try
+            ?UPSTREAM:q([{"k", "a b"}]) =:= "k=a+b"
+        catch
+            _:_ -> false
+        end.
+
+upstream_join_tags_usable() ->
+    code:ensure_loaded(?UPSTREAM) =/= {error, nofile} andalso
+        erlang:function_exported(?UPSTREAM, join_tags, 1) andalso
+        try
+            ?UPSTREAM:join_tags([a, b]) =:= "a b"
+        catch
+            _:_ -> false
+        end.

--- a/test/aws_auth_validate_http_tests.erl
+++ b/test/aws_auth_validate_http_tests.erl
@@ -760,12 +760,18 @@ http_response_contract_test_() ->
         {<<"user_path">>, <<"allow">>, ok},
         {<<"user_path">>, <<"deny">>, ok},
         {<<"user_path">>, <<"allow administrator management">>, ok},
+        %% deny-with-reason passes, mirroring the backend's `"deny " ++ Reason'
+        %% clause; a conformant server may explain the refusal.
+        {<<"user_path">>, <<"deny insufficient permissions">>, ok},
+        {<<"resource_path">>, <<"deny not allowed here">>, ok},
         %% Normalization: leading/trailing whitespace + case are tolerated,
         %% mirroring rabbit_auth_backend_http's lower(strip(Body)).
         {<<"user_path">>, <<"  ALLOW  ">>, ok},
         {<<"user_path">>, <<"Deny\n">>, ok},
         {<<"user_path">>, <<"allow\tmanagement">>, ok},
-        %% authz paths only ever return a bare allow/deny.
+        {<<"user_path">>, <<"DENY too bad">>, ok},
+        %% authz paths only ever return a bare allow or a deny (with or without
+        %% a reason).
         {<<"vhost_path">>, <<"allow">>, ok},
         {<<"resource_path">>, <<"deny">>, ok},
         {<<"topic_path">>, <<"ALLOW">>, ok},
@@ -773,6 +779,7 @@ http_response_contract_test_() ->
         {<<"user_path">>, <<"<html>hi</html>">>, {error, auth_failed, Endpoint}},
         {<<"user_path">>, <<"">>, {error, auth_failed, Endpoint}},
         {<<"user_path">>, <<"allowed">>, {error, auth_failed, Endpoint}},
+        {<<"user_path">>, <<"denied">>, {error, auth_failed, Endpoint}},
         {<<"user_path">>, <<"{\"result\":\"allow\"}">>, {error, auth_failed, Endpoint}},
         %% allow-with-tags is NOT valid on an authz path (exact match only).
         {<<"vhost_path">>, <<"allow administrator">>, {error, auth_failed, Endpoint}},


### PR DESCRIPTION
## Summary

The HTTP validation method (`aws_auth_validate_http`) mirrors `rabbit_auth_backend_http` by hand: it builds the same request queries and interprets the same `allow`/`deny` responses, so a green validation result reflects how the real broker would behave. Nothing pinned that contract, so an upstream change to the query encoding or the response grammar could make the probe diverge from a real broker request without any test noticing.

This adds that protection, analogous to the LDAP query-parser parity tests (`aws_auth_validate_tests:parity_test_/0`), which exist for the same reason: to keep a hand-mirrored contract from silently drifting.

## What changed

- Add `rabbitmq_auth_backend_http` as a `TEST_DEP`.
- New `test/aws_auth_validate_http_parity_tests.erl`:
  - **Query-encoding parity** -- the probe's per-path query strings encode identically to the exported `rabbit_auth_backend_http:q/1`. This is a true differential test: both are run on the same params and asserted equal, so a change in upstream encoding (e.g. space as `%20` instead of `+`) fails the build.
  - **`join_tags/1` parity** -- against the exported upstream helper.
  - **Response-grammar contract** -- `classify_response/2` accepts exactly the `allow`/`deny` forms the broker's parsing accepts (bare `deny` or `allow` + space-separated tags for authn; bare `allow`/`deny` for authz), and rejects the rest. The broker's parsing is inline in `user_login_authentication/2` and `req/2` (not an exported pure function), so this side is pinned against the documented grammar rather than called directly.
- Expose `query_for/1` and `params_for/1` under `-ifdef(TEST)` for the parity test.
- Fix a stale comment: the grammar comment referenced a `parse_resp/1` that does not exist upstream; the parsing lives in `user_login_authentication/2` + `req/2`. (This stale reference is itself an example of the drift this PR guards against.)

The differential checks skip -- rather than fail -- when upstream is not usable in the node (module or its deps not loaded), matching how the LDAP parity tests handle the RMQ-version CI matrix.

## Limitation

This guard is necessarily weaker than the LDAP parity tests. LDAP reimplements a whole parser and gets a clean "run both implementations, assert equal" test. HTTP only gets query-encoding parity plus grammar-contract assertions, because the two things most worth pinning -- upstream's `?SUCCESSFUL_RESPONSE_CODES` macro and its inline `allow`/`deny` parser -- are not exported. A full parity test would require a small upstream change to export a response-code predicate and factor out the response parser.

## Testing

- Full eunit suite passes (603 tests).
- Confirmed the differential checks are non-vacuous: the upstream-usable guards return true in the umbrella build, so the query-encoding and `join_tags` parity tests run against the real backend rather than skipping.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
