### PR TITLE
Auth Validation Endpoint: Adding crash dump coverage and preventing unauthenticated-PUT authz + silent downgrading

### DIFF
--- a/test/aws_auth_validate_mgmt_SUITE.erl
+++ b/test/aws_auth_validate_mgmt_SUITE.erl
@@ -31,7 +31,9 @@
     capacity_exhausted_returns_503/1,
     enabled_without_worker_returns_503/1,
     method_disabled_returns_404/1,
+    backend_raise_returns_500_without_leak/1,
     custom_tag_insufficient_returns_401/1,
+    custom_tag_unauthenticated_put_returns_401/1,
     custom_tag_options_preflight_allowed/1,
     options_returns_allowed_methods/1,
     get_returns_405/1,
@@ -46,7 +48,7 @@
 -export([hold_slot/1]).
 
 %% Invoked on the broker node via rpc to stub/unstub the registry dispatch.
--export([mock_dispatch_ok/0, unmock_dispatch/0]).
+-export([mock_dispatch_ok/0, mock_dispatch_raise/1, unmock_dispatch/0]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -55,6 +57,11 @@
 
 -define(API, "/aws/auth/validate/ldap").
 -define(OAUTH_API, "/aws/auth/validate/oauth").
+
+%% A unique secret-shaped sentinel that a backend raise carries in scope. If the
+%% handler's crash-dump guard ever let it escape, it would surface in the HTTP
+%% response body; backend_raise_returns_500_without_leak asserts it does not.
+-define(LEAK_SENTINEL, <<"S3cr3t-Sentinel-Handler-Leak-DO-NOT-LEAK">>).
 
 all() ->
     [
@@ -78,6 +85,7 @@ groups() ->
             capacity_exhausted_returns_503,
             enabled_without_worker_returns_503,
             method_disabled_returns_404,
+            backend_raise_returns_500_without_leak,
             options_returns_allowed_methods,
             get_returns_405,
             password_not_in_response,
@@ -88,6 +96,7 @@ groups() ->
         %% (unauthenticated, user=undefined) must still be allowed through.
         {feature_enabled_custom_tag, [], [
             custom_tag_insufficient_returns_401,
+            custom_tag_unauthenticated_put_returns_401,
             custom_tag_options_preflight_allowed
         ]},
         %% OAuth method tests: opt-in behaviour (disabled by default -> 404),
@@ -167,6 +176,15 @@ init_per_testcase(success_returns_204 = TC, Config) ->
         Config, 0, ?MODULE, mock_dispatch_ok, []
     ),
     rabbit_ct_helpers:testcase_started(Config, TC);
+init_per_testcase(backend_raise_returns_500_without_leak = TC, Config) ->
+    %% Drive the registry dispatch to RAISE with a secret-bearing term, so the
+    %% handler's with_semaphore/6 defence-in-depth catch (the R6 crash-dump guard)
+    %% is exercised through the real Cowboy pipeline. The mock runs ON THE BROKER
+    %% NODE so the handler sees it.
+    ok = rabbit_ct_broker_helpers:rpc(
+        Config, 0, ?MODULE, mock_dispatch_raise, [?LEAK_SENTINEL]
+    ),
+    rabbit_ct_helpers:testcase_started(Config, TC);
 init_per_testcase(oauth_success_returns_204 = TC, Config) ->
     %% Enable the oauth method and mock dispatch to return ok.
     rabbit_ct_broker_helpers:rpc(
@@ -202,6 +220,11 @@ end_per_testcase(method_disabled_returns_404 = TC, Config) ->
     ),
     rabbit_ct_helpers:testcase_finished(Config, TC);
 end_per_testcase(success_returns_204 = TC, Config) ->
+    ok = rabbit_ct_broker_helpers:rpc(
+        Config, 0, ?MODULE, unmock_dispatch, []
+    ),
+    rabbit_ct_helpers:testcase_finished(Config, TC);
+end_per_testcase(backend_raise_returns_500_without_leak = TC, Config) ->
     ok = rabbit_ct_broker_helpers:rpc(
         Config, 0, ?MODULE, unmock_dispatch, []
     ),
@@ -293,6 +316,36 @@ method_disabled_returns_404(Config) ->
     {ok, {{_, Code, _}, _, _}} = put_request(Config, ?API, Body),
     ?assertEqual(404, Code).
 
+%% R5/R6 (crash-dump leakage): the handler's with_semaphore/6 wraps the backend
+%% dispatch in a try/catch whose sole purpose is to keep an escaping exception --
+%% which would carry the request BodyMap (and any resolved secret) into a Cowboy
+%% crash report -- from ever surfacing. Nothing exercised that catch before: the
+%% success/error paths all RETURN a value, so the class:reason:stack discard was
+%% asserted nowhere.
+%%
+%% Here we force dispatch to RAISE with a secret-bearing term (the worst case for
+%% a crash-report leak) and drive a real PUT through the handler. We assert:
+%%   1. the caller gets the fixed 500 internal_error response (the catch fired --
+%%      the request did not 500 with a stacktrace or hang), and
+%%   2. neither the sentinel secret nor the raised reason leaks into the response
+%%      body -- it is a fixed category + message only.
+%% The submitted-password no-leak on the response is covered by
+%% password_not_in_response; this is specifically the RAISE path through the
+%% handler boundary that the design doc flagged as unproven.
+backend_raise_returns_500_without_leak(Config) ->
+    Body = (base_body())#{<<"password">> => ?LEAK_SENTINEL},
+    {ok, {{_, Code, _}, _Headers, ResBody}} = put_request(Config, ?API, Body),
+    ?assertEqual(500, Code),
+    Decoded = decode(ResBody),
+    ?assertMatch(#{<<"error">> := <<"internal_error">>}, Decoded),
+    %% The fixed message is the only detail; no raised reason / stacktrace.
+    ?assertMatch(
+        #{<<"message">> := <<"Internal error during validation">>}, Decoded
+    ),
+    %% The secret the raise carried in scope must not appear anywhere in the body.
+    RawResBody = iolist_to_binary(ResBody),
+    ?assertEqual(nomatch, binary:match(RawResBody, ?LEAK_SENTINEL)).
+
 %% Feature reads enabled but the semaphore worker is not running (the
 %% runtime-enable-without-restart / supervisor-gave-up case). The handler
 %% must return a graceful 503, not an opaque 500 from a noproc gen_server
@@ -324,6 +377,29 @@ custom_tag_insufficient_returns_401(Config) ->
     {ok, {{_, Code, _}, _, ResBody}} = put_request(Config, ?API, Body),
     ?assertEqual(401, Code),
     ?assertMatch(#{<<"error">> := <<"insufficient_user_tag">>}, decode(ResBody)).
+
+%% R2 confirmatory test: the authorize_tag/3 `user = undefined' clause
+%% (aws_auth_validate_mgmt.erl) lets a request through WITHOUT a user, on the
+%% documented assumption that only an unauthenticated OPTIONS preflight can reach
+%% it (rabbit_mgmt_util short-circuits OPTIONS to {true, _, undefined} before
+%% authenticating). The safety of the whole custom-tag branch rests on that
+%% clause being UNREACHABLE by a state-changing PUT. This asserts the invariant:
+%% an UNAUTHENTICATED PUT (no auth header) is stopped with 401 by is_authorized/2
+%% BEFORE authorize_tag/3 is reached -- it must never dispatch. If a future
+%% refactor let an anonymous PUT reach the user=undefined pass-through, this
+%% would see a 2xx/4xx-from-dispatch instead of the 401 and fail (CWE-862/863).
+custom_tag_unauthenticated_put_returns_401(Config) ->
+    Body = binary_to_list(rabbit_json:encode(base_body())),
+    %% No auth_header/2 credential -- an anonymous request.
+    {ok, {{_, Code, _}, _Headers, _ResBody}} = rabbit_mgmt_test_util:req(
+        Config,
+        0,
+        put,
+        ?API,
+        [{"content-type", "application/json"}],
+        Body
+    ),
+    ?assertEqual(401, Code).
 
 %% An OPTIONS preflight is unauthenticated (user=undefined) but must still be
 %% allowed through on the custom-tag branch -- regression test for the bug
@@ -423,6 +499,17 @@ oauth_response_no_secret(Config) ->
 mock_dispatch_ok() ->
     ok = meck:new(aws_auth_validate_registry, [passthrough, no_link]),
     ok = meck:expect(aws_auth_validate_registry, dispatch, fun(_Method, _Body) -> ok end),
+    ok.
+
+%% Run ON THE BROKER NODE (invoked via rpc). Stub the registry dispatch so it
+%% RAISES with the given secret-bearing term, exercising the handler's
+%% with_semaphore/6 crash-dump guard. The secret is embedded in the raised reason
+%% -- the worst case for a crash-report leak.
+mock_dispatch_raise(Secret) ->
+    ok = meck:new(aws_auth_validate_registry, [passthrough, no_link]),
+    ok = meck:expect(aws_auth_validate_registry, dispatch, fun(_Method, _Body) ->
+        erlang:error({boom, Secret})
+    end),
     ok.
 
 unmock_dispatch() ->

--- a/test/aws_auth_validate_shared_tests.erl
+++ b/test/aws_auth_validate_shared_tests.erl
@@ -169,3 +169,81 @@ scheme_policy_divergence_test() ->
     HttpsUrl = #{scheme => "https", host => "example.com"},
     ?assertEqual(ok, aws_auth_validate_http:url_allowed(HttpsUrl)),
     ?assertEqual(ok, aws_auth_validate_oauth:url_allowed(HttpsUrl)).
+
+%%--------------------------------------------------------------------
+%% aws_auth_validate_ssl:apply_verify_default/2 (R7): verify_peer is never
+%% SILENTLY downgraded. This is the false-positive the whole endpoint exists to
+%% prevent -- an operator who wrote verify_peer must not be told "reachable" by a
+%% probe that quietly fell back to verify_none. These pin every branch of the
+%% policy directly, deterministically, without needing a live TLS server (the
+%% http/oauth/tls SUITEs cover it end to end but skip when no server is present).
+%%
+%% Branch matrix (VerifyExplicit x anchor-present):
+%%   explicit verify_peer + no anchor   -> {error, tls_failed, _}   (FAIL, never downgrade)
+%%   explicit verify_peer + anchor      -> {ok, _} unchanged
+%%   defaulted verify_peer + no anchor  -> {ok, _} downgraded to verify_none
+%%   explicit verify_none               -> {ok, _} untouched
+%%   absent verify + anchor             -> {ok, _} verify_peer added
+%%   absent verify + no anchor          -> {ok, _} verify left unset
+%%--------------------------------------------------------------------
+
+%% Run Fun/0 (an eunit instantiator returning a test list) with the OS trust
+%% store forced empty, so the "no anchor" branches are deterministic regardless
+%% of the host's CA store. os_cacerts/0 wraps public_key:cacerts_get/0 in a
+%% try/catch, so returning [] here means "no trust anchor available".
+with_empty_os_store(Fun) ->
+    {setup,
+        fun() ->
+            ok = meck:new(public_key, [unstick, passthrough]),
+            meck:expect(public_key, cacerts_get, fun() -> [] end),
+            ok
+        end,
+        fun(_) -> meck:unload(public_key) end, Fun}.
+
+%% LOAD-BEARING R7 assertion: an EXPLICIT verify_peer with no trust anchor MUST
+%% fail closed with tls_failed -- it must never be silently downgraded to
+%% verify_none.
+apply_verify_default_explicit_verify_peer_without_anchor_fails_test_() ->
+    with_empty_os_store(fun() ->
+        Result = aws_auth_validate_ssl:apply_verify_default([{verify, verify_peer}], true),
+        [?_assertMatch({error, tls_failed, _}, Result)]
+    end).
+
+%% A DEFAULTED verify_peer (not explicitly requested) with no anchor is the ONLY
+%% case allowed to downgrade -- to verify_none -- so a plain reachability probe
+%% still works without a CA store. Explicitness (previous test) is what forbids
+%% the downgrade.
+apply_verify_default_defaulted_verify_peer_without_anchor_downgrades_test_() ->
+    with_empty_os_store(fun() ->
+        {ok, Opts} = aws_auth_validate_ssl:apply_verify_default([{verify, verify_peer}], false),
+        [?_assertEqual({verify, verify_none}, lists:keyfind(verify, 1, Opts))]
+    end).
+
+%% Absent verify + no anchor: leave verify unset (do not fabricate verify_peer
+%% with nothing to verify against).
+apply_verify_default_absent_verify_without_anchor_stays_unset_test_() ->
+    with_empty_os_store(fun() ->
+        {ok, Opts} = aws_auth_validate_ssl:apply_verify_default([], false),
+        [?_assertNot(lists:keymember(verify, 1, Opts))]
+    end).
+
+%% Explicit verify_peer WITH a supplied trust anchor (cacerts) is accepted
+%% unchanged -- the presence of cacerts short-circuits before the OS store, so no
+%% mock is needed.
+apply_verify_default_explicit_verify_peer_with_cacerts_is_ok_test() ->
+    Opts0 = [{verify, verify_peer}, {cacerts, [<<"der">>]}],
+    ?assertEqual({ok, Opts0}, aws_auth_validate_ssl:apply_verify_default(Opts0, true)).
+
+%% An explicit verify_none is honoured as-is (the operator opted out of
+%% verification); apply_verify_default never touches it.
+apply_verify_default_explicit_verify_none_untouched_test() ->
+    Opts0 = [{verify, verify_none}],
+    ?assertEqual({ok, Opts0}, aws_auth_validate_ssl:apply_verify_default(Opts0, false)).
+
+%% Absent verify WITH a trust anchor present: default up to verify_peer (secure
+%% by default when we have something to verify against).
+apply_verify_default_absent_verify_with_cacerts_adds_verify_peer_test() ->
+    Opts0 = [{cacerts, [<<"der">>]}],
+    {ok, Opts1} = aws_auth_validate_ssl:apply_verify_default(Opts0, false),
+    ?assertEqual({verify, verify_peer}, lists:keyfind(verify, 1, Opts1)),
+    ?assert(lists:keymember(cacerts, 1, Opts1)).


### PR DESCRIPTION
Stacks on top of #141 (the `rabbit_auth_backend_http` drift-guard / parity tests) and lands after it. The parity files may show in this PR's diff until #141 merges -- once it does, this PR's net delta is the three test-coverage additions below. Test-only; no behavioral change to the endpoint (the sole `src/` edit is an `-ifdef(TEST)` export in service of the tests).

Three security-relevant paths in the auth-validation endpoint had no direct test coverage. This adds them.

- **crash-dump leakage guard** (`aws_auth_validate_mgmt_SUITE`): the handler's `with_semaphore/6` wraps backend dispatch in a try/catch whose sole purpose is to keep an escaping exception -- which would carry the request body and any resolved secret into a Cowboy crash report -- from surfacing. Nothing exercised that catch; the success/error paths all return a value. New `mock_dispatch_raise/1` forces dispatch to raise with a secret-bearing term and drives a real PUT, asserting a fixed 500 `internal_error` and that neither the secret nor the raised reason leaks into the response body.
- **unauthenticated-PUT authorization** (`aws_auth_validate_mgmt_SUITE`): the `authorize_tag/3` `user=undefined` clause lets a request through without a user, on the assumption only an unauthenticated OPTIONS preflight can reach it. The custom-tag branch's safety rests on that clause being unreachable by a state-changing PUT. New `custom_tag_unauthenticated_put_returns_401` pins the invariant: an anonymous PUT is stopped with 401 by `is_authorized/2` before `authorize_tag/3`, so it never dispatches.
- **verify_peer never silently downgraded** (`aws_auth_validate_shared_tests`): direct unit tests of `apply_verify_default/2` across the full branch matrix, made deterministic by mocking `public_key:cacerts_get` to force an empty OS trust store. The load-bearing case: an explicit `verify_peer` with no trust anchor fails closed with `tls_failed` rather than downgrading to `verify_none` -- the false positive the endpoint exists to prevent. The live-TLS SUITEs cover this end to end but skip when no server is present.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.