### PR TITLE
Set LDAP validation method to be opt-in like every other method

### DIFF
--- a/priv/schema/aws.schema
+++ b/priv/schema/aws.schema
@@ -109,10 +109,11 @@
 {mapping, "aws.auth_validation.enabled", "aws.auth_validation_enabled",
     [{datatype, {enum, [true, false]}}]}.
 
-%% @doc Per-method enable flag. Methods are enabled by default; set
-%% explicit false to disable a specific method even when the master
-%% toggle is on. Example:
-%%   aws.auth_validation.enabled_methods.ldap = false
+%% @doc Per-method enable flag. Every method is opt-in and defaults to
+%% DISABLED: the master toggle (aws.auth_validation.enabled) starts the
+%% subsystem but brings no individual method online. Set an explicit true to
+%% enable a specific method. Example:
+%%   aws.auth_validation.enabled_methods.ldap = true
 %%   aws.auth_validation.enabled_methods.oauth = true
 {mapping, "aws.auth_validation.enabled_methods.$name", "aws.auth_validation_enabled_methods",
     [{datatype, {enum, [true, false]}}]}.

--- a/src/aws_auth_validate_registry.erl
+++ b/src/aws_auth_validate_registry.erl
@@ -53,16 +53,23 @@ effective_allowed_fields(Module, Method) ->
 
 %%--------------------------------------------------------------------
 
-%% Per-method enable check. Most methods default to enabled when no
-%% per-method setting is provided (operator opts out, not in) -- but a method
-%% in ?OPT_IN_METHODS defaults to DISABLED and must be turned on explicitly.
-%% http and oauth connect to a customer-supplied URL (an SSRF surface). Their
-%% address policy is implemented and enforced (see aws_auth_validate_net); they
-%% are opt-in so enabling ldap or the feature toggle does not bring them live.
-%% tls makes no outbound connection, but resolving a cacertfile ARN under the
-%% assume_role is still a capability worth enabling explicitly, so it is opt-in
-%% too: turning on ldap or the feature toggle does not bring it live.
--define(OPT_IN_METHODS, [<<"http">>, <<"oauth">>, <<"tls">>]).
+%% Per-method enable check. EVERY method is opt-in: a method in ?OPT_IN_METHODS
+%% defaults to DISABLED and must be turned on explicitly with
+%% aws.auth_validation.enabled_methods.<method> = true. The master feature
+%% toggle (aws.auth_validation.enabled) only starts the subsystem; it never
+%% brings any individual method online on its own.
+%%
+%% All four methods make an operator-supplied outbound connection or resolve a
+%% secret ARN, so none should activate implicitly:
+%%   * ldap connects to a customer-supplied LDAP server (an SSRF surface, guarded
+%%     by aws_auth_validate_ldap's stricter address policy).
+%%   * http and oauth connect to a customer-supplied URL (SSRF surface; address
+%%     policy enforced in aws_auth_validate_net).
+%%   * tls makes no outbound connection, but resolving a cacertfile ARN under the
+%%     assume_role is still a capability worth enabling explicitly.
+%% Because every method is listed, is_method_enabled/1's Default is always false;
+%% the list is retained so the opt-in set stays explicit and greppable.
+-define(OPT_IN_METHODS, [<<"ldap">>, <<"http">>, <<"oauth">>, <<"tls">>]).
 
 -spec is_method_enabled(binary()) -> boolean().
 is_method_enabled(Method) ->

--- a/test/aws_auth_validate_mgmt_SUITE.erl
+++ b/test/aws_auth_validate_mgmt_SUITE.erl
@@ -122,6 +122,10 @@ init_per_group(feature_disabled, Config) ->
 init_per_group(feature_enabled, Config) ->
     setup_broker(Config, [
         {auth_validation_enabled, true},
+        %% ldap is opt-in like every other method: the master toggle alone does
+        %% not bring it online, so this group must enable it explicitly or every
+        %% ldap case below would get a 404 (method_disabled).
+        {auth_validation_enabled_methods, [{<<"ldap">>, true}]},
         {auth_validation_max_concurrent, 1},
         {auth_validation_max_body_size, 1024},
         %% base_body/0 uses a loopback server (127.0.0.1); without this the
@@ -135,6 +139,8 @@ init_per_group(feature_enabled, Config) ->
 init_per_group(feature_enabled_custom_tag, Config) ->
     setup_broker(Config, [
         {auth_validation_enabled, true},
+        %% ldap is opt-in; enable it explicitly (see the feature_enabled note).
+        {auth_validation_enabled_methods, [{<<"ldap">>, true}]},
         {auth_validation_max_concurrent, 1},
         {auth_validation_max_body_size, 1024},
         {auth_validation_allow_private_networks, true},
@@ -215,8 +221,15 @@ init_per_testcase(TC, Config) ->
     rabbit_ct_helpers:testcase_started(Config, TC).
 
 end_per_testcase(method_disabled_returns_404 = TC, Config) ->
+    %% Restore the group's ldap-enabled setting rather than unset it: ldap is now
+    %% opt-in, so unsetting would leave it DISABLED and spuriously 404 the later
+    %% ldap cases in this group (password_not_in_response, success_returns_204).
     rabbit_ct_broker_helpers:rpc(
-        Config, 0, application, unset_env, [aws, auth_validation_enabled_methods]
+        Config,
+        0,
+        application,
+        set_env,
+        [aws, auth_validation_enabled_methods, [{<<"ldap">>, true}]]
     ),
     rabbit_ct_helpers:testcase_finished(Config, TC);
 end_per_testcase(success_returns_204 = TC, Config) ->


### PR DESCRIPTION
Issue #43

The auth-validation master toggle (aws.auth_validation.enabled) started the subsystem AND implicitly brought the ldap method online, while http, oauth, and tls each required an explicit enabled_methods.<method> = true. That split was inconsistent: ldap connects to a customer-supplied LDAP server, the same class of operator-controlled outbound surface as the others. Enabling the feature should not activate any individual method on its own.

- registry: add ldap to ?OPT_IN_METHODS, so is_method_enabled/1 defaults it to disabled; an ldap request now returns 404 method_disabled unless the operator sets aws.auth_validation.enabled_methods.ldap = true. Rewrite the stale comment (it claimed enabling ldap or the toggle would not bring the others live; now every method is opt-in).
- schema: the doc said methods are enabled by default; correct it to opt-in / default-disabled and flip the example from ldap = false to ldap = true.
- mgmt_SUITE: the feature_enabled and feature_enabled_custom_tag groups enabled the feature but never set enabled_methods, relying on ldap-by-default -- every ldap case in them would now 404. Enable ldap explicitly in both. Also fix an ordering hazard: method_disabled_returns_404's teardown unset enabled_methods (previously harmless, since unset meant ldap-on); it now restores {ldap, true} so the later ldap cases in the group are not spuriously disabled.

Verified against the umbrella (gmake): clean build, aws_auth_validate_mgmt CT suite 20/20, eunit 654/654.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
