### PR TITLE
Add optional OAuth authorization-evaluation layer to validation endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,16 +20,18 @@ DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 include ../../rabbitmq-components.mk
 include ../../erlang.mk
 
-# The optional OAuth authz-evaluation layer (aws_auth_validate_oauth_authz)
-# builds the broker's #resource_server{} record and so needs oauth2.hrl at
-# compile time. rabbitmq_auth_backend_oauth2 is a RUNTIME soft dependency, and
-# its header is absent on older broker series (e.g. 3.13.x). Define
-# HAVE_OAUTH2_RESOURCE_SERVER only when the header actually exists in the
-# resolved deps dir, so the plugin still compiles where it does not (the authz
-# layer is then merely unavailable at runtime via available/0). This must come
-# after erlang.mk so DEPS_DIR and ERLC_OPTS are set.
+# Gate the optional OAuth authz layer on the arity-4 scope API it needs, not
+# just oauth2.hrl existing: the header predates resource_access/4 and the
+# scope_pattern_syntax field (both landed in the v4.2.0-beta series -- the
+# supported-series floor), so a header-only guard would build against a missing
+# function. scope_pattern_syntax in the resolved header is the sentinel for that
+# API. When absent, the module still compiles (-else branch), available/0
+# returns false, and authz_check reports config_conflict. Must follow erlang.mk
+# so DEPS_DIR and ERLC_OPTS are set.
 OAUTH2_HRL = $(DEPS_DIR)/rabbitmq_auth_backend_oauth2/include/oauth2.hrl
 ifneq ($(wildcard $(OAUTH2_HRL)),)
+ifneq ($(shell grep -l scope_pattern_syntax $(OAUTH2_HRL) 2>/dev/null),)
 ERLC_OPTS += -DHAVE_OAUTH2_RESOURCE_SERVER=1
 TEST_ERLC_OPTS += -DHAVE_OAUTH2_RESOURCE_SERVER=1
+endif
 endif

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ define PROJECT_ENV
 endef
 
 DEPS = rabbit_common rabbit rabbitmq_management gun jose
-TEST_DEPS = meck proper rabbitmq_ct_helpers rabbitmq_ct_client_helpers rabbitmq_auth_backend_ldap rabbitmq_auth_backend_http
+TEST_DEPS = meck proper rabbitmq_ct_helpers rabbitmq_ct_client_helpers rabbitmq_auth_backend_ldap rabbitmq_auth_backend_http rabbitmq_auth_backend_oauth2
 LOCAL_DEPS = crypto inets ssl xmerl public_key eldap
 
 PLT_APPS = rabbit

--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,17 @@ DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
 include ../../rabbitmq-components.mk
 include ../../erlang.mk
+
+# The optional OAuth authz-evaluation layer (aws_auth_validate_oauth_authz)
+# builds the broker's #resource_server{} record and so needs oauth2.hrl at
+# compile time. rabbitmq_auth_backend_oauth2 is a RUNTIME soft dependency, and
+# its header is absent on older broker series (e.g. 3.13.x). Define
+# HAVE_OAUTH2_RESOURCE_SERVER only when the header actually exists in the
+# resolved deps dir, so the plugin still compiles where it does not (the authz
+# layer is then merely unavailable at runtime via available/0). This must come
+# after erlang.mk so DEPS_DIR and ERLC_OPTS are set.
+OAUTH2_HRL = $(DEPS_DIR)/rabbitmq_auth_backend_oauth2/include/oauth2.hrl
+ifneq ($(wildcard $(OAUTH2_HRL)),)
+ERLC_OPTS += -DHAVE_OAUTH2_RESOURCE_SERVER=1
+TEST_ERLC_OPTS += -DHAVE_OAUTH2_RESOURCE_SERVER=1
+endif

--- a/src/aws_auth_validate_oauth.erl
+++ b/src/aws_auth_validate_oauth.erl
@@ -190,6 +190,18 @@
     "(auth_oauth2.require_exp)"
 >>).
 -define(REASON_TOKEN_AUDIENCE, <<"access_token audience does not include resource_server_id">>).
+%% PROTOTYPE: optional authz-evaluation config shape errors (pure phase).
+-define(REASON_BAD_AUTHZ_CHECK, <<
+    "authz_check must be an object with a permission (configure|write|read) and "
+    "a resource string"
+>>).
+-define(REASON_BAD_AUTHZ_CONFIG, <<
+    "scope_aliases must be an object, additional_scopes_key/scope_prefix a "
+    "string, and scope_pattern_syntax one of wildcard|regex"
+>>).
+-define(REASON_AUTHZ_NEEDS_TOKEN, <<
+    "authz_check requires an access_token to evaluate"
+>>).
 -define(REASON_ASSUME_ROLE, <<"failed to assume the configured role">>).
 -define(REASON_NO_ASSUME_ROLE, <<
     "auth validation requires an assume_role to be configured; "
@@ -280,7 +292,19 @@ allowed_fields() ->
         %% Optional customer-supplied access token. Present access_token
         %% activates signature + exp/nbf/aud verification against the fetched
         %% JWKS. Carries no secret (the customer minted it out of band).
-        <<"access_token">>
+        <<"access_token">>,
+        %% PROTOTYPE (optional authorization-evaluation layer): the customer's
+        %% OAuth authz config (scope_aliases / additional_scopes_key /
+        %% scope_prefix / scope_pattern_syntax) plus an authz_check block
+        %% {vhost,resource,permission} to evaluate the supplied access_token
+        %% against, via the broker's own scope-decision functions (runtime soft
+        %% dependency on rabbitmq_auth_backend_oauth2). See
+        %% aws_auth_validate_oauth_authz.
+        <<"scope_aliases">>,
+        <<"additional_scopes_key">>,
+        <<"scope_prefix">>,
+        <<"scope_pattern_syntax">>,
+        <<"authz_check">>
     ].
 
 -spec validate(map()) -> aws_auth_validate_backend:result().
@@ -337,6 +361,8 @@ parse_input(Body) ->
         %% supplied token and pre-decodes its header so the alg allowlist can be
         %% enforced without network I/O. No verification happens here.
         fun parse_access_token/2,
+        %% PROTOTYPE: pure shape-check of the optional authz-evaluation config.
+        fun parse_authz_config/2,
         %% SSRF guard runs in the pure phase so a disallowed target is rejected
         %% before any ARN resolution or outbound request.
         fun guard_urls/2
@@ -488,6 +514,86 @@ check_header_kid(Header) ->
         _ -> {error, input_invalid, ?REASON_TOKEN_MALFORMED}
     end.
 
+%% PROTOTYPE: pure shape-check of the optional authorization-evaluation config.
+%% When no authz_check is supplied, this is a no-op (authz_check => none) and the
+%% backend behaves exactly as before. When supplied, we shape-check the config
+%% fields and the check block here (pure phase) so a malformed request never
+%% reaches the network / crypto phase. The actual evaluation happens after token
+%% verification, in aws_auth_validate_oauth_authz. authz_check requires an
+%% access_token (there is nothing to evaluate without one).
+parse_authz_config(Body, Acc) ->
+    case maps:get(<<"authz_check">>, Body, undefined) of
+        undefined ->
+            {ok, Acc#{authz_check => none}};
+        Check when is_map(Check) ->
+            case maps:get(token, Acc, none) of
+                none ->
+                    {error, input_invalid, ?REASON_AUTHZ_NEEDS_TOKEN};
+                _ ->
+                    parse_authz_check(Body, Check, Acc)
+            end;
+        _ ->
+            {error, input_invalid, ?REASON_BAD_AUTHZ_CHECK}
+    end.
+
+parse_authz_check(Body, Check, Acc) ->
+    Permission = maps:get(<<"permission">>, Check, undefined),
+    Resource = maps:get(<<"resource">>, Check, undefined),
+    VHost = maps:get(<<"vhost">>, Check, <<"/">>),
+    ValidPerm = lists:member(Permission, [<<"configure">>, <<"write">>, <<"read">>]),
+    case ValidPerm andalso is_binary(Resource) andalso byte_size(Resource) > 0 of
+        false ->
+            {error, input_invalid, ?REASON_BAD_AUTHZ_CHECK};
+        true ->
+            CheckMap = #{permission => Permission, resource => Resource, vhost => VHost},
+            parse_authz_scope_config(Body, Acc#{authz_check => CheckMap})
+    end.
+
+%% Shape-check the optional scope-config fields (all optional; each drives the
+%% #resource_server{} the evaluator builds). Stored as parsed atoms/values on the
+%% accumulator for aws_auth_validate_oauth_authz to consume.
+parse_authz_scope_config(Body, Acc) ->
+    Aliases = maps:get(<<"scope_aliases">>, Body, undefined),
+    AddKey = maps:get(<<"additional_scopes_key">>, Body, undefined),
+    Prefix = maps:get(<<"scope_prefix">>, Body, undefined),
+    Syntax = maps:get(<<"scope_pattern_syntax">>, Body, <<"wildcard">>),
+    case
+        {
+            valid_opt(Aliases, fun is_map/1),
+            valid_opt(AddKey, fun erlang:is_binary/1),
+            valid_opt(Prefix, fun erlang:is_binary/1),
+            parse_syntax(Syntax)
+        }
+    of
+        {true, true, true, {ok, SyntaxAtom}} ->
+            {ok,
+                maybe_put(
+                    scope_pattern_syntax,
+                    SyntaxAtom,
+                    maybe_put(
+                        scope_prefix,
+                        Prefix,
+                        maybe_put(
+                            additional_scopes_key,
+                            AddKey,
+                            maybe_put(scope_aliases, Aliases, Acc)
+                        )
+                    )
+                )};
+        _ ->
+            {error, input_invalid, ?REASON_BAD_AUTHZ_CONFIG}
+    end.
+
+valid_opt(undefined, _Pred) -> true;
+valid_opt(V, Pred) -> Pred(V).
+
+maybe_put(_Key, undefined, Acc) -> Acc;
+maybe_put(Key, Value, Acc) -> Acc#{Key => Value}.
+
+parse_syntax(<<"wildcard">>) -> {ok, wildcard};
+parse_syntax(<<"regex">>) -> {ok, regex};
+parse_syntax(_) -> error.
+
 %% Decode the protected header into a JSON object map via jose (the same
 %% facility rabbitmq_auth_backend_oauth2's uaa_jwt_jwt uses to peek a token
 %% header), rather than a hand-rolled base64url + JSON parser. We still enforce
@@ -616,11 +722,25 @@ do_oauth_validate(Params) ->
 %% rabbit_auth_backend_oauth2 computes.
 
 %% When no access_token was supplied (token => none), this layer is a no-op.
-maybe_verify_token(#{token := none}, _Keys) ->
+maybe_verify_token(#{token := none} = Params, _Keys) ->
+    %% Guard: an authz_check without an access_token is rejected in the pure
+    %% phase (parse_authz_config), so token=none implies authz_check=none here.
+    %% Belt-and-braces: if a check somehow reached here with no token, it is a
+    %% no-op rather than a crash.
+    _ = Params,
     ok;
 maybe_verify_token(#{token := #{raw := Raw, header := Header}} = Params, Keys) ->
     ResourceServerId = maps:get(resource_server_id, Params, undefined),
-    verify_token(Raw, Header, {Keys, ResourceServerId}).
+    %% Verify signature + exp + aud, capturing the decoded claims so the optional
+    %% PROTOTYPE authorization-evaluation layer can run against them.
+    case verify_token_claims(Raw, Header, {Keys, ResourceServerId}) of
+        {error, _, _} = Err ->
+            Err;
+        {ok, Claims} ->
+            %% PROTOTYPE: optional authz evaluation via the broker's own scope
+            %% functions (runtime soft dependency). No-op when no authz_check.
+            aws_auth_validate_oauth_authz:maybe_check(Params, Claims)
+    end.
 
 %% Verify a customer-supplied JWT against the fetched JWKS. Steps, in order:
 %%   1. select the JWKS key whose `kid' matches the token header (a token with
@@ -638,9 +758,25 @@ maybe_verify_token(#{token := #{raw := Raw, header := Header}} = Params, Keys) -
 %% token_expired (transient, just re-mint); an audience mismatch stays
 %% auth_failed. verify_token/3 takes the pre-decoded header so the -ifdef(TEST)
 %% export can exercise it directly.
+-ifdef(TEST).
+%% Test-only wrapper preserving the historical verify_token/3 contract (returns
+%% `ok' on success). Production code calls verify_token_claims/3 directly (it
+%% needs the decoded claims for the optional authz-evaluation layer).
 -spec verify_token(binary(), map(), {list(), binary() | undefined}) ->
     ok | {error, aws_auth_validate_backend:error_category(), binary()}.
-verify_token(Raw, Header, {Keys, ResourceServerId}) ->
+verify_token(Raw, Header, Ctx) ->
+    case verify_token_claims(Raw, Header, Ctx) of
+        {ok, _Claims} -> ok;
+        {error, _, _} = Err -> Err
+    end.
+-endif.
+
+%% Verify a customer-supplied JWT against the fetched JWKS, returning {ok, Claims}
+%% on success so the caller can feed the verified claims to the optional authz-
+%% evaluation layer without re-decoding.
+-spec verify_token_claims(binary(), map(), {list(), binary() | undefined}) ->
+    {ok, map()} | {error, aws_auth_validate_backend:error_category(), binary()}.
+verify_token_claims(Raw, Header, {Keys, ResourceServerId}) ->
     Alg = maps:get(<<"alg">>, Header),
     Kid = maps:get(<<"kid">>, Header, undefined),
     case select_jwk(Kid, Keys) of
@@ -652,8 +788,13 @@ verify_token(Raw, Header, {Keys, ResourceServerId}) ->
                     Err;
                 {ok, Claims} ->
                     case check_token_expiry(Claims) of
-                        {error, _, _} = Err -> Err;
-                        ok -> check_token_audience(Claims, ResourceServerId)
+                        {error, _, _} = Err ->
+                            Err;
+                        ok ->
+                            case check_token_audience(Claims, ResourceServerId) of
+                                ok -> {ok, Claims};
+                                {error, _, _} = Err -> Err
+                            end
                     end
             end
     end.

--- a/src/aws_auth_validate_oauth.erl
+++ b/src/aws_auth_validate_oauth.erl
@@ -190,7 +190,7 @@
     "(auth_oauth2.require_exp)"
 >>).
 -define(REASON_TOKEN_AUDIENCE, <<"access_token audience does not include resource_server_id">>).
-%% PROTOTYPE: optional authz-evaluation config shape errors (pure phase).
+%% Optional authz-evaluation config shape errors (pure phase).
 -define(REASON_BAD_AUTHZ_CHECK, <<
     "authz_check must be an object with a permission (configure|write|read) and "
     "a resource string"
@@ -293,7 +293,7 @@ allowed_fields() ->
         %% activates signature + exp/nbf/aud verification against the fetched
         %% JWKS. Carries no secret (the customer minted it out of band).
         <<"access_token">>,
-        %% PROTOTYPE (optional authorization-evaluation layer): the customer's
+        %% Optional authorization-evaluation layer: the customer's
         %% OAuth authz config (scope_aliases / additional_scopes_key /
         %% scope_prefix / scope_pattern_syntax) plus an authz_check block
         %% {vhost,resource,permission} to evaluate the supplied access_token
@@ -361,7 +361,7 @@ parse_input(Body) ->
         %% supplied token and pre-decodes its header so the alg allowlist can be
         %% enforced without network I/O. No verification happens here.
         fun parse_access_token/2,
-        %% PROTOTYPE: pure shape-check of the optional authz-evaluation config.
+        %% Pure shape-check of the optional authz-evaluation config.
         fun parse_authz_config/2,
         %% SSRF guard runs in the pure phase so a disallowed target is rejected
         %% before any ARN resolution or outbound request.
@@ -514,7 +514,7 @@ check_header_kid(Header) ->
         _ -> {error, input_invalid, ?REASON_TOKEN_MALFORMED}
     end.
 
-%% PROTOTYPE: pure shape-check of the optional authorization-evaluation config.
+%% Pure shape-check of the optional authorization-evaluation config.
 %% When no authz_check is supplied, this is a no-op (authz_check => none) and the
 %% backend behaves exactly as before. When supplied, we shape-check the config
 %% fields and the check block here (pure phase) so a malformed request never
@@ -732,13 +732,13 @@ maybe_verify_token(#{token := none} = Params, _Keys) ->
 maybe_verify_token(#{token := #{raw := Raw, header := Header}} = Params, Keys) ->
     ResourceServerId = maps:get(resource_server_id, Params, undefined),
     %% Verify signature + exp + aud, capturing the decoded claims so the optional
-    %% PROTOTYPE authorization-evaluation layer can run against them.
+    %% authorization-evaluation layer can run against them.
     case verify_token_claims(Raw, Header, {Keys, ResourceServerId}) of
         {error, _, _} = Err ->
             Err;
         {ok, Claims} ->
-            %% PROTOTYPE: optional authz evaluation via the broker's own scope
-            %% functions (runtime soft dependency). No-op when no authz_check.
+            %% Optional authz evaluation via the broker's own scope functions
+            %% (runtime soft dependency). No-op when no authz_check.
             aws_auth_validate_oauth_authz:maybe_check(Params, Claims)
     end.
 

--- a/src/aws_auth_validate_oauth.erl
+++ b/src/aws_auth_validate_oauth.erl
@@ -196,8 +196,9 @@
     "a resource string, and an optional vhost string"
 >>).
 -define(REASON_BAD_AUTHZ_CONFIG, <<
-    "scope_aliases must be an object, additional_scopes_key/scope_prefix a "
-    "string, and scope_pattern_syntax one of wildcard|regex"
+    "scope_aliases must be an object mapping each alias name (string) to a list "
+    "of scope strings, additional_scopes_key/scope_prefix a string, and "
+    "scope_pattern_syntax one of wildcard|regex"
 >>).
 -define(REASON_AUTHZ_NEEDS_TOKEN, <<
     "authz_check requires an access_token to evaluate"
@@ -587,7 +588,7 @@ parse_authz_scope_config(Body, Acc) ->
     Syntax = maps:get(<<"scope_pattern_syntax">>, Body, <<"wildcard">>),
     case
         {
-            valid_opt(Aliases, fun is_map/1),
+            valid_opt(Aliases, fun valid_scope_aliases/1),
             valid_opt(AddKey, fun erlang:is_binary/1),
             valid_opt(Prefix, fun erlang:is_binary/1),
             parse_syntax(Syntax)
@@ -614,6 +615,40 @@ parse_authz_scope_config(Body, Acc) ->
 
 valid_opt(undefined, _Pred) -> true;
 valid_opt(V, Pred) -> Pred(V).
+
+%% scope_aliases must match the shape the broker's #resource_server{} record
+%% holds: a map of alias-name binary => list of scope binaries. The oauth2
+%% schema (rabbit_oauth2_schema:translate_scope_aliases/1) produces exactly
+%% #{binary() => [binary()]}, so a request that supplies any other shape is
+%% describing a config the broker could never hold.
+%%
+%% Beyond the parity gap, an unvalidated value is a crash footgun (the same
+%% class as the authz_check.vhost fix): when a token scope matches an alias key,
+%% the backend runs rabbit_data_coercion:to_binary/1 over the value, which has
+%% no clause for a float or a map and raises. The outer network catch would then
+%% misreport that crash as a connection failure -- the exact misclassification
+%% the pure-phase guards exist to prevent. Reject the bad shape here with
+%% input_invalid so the caller is told their scope_aliases is malformed.
+%%
+%% We require a list of scope strings (not a bare string) so there is no
+%% ambiguity about space-splitting: the config path space-splits a string into a
+%% list, but the caller supplies the already-split list directly here.
+valid_scope_aliases(Map) when is_map(Map) ->
+    maps:fold(
+        fun
+            (K, V, true) -> is_binary(K) andalso is_list_of_binaries(V);
+            (_K, _V, false) -> false
+        end,
+        true,
+        Map
+    );
+valid_scope_aliases(_) ->
+    false.
+
+is_list_of_binaries(L) when is_list(L) ->
+    lists:all(fun erlang:is_binary/1, L);
+is_list_of_binaries(_) ->
+    false.
 
 maybe_put(_Key, undefined, Acc) -> Acc;
 maybe_put(Key, Value, Acc) -> Acc#{Key => Value}.

--- a/src/aws_auth_validate_oauth.erl
+++ b/src/aws_auth_validate_oauth.erl
@@ -192,8 +192,8 @@
 -define(REASON_TOKEN_AUDIENCE, <<"access_token audience does not include resource_server_id">>).
 %% Optional authz-evaluation config shape errors (pure phase).
 -define(REASON_BAD_AUTHZ_CHECK, <<
-    "authz_check must be an object with a permission (configure|write|read) and "
-    "a resource string"
+    "authz_check must be an object with a permission (configure|write|read), "
+    "a resource string, and an optional vhost string"
 >>).
 -define(REASON_BAD_AUTHZ_CONFIG, <<
     "scope_aliases must be an object, additional_scopes_key/scope_prefix a "
@@ -559,9 +559,17 @@ parse_authz_config(Body, Acc) ->
 parse_authz_check(Body, Check, Acc) ->
     Permission = maps:get(<<"permission">>, Check, undefined),
     Resource = maps:get(<<"resource">>, Check, undefined),
+    %% vhost defaults to <<"/">> when absent. When supplied it must be a binary:
+    %% a non-binary vhost would flow into #resource{virtual_host = VHost} and
+    %% crash the broker's scope matcher (rabbit_data_coercion:to_binary/1 has no
+    %% clause for a float or map), a crash the outer network catch would then
+    %% misreport as a connection failure. Validate it here in the pure phase,
+    %% alongside resource and permission.
     VHost = maps:get(<<"vhost">>, Check, <<"/">>),
     ValidPerm = lists:member(Permission, [<<"configure">>, <<"write">>, <<"read">>]),
-    case ValidPerm andalso is_binary(Resource) andalso byte_size(Resource) > 0 of
+    ValidResource = is_binary(Resource) andalso byte_size(Resource) > 0,
+    ValidVHost = is_binary(VHost),
+    case ValidPerm andalso ValidResource andalso ValidVHost of
         false ->
             {error, input_invalid, ?REASON_BAD_AUTHZ_CHECK};
         true ->

--- a/src/aws_auth_validate_oauth.erl
+++ b/src/aws_auth_validate_oauth.erl
@@ -202,6 +202,14 @@
 -define(REASON_AUTHZ_NEEDS_TOKEN, <<
     "authz_check requires an access_token to evaluate"
 >>).
+%% authz evaluation builds the broker's #resource_server{} from resource_server_id
+%% (it seeds the default scope_prefix and the record id). Without it the record
+%% cannot be constructed, so we require it explicitly here in the pure phase
+%% rather than defaulting silently -- a missing resource_server_id is the
+%% operator's config to supply, and guessing one would break decision parity.
+-define(REASON_AUTHZ_NEEDS_RESOURCE_SERVER_ID, <<
+    "authz_check requires resource_server_id to be set"
+>>).
 -define(REASON_ASSUME_ROLE, <<"failed to assume the configured role">>).
 -define(REASON_NO_ASSUME_ROLE, <<
     "auth validation requires an assume_role to be configured; "
@@ -530,7 +538,19 @@ parse_authz_config(Body, Acc) ->
                 none ->
                     {error, input_invalid, ?REASON_AUTHZ_NEEDS_TOKEN};
                 _ ->
-                    parse_authz_check(Body, Check, Acc)
+                    %% authz evaluation needs resource_server_id to construct the
+                    %% broker's #resource_server{} (it seeds the record id and the
+                    %% default scope_prefix). parse_resource_server_id always seats
+                    %% the slot -- present-and-binary or undefined -- so an absent
+                    %% id surfaces here as undefined. Reject it in the pure phase
+                    %% rather than letting new_resource_server(undefined) crash and
+                    %% be misreported as a connection failure by the network catch.
+                    case maps:get(resource_server_id, Acc, undefined) of
+                        undefined ->
+                            {error, input_invalid, ?REASON_AUTHZ_NEEDS_RESOURCE_SERVER_ID};
+                        _ ->
+                            parse_authz_check(Body, Check, Acc)
+                    end
             end;
         _ ->
             {error, input_invalid, ?REASON_BAD_AUTHZ_CHECK}

--- a/src/aws_auth_validate_oauth_authz.erl
+++ b/src/aws_auth_validate_oauth_authz.erl
@@ -298,14 +298,15 @@ decide(Scopes, Resource, PermAtom, Syntax) ->
         false -> {error, authz_unverified, ?REASON_AUTHZ_NO_MATCH}
     end.
 
-%% Map the supplied permission string to the broker's permission atom. Only the
-%% three RabbitMQ permission verbs are accepted; anything else is bad input
-%% (caught by the caller's is_binary guard returning a non-matching atom is not
-%% possible, so we constrain here).
+%% Map the supplied permission string to the broker's permission atom. The
+%% permission is already allowlisted to exactly these three verbs in the pure
+%% phase (aws_auth_validate_oauth:parse_authz_check/3), so this clause set is
+%% total over every value that can reach it. It has no catch-all: an unexpected
+%% value must fail loudly here rather than be silently mapped to a non-matching
+%% atom that resource_access/4 would report as a spurious "none grant".
 to_permission_atom(<<"configure">>) -> configure;
 to_permission_atom(<<"write">>) -> write;
-to_permission_atom(<<"read">>) -> read;
-to_permission_atom(_) -> undefined.
+to_permission_atom(<<"read">>) -> read.
 
 -else.
 

--- a/src/aws_auth_validate_oauth_authz.erl
+++ b/src/aws_auth_validate_oauth_authz.erl
@@ -61,13 +61,28 @@
 
 -export([maybe_check/2, available/0]).
 
-%% We build the broker's #resource_server{} record, so we include its header.
-%% This is a COMPILE-TIME header include (a record shape), not a code/DEPS
-%% dependency: if upstream changes the record, this fails loudly at build time
-%% rather than drifting silently at runtime. #resource{} is from rabbit_common,
-%% already a real dependency of this plugin.
--include_lib("rabbitmq_auth_backend_oauth2/include/oauth2.hrl").
+%% The evaluation path builds the broker's #resource_server{} record, so it needs
+%% that record's shape (from oauth2.hrl). But rabbitmq_auth_backend_oauth2 is a
+%% RUNTIME soft dependency, not a build DEPS: the plugin is compiled against a
+%% range of broker series, and the oauth2 backend's shape is NOT stable across
+%% them -- older series (e.g. 3.13.x) ship no oauth2.hrl at all, and newer ones
+%% add record fields (scope_pattern_syntax). Hard-including the header would make
+%% the whole plugin fail to COMPILE on any series that lacks it, defeating the
+%% soft-dependency design (the feature is meant to be merely UNAVAILABLE there,
+%% via available/0, not a build break).
+%%
+%% So the header include and the record-using evaluation code are guarded by
+%% -ifdef(HAVE_OAUTH2_RESOURCE_SERVER), a macro the Makefile defines only when
+%% $(DEPS_DIR)/rabbitmq_auth_backend_oauth2/include/oauth2.hrl actually exists at
+%% build time. When it is absent, the module still compiles; available/0 returns
+%% false and maybe_check/2 reports config_conflict (authz unavailable). When it
+%% is present, the record-typed evaluator is compiled in. We do NOT reference
+%% fields that vary across supported series (scope_pattern_syntax): the syntax is
+%% threaded as a plain argument to the scope functions instead (see evaluate/3).
 -include_lib("rabbit_common/include/resource.hrl").
+-ifdef(HAVE_OAUTH2_RESOURCE_SERVER).
+-include_lib("rabbitmq_auth_backend_oauth2/include/oauth2.hrl").
+-endif.
 
 -define(OAUTH2_MOD, rabbit_auth_backend_oauth2).
 -define(SCOPE_MOD, rabbit_oauth2_scope).
@@ -135,6 +150,7 @@
 %% we actually want -- and stays false only when the backend genuinely is not
 %% deployed on this broker.
 -spec available() -> boolean().
+-ifdef(HAVE_OAUTH2_RESOURCE_SERVER).
 available() ->
     module_ready(?SCOPE_MOD) andalso
         module_ready(?OAUTH2_MOD) andalso
@@ -149,6 +165,12 @@ module_ready(Mod) ->
         {module, Mod} -> true;
         _ -> false
     end.
+-else.
+%% Built against a broker series with no oauth2 resource_server record: the
+%% evaluator cannot be compiled in, so authz is unconditionally unavailable.
+available() ->
+    false.
+-endif.
 
 %% Optional layer: when the request carried an `authz_check' block, evaluate it
 %% against the verified token's claims. Params is the parsed request accumulator
@@ -167,19 +189,25 @@ module_ready(Mod) ->
 maybe_check(#{authz_check := none}, _Claims) ->
     ok;
 maybe_check(#{authz_check := Check} = Params, Claims) when is_map(Check) ->
-    case available() of
-        false ->
-            {error, config_conflict, ?REASON_AUTHZ_UNAVAILABLE};
-        true ->
-            evaluate(Params, Check, Claims)
-    end;
+    maybe_check_available(Params, Check, Claims);
 maybe_check(_Params, _Claims) ->
     %% No authz_check slot at all (older parse path) -> no-op.
     ok.
 
 %%--------------------------------------------------------------------
-%% Evaluation (runs only when oauth2 is loaded)
+%% Evaluation (compiled in only when the oauth2 resource_server record is
+%% available at build time; see HAVE_OAUTH2_RESOURCE_SERVER at the top).
 %%--------------------------------------------------------------------
+
+-ifdef(HAVE_OAUTH2_RESOURCE_SERVER).
+
+maybe_check_available(Params, Check, Claims) ->
+    case available() of
+        false ->
+            {error, config_conflict, ?REASON_AUTHZ_UNAVAILABLE};
+        true ->
+            evaluate(Params, Check, Claims)
+    end.
 
 evaluate(Params, Check, Claims) ->
     %% Build the broker's #resource_server{} from CUSTOMER-SUPPLIED config so the
@@ -188,13 +216,23 @@ evaluate(Params, Check, Claims) ->
     %% supplied fields.
     ResourceServerId = maps:get(resource_server_id, Params, <<"rabbitmq">>),
     RS0 = ?RS_MOD:new_resource_server(ResourceServerId),
+    %% Only overlay fields that exist in the #resource_server{} record across all
+    %% supported broker series. `scope_pattern_syntax' is deliberately NOT set on
+    %% the record: it is absent from older oauth2 backends' record definition, so
+    %% a compile-time field reference here would fail to build against those
+    %% series (this module is compiled against whatever oauth2.hrl the broker
+    %% ships). It is not needed on the record anyway -- normalize_token_scope/2
+    %% does not read it (the scope_prefix filter is a literal prefix match, not a
+    %% pattern), and the ONLY consumers of the syntax (get_expanded_scopes/3 and
+    %% rabbit_oauth2_scope:resource_access/4) take it as an explicit argument,
+    %% which we thread through as `Syntax' below. So regex parity is preserved on
+    %% brokers that support it without a record-shape dependency.
     RS = RS0#resource_server{
         scope_aliases = maps:get(scope_aliases, Params, undefined),
         additional_scopes_key = maps:get(additional_scopes_key, Params, undefined),
-        scope_prefix = maps:get(scope_prefix, Params, RS0#resource_server.scope_prefix),
-        scope_pattern_syntax = maps:get(scope_pattern_syntax, Params, wildcard)
+        scope_prefix = maps:get(scope_prefix, Params, RS0#resource_server.scope_prefix)
     },
-    Syntax = RS#resource_server.scope_pattern_syntax,
+    Syntax = maps:get(scope_pattern_syntax, Params, wildcard),
     VHost = maps:get(vhost, Check, <<"/">>),
     Name = maps:get(resource, Check, undefined),
     Permission = maps:get(permission, Check, undefined),
@@ -249,3 +287,13 @@ to_permission_atom(<<"configure">>) -> configure;
 to_permission_atom(<<"write">>) -> write;
 to_permission_atom(<<"read">>) -> read;
 to_permission_atom(_) -> undefined.
+
+-else.
+
+%% No oauth2 resource_server record at build time: authz cannot be evaluated, so
+%% a supplied authz_check is a config conflict (the feature is unavailable on
+%% this broker series). available/0 already returns false in this branch.
+maybe_check_available(_Params, _Check, _Claims) ->
+    {error, config_conflict, ?REASON_AUTHZ_UNAVAILABLE}.
+
+-endif.

--- a/src/aws_auth_validate_oauth_authz.erl
+++ b/src/aws_auth_validate_oauth_authz.erl
@@ -71,7 +71,10 @@
 %% keeps validation parity with a broker configured for regex scopes.
 -module(aws_auth_validate_oauth_authz).
 
--export([maybe_check/2, available/0]).
+-export([maybe_check/2, available/0, backend_loaded/0]).
+
+%% persistent_term key caching a positive availability result (see available/0).
+-define(AVAIL_CACHE_KEY, {?MODULE, available}).
 
 %% The evaluation path builds the broker's #resource_server{} record, so it needs
 %% that record's shape (from oauth2.hrl). But rabbitmq_auth_backend_oauth2 is a
@@ -153,6 +156,14 @@
 %% path. Used both to gate the request and (in aws_auth_validate_oauth) to decide
 %% whether to offer authz mode at all.
 %%
+%% available/0 is the strong property: the oauth2 backend is loaded AND exposes
+%% the exact arity-4 scope API this layer calls. backend_loaded/0 is the weaker
+%% property: rabbit_auth_backend_oauth2 is loaded at all, regardless of its API
+%% version. The two differ precisely on the portability regression Luke flagged:
+%% a broker series that ships the oauth2 backend but predates resource_access/4.
+%% Tests use the pair to tell a legitimate skip (backend absent entirely) from a
+%% hard failure (backend present but API too old -- must not pass silently).
+%%
 %% We use code:ensure_loaded/1 rather than a bare erlang:function_exported/3:
 %% the latter returns false for a module whose beam is on the path but has not
 %% yet been loaded into the VM, which would make availability depend on load
@@ -161,9 +172,29 @@
 %% beam is present, so this reflects "is the backend installed" -- the property
 %% we actually want -- and stays false only when the backend genuinely is not
 %% deployed on this broker.
+%%
+%% Memoization: a positive result is cached in persistent_term so the per-request
+%% probe (3x code:ensure_loaded + 4x function_exported) runs at most once per
+%% boot. We cache ONLY `true' -- never `false' -- so a backend that loads AFTER
+%% the first call (e.g. plugin enabled at runtime) is still picked up on a later
+%% request rather than being pinned "unavailable" for the node's lifetime.
 -spec available() -> boolean().
 -ifdef(HAVE_OAUTH2_RESOURCE_SERVER).
 available() ->
+    case persistent_term:get(?AVAIL_CACHE_KEY, false) of
+        true ->
+            true;
+        false ->
+            case probe_available() of
+                true ->
+                    persistent_term:put(?AVAIL_CACHE_KEY, true),
+                    true;
+                false ->
+                    false
+            end
+    end.
+
+probe_available() ->
     module_ready(?SCOPE_MOD) andalso
         module_ready(?OAUTH2_MOD) andalso
         module_ready(?RS_MOD) andalso
@@ -177,11 +208,29 @@ module_ready(Mod) ->
         {module, Mod} -> true;
         _ -> false
     end.
+
+%% Weaker probe: is the oauth2 backend module loaded at all, independent of its
+%% API version? Used only by tests to distinguish "backend genuinely absent"
+%% (legitimate skip) from "backend present but too old" (hard failure). Not
+%% memoized -- it is off the request path.
+-spec backend_loaded() -> boolean().
+backend_loaded() ->
+    module_ready(?OAUTH2_MOD).
 -else.
 %% Built against a broker series with no oauth2 resource_server record: the
 %% evaluator cannot be compiled in, so authz is unconditionally unavailable.
 available() ->
     false.
+
+%% Even without the record at build time, the runtime backend module may exist;
+%% report its load state so tests can still make the absent-vs-present-but-old
+%% distinction on this build branch.
+-spec backend_loaded() -> boolean().
+backend_loaded() ->
+    case code:ensure_loaded(?OAUTH2_MOD) of
+        {module, ?OAUTH2_MOD} -> true;
+        _ -> false
+    end.
 -endif.
 
 %% Optional layer: when the request carried an `authz_check' block, evaluate it
@@ -221,6 +270,17 @@ maybe_check_available(Params, Check, Claims) ->
             evaluate(Params, Check, Claims)
     end.
 
+%% COUPLING NOTE (see the parity-scope discussion in the module header): this
+%% function replays the broker's authorization decision as an explicit chain of
+%% its internal stages -- new_resource_server/1 -> normalize_token_scope/2 ->
+%% get_expanded_scopes/3 -> resource_access/4. The matcher itself cannot drift
+%% (it IS the broker's code), but this SEQUENCING can: if a future oauth2 series
+%% inserts a normalization stage between these calls, or moves work into a
+%% higher-level entry point, this endpoint would under-report effective scopes
+%% (the safe direction -- it never over-grants -- but a parity gap). If the
+%% backend ever exposes a single pure "would this token be granted X" entry
+%% point, prefer collapsing this chain onto it. Until then, any new stage the
+%% backend adds must be mirrored here.
 evaluate(Params, Check, Claims) ->
     %% Build the broker's #resource_server{} from CUSTOMER-SUPPLIED config so the
     %% alias / additional-scopes-key / prefix logic matches what their broker

--- a/src/aws_auth_validate_oauth_authz.erl
+++ b/src/aws_auth_validate_oauth_authz.erl
@@ -71,7 +71,7 @@
 %% keeps validation parity with a broker configured for regex scopes.
 -module(aws_auth_validate_oauth_authz).
 
--export([maybe_check/2, available/0, backend_loaded/0]).
+-export([maybe_check/2, available/0, backend_loaded/0, evaluator_compiled_in/0]).
 
 %% persistent_term key caching a positive availability result (see available/0).
 -define(AVAIL_CACHE_KEY, {?MODULE, available}).
@@ -216,6 +216,18 @@ module_ready(Mod) ->
 -spec backend_loaded() -> boolean().
 backend_loaded() ->
     module_ready(?OAUTH2_MOD).
+
+%% True when the record-typed evaluator was compiled into this build (i.e. the
+%% Makefile saw the arity-4 scope API in oauth2.hrl and defined the macro). This
+%% is the COMPILE-TIME property; available/0 is the RUNTIME one. Tests use this
+%% to scope the "present-but-unusable" hard failure: only when the evaluator was
+%% compiled in but available/0 is still false at runtime is there a genuine
+%% portability regression to fail on. When the evaluator was NOT compiled in
+%% (a pre-floor broker series), a supplied authz_check is legitimately
+%% unavailable, so tests skip rather than fail.
+-spec evaluator_compiled_in() -> boolean().
+evaluator_compiled_in() ->
+    true.
 -else.
 %% Built against a broker series with no oauth2 resource_server record: the
 %% evaluator cannot be compiled in, so authz is unconditionally unavailable.
@@ -231,6 +243,11 @@ backend_loaded() ->
         {module, ?OAUTH2_MOD} -> true;
         _ -> false
     end.
+
+%% Evaluator was not compiled in on this build branch (pre-floor series).
+-spec evaluator_compiled_in() -> boolean().
+evaluator_compiled_in() ->
+    false.
 -endif.
 
 %% Optional layer: when the request carried an `authz_check' block, evaluate it

--- a/src/aws_auth_validate_oauth_authz.erl
+++ b/src/aws_auth_validate_oauth_authz.erl
@@ -25,8 +25,20 @@
 %%     unavailable and we say so with a fixed category -- we never fall back to a
 %%     home-grown scope matcher (that would reintroduce the drift risk this
 %%     approach exists to avoid).
-%%   * Because we EXECUTE the broker's own code rather than mirror it, there is
-%%     nothing to keep in sync: drift is impossible by construction.
+%%   * Because we EXECUTE the broker's own SCOPE-MATCHING code rather than mirror
+%%     it, the matching logic itself cannot drift. The parity guarantee is scoped
+%%     to that: it covers the fields we overlay onto the #resource_server{} record
+%%     below -- scope_prefix, scope_aliases, additional_scopes_key -- plus the
+%%     scope_pattern_syntax we thread through. It does NOT cover
+%%     resource-server config the broker also consumes but that this endpoint does
+%%     not model: resource_server_type (the rich-authorization-request path in
+%%     normalize_token_scope), extra_scopes_source, preferred_username_claims, and
+%%     per-`resource_servers' map entries. Those stay at new_resource_server/1
+%%     defaults here. For an operator relying on them, this endpoint can under-
+%%     report effective scopes and thus FAIL an authz_check the live broker would
+%%     grant (the safe direction -- it never over-grants -- but still a parity gap
+%%     to document, not a "drift is impossible" claim). Extending the overlay to
+%%     those fields is a documented follow-up.
 %%
 %% The broker functions used (all verified pure -- no app-env / ETS / mnesia on
 %% this path; they read all config from the #resource_server{} record we build):
@@ -214,7 +226,14 @@ evaluate(Params, Check, Claims) ->
     %% alias / additional-scopes-key / prefix logic matches what their broker
     %% would do. new_resource_server/1 seeds the defaults; we overlay the
     %% supplied fields.
-    ResourceServerId = maps:get(resource_server_id, Params, <<"rabbitmq">>),
+    %% resource_server_id is guaranteed present and a non-empty binary here:
+    %% aws_auth_validate_oauth:parse_authz_config rejects an authz_check request
+    %% that lacks it (input_invalid) in the pure phase, so this layer never
+    %% builds new_resource_server(undefined) (which would crash on the
+    %% iolist_to_binary([undefined, <<".">>]) scope_prefix seed and be misreported
+    %% as a connection failure). We read it with no default so a future caller that
+    %% breaks that invariant fails loudly rather than silently guessing an id.
+    ResourceServerId = maps:get(resource_server_id, Params),
     RS0 = ?RS_MOD:new_resource_server(ResourceServerId),
     %% Only overlay fields that exist in the #resource_server{} record across all
     %% supported broker series. `scope_pattern_syntax' is deliberately NOT set on

--- a/src/aws_auth_validate_oauth_authz.erl
+++ b/src/aws_auth_validate_oauth_authz.erl
@@ -73,9 +73,6 @@
 
 -export([maybe_check/2, available/0, backend_loaded/0, evaluator_compiled_in/0]).
 
-%% persistent_term key caching a positive availability result (see available/0).
--define(AVAIL_CACHE_KEY, {?MODULE, available}).
-
 %% The evaluation path builds the broker's #resource_server{} record, so it needs
 %% that record's shape (from oauth2.hrl). But rabbitmq_auth_backend_oauth2 is a
 %% RUNTIME soft dependency, not a build DEPS: the plugin is compiled against a
@@ -173,28 +170,18 @@
 %% we actually want -- and stays false only when the backend genuinely is not
 %% deployed on this broker.
 %%
-%% Memoization: a positive result is cached in persistent_term so the per-request
-%% probe (3x code:ensure_loaded + 4x function_exported) runs at most once per
-%% boot. We cache ONLY `true' -- never `false' -- so a backend that loads AFTER
-%% the first call (e.g. plugin enabled at runtime) is still picked up on a later
-%% request rather than being pinned "unavailable" for the node's lifetime.
+%% The probe (3x code:ensure_loaded + 4x function_exported) runs on every request.
+%% It is deliberately not memoized: once the modules are loaded each check is a
+%% cheap in-VM hash lookup against the active code-index tables -- code:ensure_loaded
+%% short-circuits on erlang:module_loaded (no code-server round-trip), and
+%% function_exported/3 looks up the export table -- the endpoint is a rarely-hit,
+%% semaphore-bounded triage aid, and a stateless probe stays correct in both
+%% directions: it picks up a backend enabled after boot and, equally, reports a
+%% backend disabled at runtime (whose modules rabbit_plugins purges), where a
+%% cached `true' would leave available/0 stale and misreport the request.
 -spec available() -> boolean().
 -ifdef(HAVE_OAUTH2_RESOURCE_SERVER).
 available() ->
-    case persistent_term:get(?AVAIL_CACHE_KEY, false) of
-        true ->
-            true;
-        false ->
-            case probe_available() of
-                true ->
-                    persistent_term:put(?AVAIL_CACHE_KEY, true),
-                    true;
-                false ->
-                    false
-            end
-    end.
-
-probe_available() ->
     module_ready(?SCOPE_MOD) andalso
         module_ready(?OAUTH2_MOD) andalso
         module_ready(?RS_MOD) andalso

--- a/src/aws_auth_validate_oauth_authz.erl
+++ b/src/aws_auth_validate_oauth_authz.erl
@@ -1,0 +1,251 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% Optional OAuth authorization-evaluation layer, wired as an opt-in step in
+%% aws_auth_validate_oauth (activates only when a request carries an authz_check
+%% block; a no-op otherwise).
+%%
+%% Purpose: given a *already-verified* customer-supplied access token (signature
+%% + exp + aud already checked by aws_auth_validate_oauth), answer "would the
+%% broker grant this principal <permission> on <vhost>/<resource>?" -- i.e. reach
+%% an authorization decision, not just an authentication one. This is a
+%% troubleshooting/triage aid: it localizes WHICH layer of an OAuth config is
+%% wrong (reachability vs. authentication vs. authorization) and, for authz,
+%% names the failing STAGE (see the reason macros), deflecting the "my token is
+%% broken (it isn't)" support ticket without a broker restart.
+%%
+%% Design: RUNTIME SOFT DEPENDENCY on rabbitmq_auth_backend_oauth2.
+%%   * We do NOT add it to the plugin's DEPS (it is not force-loaded onto
+%%     aws-plugin users who never run OAuth).
+%%   * We CALL its exported, pure decision functions when-and-only-when the
+%%     module is already loaded on the broker, guarded by
+%%     erlang:function_exported/3. When it is not loaded, authz evaluation is
+%%     unavailable and we say so with a fixed category -- we never fall back to a
+%%     home-grown scope matcher (that would reintroduce the drift risk this
+%%     approach exists to avoid).
+%%   * Because we EXECUTE the broker's own code rather than mirror it, there is
+%%     nothing to keep in sync: drift is impossible by construction.
+%%
+%% The broker functions used (all verified pure -- no app-env / ETS / mnesia on
+%% this path; they read all config from the #resource_server{} record we build):
+%%   * rabbit_oauth2_resource_server:new_resource_server/1  -- record constructor
+%%   * rabbit_auth_backend_oauth2:normalize_token_scope/2   -- alias / additional-
+%%       scopes-key / prefix-filter expansion (the IAM `scope_aliases' path)
+%%   * rabbit_auth_backend_oauth2:get_expanded_scopes/3     -- {vhost} placeholder
+%%       expansion
+%%   * rabbit_oauth2_scope:{vhost,resource,topic}_access/*  -- the final match
+%%
+%% R3 (zero side effects): every function above is side-effect-free; the config
+%% comes from the record argument, so this reads nothing from broker state and
+%% mutates nothing. We construct the #resource_server{} from CUSTOMER-SUPPLIED
+%% fields, so we are validating the customer's config, not the broker's live one.
+%% (Verified: no ETS / mnesia / persistent_term / application:get_env on this
+%% call path -- the only side effect reachable is rabbit_oauth2_scope's own
+%% ?LOG_WARNING on a rejected/invalid pattern, which carries no token or claim
+%% content. The impure resource-server *resolution* functions that DO read
+%% app-env are bypassed by constructing the record via new_resource_server/1.)
+%%
+%% scope_pattern_syntax: both `wildcard' (the default, used by IAM and the
+%% documented OAuth recipe) and `regex' are accepted. The regex path carries NO
+%% new ReDoS surface: rabbit_oauth2_scope runs the SAME bounded matcher the live
+%% broker runs on every OAuth-authenticated connection -- a 2048-byte pattern
+%% cap, a rejected-construct denylist (inline modifiers / callouts / comments /
+%% control verbs), and hard PCRE bounds (match_limit=10000,
+%% match_limit_recursion=1000) that cap backtracking regardless of pattern. A
+%% crafted pattern cannot exceed what the broker already permits at auth time,
+%% and the concurrency semaphore bounds how many run at once. Allowing regex
+%% keeps validation parity with a broker configured for regex scopes.
+-module(aws_auth_validate_oauth_authz).
+
+-export([maybe_check/2, available/0]).
+
+%% We build the broker's #resource_server{} record, so we include its header.
+%% This is a COMPILE-TIME header include (a record shape), not a code/DEPS
+%% dependency: if upstream changes the record, this fails loudly at build time
+%% rather than drifting silently at runtime. #resource{} is from rabbit_common,
+%% already a real dependency of this plugin.
+-include_lib("rabbitmq_auth_backend_oauth2/include/oauth2.hrl").
+-include_lib("rabbit_common/include/resource.hrl").
+
+-define(OAUTH2_MOD, rabbit_auth_backend_oauth2).
+-define(SCOPE_MOD, rabbit_oauth2_scope).
+-define(RS_MOD, rabbit_oauth2_resource_server).
+
+%% Fixed reasons. NOTE on granularity vs R4: R4's fixed-category rule guards
+%% against leaking BROKER INFRASTRUCTURE or an SSRF target (hostnames, IPs, raw
+%% network/LDAP errors) that an attacker does not already know. The authz
+%% failure reasons below are categorically different: they describe only the
+%% CALLER'S OWN token and the CALLER'S OWN supplied authorization config (both
+%% arrived in this same request), never broker infra or a network target -- the
+%% same basis on which token_expired/token_invalid were already split out. So we
+%% keep a single error CATEGORY (authz_unverified) for the audit-log/response
+%% contract but differentiate the human-readable message, which is what actually
+%% lets a customer self-diagnose the "my token is broken (it isn't)" case. The
+%% messages carry NO scope values or claim content -- they name the failing
+%% STAGE, not the data -- so no token material is echoed, and (per the design
+%% decision) the message is not audit-logged regardless.
+-define(REASON_AUTHZ_UNAVAILABLE, <<
+    "authorization evaluation requires the rabbitmq_auth_backend_oauth2 plugin "
+    "to be loaded on this broker; it is not"
+>>).
+%% Authentic token, but nothing survived scope_prefix / resource_server_id
+%% filtering -- the #1 cause of a spurious "my token is broken" ticket (a
+%% scope_prefix or scope_aliases typo). Naming this stage points the customer
+%% straight at their prefix/alias config.
+-define(REASON_AUTHZ_NO_EFFECTIVE_SCOPES, <<
+    "the access_token carries no scopes for this resource_server after "
+    "scope_prefix / resource_server_id filtering; check scope_prefix, "
+    "resource_server_id, additional_scopes_key, and scope_aliases"
+>>).
+%% Token has effective scopes, but none grant the requested permission on the
+%% requested resource -- the genuine authorization mismatch.
+-define(REASON_AUTHZ_NO_MATCH, <<
+    "the access_token has scopes for this resource_server, but none grant the "
+    "requested permission on the requested vhost/resource"
+>>).
+%% normalize_token_scope/2's only explicit error: the token exceeded the
+%% broker's maximum scope count. Previously swallowed as a generic denial, which
+%% wrongly told the customer to fix their permission mapping.
+-define(REASON_AUTHZ_TOO_MANY_SCOPES, <<
+    "the access_token carries more scopes than the broker will process "
+    "(auth_oauth2 maximum); the live broker would also reject it"
+>>).
+%% Catch-all for any future normalize_token_scope/2 error we do not yet model,
+%% so an upstream change cannot crash or be misclassified.
+-define(REASON_AUTHZ_UNPROCESSABLE, <<
+    "the access_token's scopes could not be processed under the supplied "
+    "authorization config"
+>>).
+-define(REASON_AUTHZ_BAD_INPUT, <<
+    "authz_check must be an object with permission and resource fields"
+>>).
+
+%% True when the broker has the oauth2 decision functions available on the code
+%% path. Used both to gate the request and (in aws_auth_validate_oauth) to decide
+%% whether to offer authz mode at all.
+%%
+%% We use code:ensure_loaded/1 rather than a bare erlang:function_exported/3:
+%% the latter returns false for a module whose beam is on the path but has not
+%% yet been loaded into the VM, which would make availability depend on load
+%% order (a request could see the oauth2 backend as "absent" simply because
+%% nothing had called it yet this boot). ensure_loaded triggers the load if the
+%% beam is present, so this reflects "is the backend installed" -- the property
+%% we actually want -- and stays false only when the backend genuinely is not
+%% deployed on this broker.
+-spec available() -> boolean().
+available() ->
+    module_ready(?SCOPE_MOD) andalso
+        module_ready(?OAUTH2_MOD) andalso
+        module_ready(?RS_MOD) andalso
+        erlang:function_exported(?SCOPE_MOD, resource_access, 4) andalso
+        erlang:function_exported(?OAUTH2_MOD, get_expanded_scopes, 3) andalso
+        erlang:function_exported(?OAUTH2_MOD, normalize_token_scope, 2) andalso
+        erlang:function_exported(?RS_MOD, new_resource_server, 1).
+
+module_ready(Mod) ->
+    case code:ensure_loaded(Mod) of
+        {module, Mod} -> true;
+        _ -> false
+    end.
+
+%% Optional layer: when the request carried an `authz_check' block, evaluate it
+%% against the verified token's claims. Params is the parsed request accumulator
+%% from aws_auth_validate_oauth; Claims is the decoded, already-signature-and-
+%% expiry-verified JWT claims map.
+%%
+%%   * no authz_check supplied            -> ok (layer is a no-op)
+%%   * authz_check supplied, oauth2 absent -> {error, config_conflict, ...}
+%%   * granted                            -> ok
+%%   * denied / unprocessable             -> {error, authz_unverified, Msg}
+%%       where Msg distinguishes: no effective scopes after prefix/alias
+%%       filtering, scopes present but none match, or too-many-scopes. The
+%%       CATEGORY stays authz_unverified in every failing case; only the message
+%%       differs (see the reason macros above for the R4 rationale).
+-spec maybe_check(map(), map()) -> aws_auth_validate_backend:result().
+maybe_check(#{authz_check := none}, _Claims) ->
+    ok;
+maybe_check(#{authz_check := Check} = Params, Claims) when is_map(Check) ->
+    case available() of
+        false ->
+            {error, config_conflict, ?REASON_AUTHZ_UNAVAILABLE};
+        true ->
+            evaluate(Params, Check, Claims)
+    end;
+maybe_check(_Params, _Claims) ->
+    %% No authz_check slot at all (older parse path) -> no-op.
+    ok.
+
+%%--------------------------------------------------------------------
+%% Evaluation (runs only when oauth2 is loaded)
+%%--------------------------------------------------------------------
+
+evaluate(Params, Check, Claims) ->
+    %% Build the broker's #resource_server{} from CUSTOMER-SUPPLIED config so the
+    %% alias / additional-scopes-key / prefix logic matches what their broker
+    %% would do. new_resource_server/1 seeds the defaults; we overlay the
+    %% supplied fields.
+    ResourceServerId = maps:get(resource_server_id, Params, <<"rabbitmq">>),
+    RS0 = ?RS_MOD:new_resource_server(ResourceServerId),
+    RS = RS0#resource_server{
+        scope_aliases = maps:get(scope_aliases, Params, undefined),
+        additional_scopes_key = maps:get(additional_scopes_key, Params, undefined),
+        scope_prefix = maps:get(scope_prefix, Params, RS0#resource_server.scope_prefix),
+        scope_pattern_syntax = maps:get(scope_pattern_syntax, Params, wildcard)
+    },
+    Syntax = RS#resource_server.scope_pattern_syntax,
+    VHost = maps:get(vhost, Check, <<"/">>),
+    Name = maps:get(resource, Check, undefined),
+    Permission = maps:get(permission, Check, undefined),
+    case {Name, Permission} of
+        {N, P} when is_binary(N), is_binary(P) ->
+            %% 1. normalize_token_scope applies aliases + additional_scopes_key +
+            %%    prefix filter (the IAM `scope_aliases' expansion), storing the
+            %%    result in the token's `scope' field. Its errors are no longer
+            %%    swallowed as a generic denial (which wrongly implied a
+            %%    permission-mapping problem): they are mapped to their own
+            %%    message so the customer sees the real cause.
+            case ?OAUTH2_MOD:normalize_token_scope(RS, Claims) of
+                {ok, Normalized} ->
+                    Resource = #resource{
+                        virtual_host = VHost,
+                        kind = queue,
+                        name = Name
+                    },
+                    %% 2. expand {vhost} etc. placeholders, then 3. match.
+                    Scopes = ?OAUTH2_MOD:get_expanded_scopes(Normalized, Resource, Syntax),
+                    decide(Scopes, Resource, to_permission_atom(P), Syntax);
+                {error, too_many_scopes} ->
+                    {error, authz_unverified, ?REASON_AUTHZ_TOO_MANY_SCOPES};
+                {error, _Other} ->
+                    %% Any future normalize error we do not yet model: fixed,
+                    %% generic message (never the raw reason) so an upstream
+                    %% change cannot crash or misclassify.
+                    {error, authz_unverified, ?REASON_AUTHZ_UNPROCESSABLE}
+            end;
+        _ ->
+            {error, input_invalid, ?REASON_AUTHZ_BAD_INPUT}
+    end.
+
+%% Distinguish "authentic token, but no scopes survived prefix/alias filtering"
+%% (the prefix/alias-typo footgun) from "has scopes, but none grant this
+%% permission" (a genuine mapping mismatch). Both stay in the authz_unverified
+%% category; only the message differs. No scope value is echoed -- the messages
+%% name the failing stage, not the data.
+decide([], _Resource, _PermAtom, _Syntax) ->
+    {error, authz_unverified, ?REASON_AUTHZ_NO_EFFECTIVE_SCOPES};
+decide(Scopes, Resource, PermAtom, Syntax) ->
+    case ?SCOPE_MOD:resource_access(Resource, PermAtom, Scopes, Syntax) of
+        true -> ok;
+        false -> {error, authz_unverified, ?REASON_AUTHZ_NO_MATCH}
+    end.
+
+%% Map the supplied permission string to the broker's permission atom. Only the
+%% three RabbitMQ permission verbs are accepted; anything else is bad input
+%% (caught by the caller's is_binary guard returning a non-matching atom is not
+%% possible, so we constrain here).
+to_permission_atom(<<"configure">>) -> configure;
+to_permission_atom(<<"write">>) -> write;
+to_permission_atom(<<"read">>) -> read;
+to_permission_atom(_) -> undefined.

--- a/test/aws_auth_validate_mgmt_SUITE.erl
+++ b/test/aws_auth_validate_mgmt_SUITE.erl
@@ -41,7 +41,9 @@
     success_returns_204/1,
     oauth_disabled_by_default_returns_404/1,
     oauth_success_returns_204/1,
-    oauth_response_no_secret/1
+    oauth_response_no_secret/1,
+    oauth_authz_grants_returns_204/1,
+    oauth_authz_denies_returns_422/1
 ]).
 
 %% Invoked on the broker node via rpc to hold a semaphore slot.
@@ -49,6 +51,17 @@
 
 %% Invoked on the broker node via rpc to stub/unstub the registry dispatch.
 -export([mock_dispatch_ok/0, mock_dispatch_raise/1, unmock_dispatch/0]).
+
+%% Invoked on the broker node via rpc for the authz-through-the-pipeline cases:
+%% probe for the oauth2 backend, mint a token + matching JWKS with jose, and
+%% stub ONLY the network seam (DNS resolve-and-pin + the JWKS httpc GET) so the
+%% REAL backend + registry run end-to-end through the Cowboy handler.
+-export([
+    oauth2_backend_available/0,
+    oauth_authz_mint/0,
+    mock_oauth_network/1,
+    unmock_oauth_network/0
+]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -100,11 +113,15 @@ groups() ->
             custom_tag_options_preflight_allowed
         ]},
         %% OAuth method tests: opt-in behaviour (disabled by default -> 404),
-        %% and success/no-secret when enabled with mocked dispatch.
+        %% success/no-secret when enabled with mocked dispatch, and the optional
+        %% authorization-evaluation layer driven end-to-end through the real
+        %% backend + registry (dispatch NOT mocked; only the JWKS network seam is).
         {oauth_method, [], [
             oauth_disabled_by_default_returns_404,
             oauth_success_returns_204,
-            oauth_response_no_secret
+            oauth_response_no_secret,
+            oauth_authz_grants_returns_204,
+            oauth_authz_denies_returns_422
         ]}
     ].
 
@@ -217,6 +234,40 @@ init_per_testcase(oauth_response_no_secret = TC, Config) ->
         Config, 0, ?MODULE, mock_dispatch_ok, []
     ),
     rabbit_ct_helpers:testcase_started(Config, TC);
+init_per_testcase(TC, Config) when
+    TC =:= oauth_authz_grants_returns_204; TC =:= oauth_authz_denies_returns_422
+->
+    %% These drive the REAL oauth backend + registry end-to-end through the
+    %% Cowboy handler (dispatch is NOT mocked), so we only stub the network seam
+    %% (DNS resolve-and-pin + the JWKS httpc GET). The optional authz layer runs
+    %% the broker's own scope-decision functions, so it needs
+    %% rabbitmq_auth_backend_oauth2 loadable on the broker; skip gracefully if it
+    %% is not (mirrors the eunit maybe_skip_authz and the LDAP suite's slapd skip).
+    case rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, oauth2_backend_available, []) of
+        true ->
+            rabbit_ct_broker_helpers:rpc(
+                Config,
+                0,
+                application,
+                set_env,
+                [aws, auth_validation_enabled_methods, [{<<"oauth">>, true}]]
+            ),
+            %% A signed RS256 token plus the authz config exceeds the group's
+            %% 1024-byte cap; give the body headroom for these two cases only.
+            rabbit_ct_broker_helpers:rpc(
+                Config, 0, application, set_env, [aws, auth_validation_max_body_size, 8192]
+            ),
+            {Token, JwksJson} = rabbit_ct_broker_helpers:rpc(
+                Config, 0, ?MODULE, oauth_authz_mint, []
+            ),
+            ok = rabbit_ct_broker_helpers:rpc(
+                Config, 0, ?MODULE, mock_oauth_network, [JwksJson]
+            ),
+            Config1 = rabbit_ct_helpers:set_config(Config, [{oauth_token, Token}]),
+            rabbit_ct_helpers:testcase_started(Config1, TC);
+        false ->
+            {skip, "rabbitmq_auth_backend_oauth2 is not loaded on the broker node"}
+    end;
 init_per_testcase(TC, Config) ->
     rabbit_ct_helpers:testcase_started(Config, TC).
 
@@ -256,6 +307,20 @@ end_per_testcase(oauth_response_no_secret = TC, Config) ->
     ),
     rabbit_ct_broker_helpers:rpc(
         Config, 0, application, unset_env, [aws, auth_validation_enabled_methods]
+    ),
+    rabbit_ct_helpers:testcase_finished(Config, TC);
+end_per_testcase(TC, Config) when
+    TC =:= oauth_authz_grants_returns_204; TC =:= oauth_authz_denies_returns_422
+->
+    ok = rabbit_ct_broker_helpers:rpc(
+        Config, 0, ?MODULE, unmock_oauth_network, []
+    ),
+    rabbit_ct_broker_helpers:rpc(
+        Config, 0, application, unset_env, [aws, auth_validation_enabled_methods]
+    ),
+    %% Restore the group's body-size cap so later cases are unaffected.
+    rabbit_ct_broker_helpers:rpc(
+        Config, 0, application, set_env, [aws, auth_validation_max_body_size, 1024]
     ),
     rabbit_ct_helpers:testcase_finished(Config, TC);
 end_per_testcase(TC, Config) ->
@@ -502,6 +567,38 @@ oauth_response_no_secret(Config) ->
     {ok, {{_, _Code, _}, _, ResBody}} = put_request(Config, ?OAUTH_API, Body),
     ?assertEqual(nomatch, binary:match(iolist_to_binary(ResBody), Secret)).
 
+%% Optional authorization-evaluation layer, driven END-TO-END through the full
+%% Cowboy pipeline: auth gate -> body-size cap -> JSON decode -> semaphore ->
+%% registry field-filter -> REAL oauth backend -> token verification -> authz
+%% evaluation via the broker's own scope-decision functions. Unlike
+%% oauth_success_returns_204, dispatch is NOT mocked here; only the JWKS network
+%% seam (DNS resolve-and-pin + httpc GET) is stubbed, so the authz decision is
+%% genuinely computed. The minted token grants `read' on any vhost/resource.
+%%
+%% GRANT: request `read' -> the broker's resource_access says yes -> 204. This
+%% proves the authz_check field survives the registry allowlist filter and the
+%% grant path returns success through the handler (not just via dispatch/2).
+oauth_authz_grants_returns_204(Config) ->
+    Token = ?config(oauth_token, Config),
+    Body = oauth_authz_body(Token, <<"read">>),
+    {ok, {{_, Code, _}, _Headers, ResBody}} = put_request(Config, ?OAUTH_API, Body),
+    ?assertEqual(204, Code),
+    ?assertEqual(<<>>, iolist_to_binary(ResBody)).
+
+%% DENY: the SAME verified token (grants `read' only), but request `configure'.
+%% The broker's scope match fails -> authz_unverified -> 422. Same token, only
+%% the requested permission differs, so a 422 here (vs 204 above) proves the
+%% authz config is genuinely consumed and not a no-op. The response carries the
+%% fixed category only; it must not leak the token.
+oauth_authz_denies_returns_422(Config) ->
+    Token = ?config(oauth_token, Config),
+    Body = oauth_authz_body(Token, <<"configure">>),
+    {ok, {{_, Code, _}, _Headers, ResBody}} = put_request(Config, ?OAUTH_API, Body),
+    ?assertEqual(422, Code),
+    ?assertMatch(#{<<"error">> := <<"authz_unverified">>}, decode(ResBody)),
+    %% R6/R4: the caller's token must never appear in the response body.
+    ?assertEqual(nomatch, binary:match(iolist_to_binary(ResBody), Token)).
+
 %%--------------------------------------------------------------------
 %% Helpers
 %%--------------------------------------------------------------------
@@ -528,6 +625,68 @@ mock_dispatch_raise(Secret) ->
 unmock_dispatch() ->
     catch meck:unload(aws_auth_validate_registry),
     ok.
+
+%% Runs ON THE BROKER NODE. True when the optional authz layer can run there --
+%% i.e. rabbitmq_auth_backend_oauth2's scope-decision functions are loadable.
+%% Delegates to the layer's own availability probe (code:ensure_loaded-backed),
+%% so this matches exactly what the request path checks at runtime.
+oauth2_backend_available() ->
+    aws_auth_validate_oauth_authz:available().
+
+%% Runs ON THE BROKER NODE. Mint a fresh RSA keypair with jose, sign an RS256
+%% token whose scope grants `read' on any vhost/resource (aud=rabbitmq so the
+%% backend's audience check passes), and return {Token, JwksJson} where JwksJson
+%% is the PUBLIC key as a one-key JWKS document the network stub will serve.
+%% Minting on the broker node guarantees the key that signs the token is the same
+%% one the backend fetches (no cross-node key/JWKS mismatch).
+oauth_authz_mint() ->
+    Priv = jose_jwk:generate_key({rsa, 2048}),
+    {_, PubMap0} = jose_jwk:to_public_map(Priv),
+    PubMap = PubMap0#{<<"kid">> => <<"k1">>},
+    Claims = #{
+        <<"sub">> => <<"alice">>,
+        <<"aud">> => <<"rabbitmq">>,
+        <<"exp">> => os:system_time(seconds) + 3600,
+        <<"scope">> => <<"rabbitmq.read:*/*">>
+    },
+    JWS = #{<<"alg">> => <<"RS256">>, <<"kid">> => <<"k1">>},
+    {_, Token} = jose_jws:compact(jose_jwt:sign(Priv, JWS, Claims)),
+    JwksJson = rabbit_json:encode(#{<<"keys">> => [PubMap]}),
+    {Token, JwksJson}.
+
+%% Runs ON THE BROKER NODE. Stub ONLY the network seam so the REAL backend +
+%% registry + authz layer run: (1) aws_auth_validate_net:resolve_and_pin/2 skips
+%% DNS and pins the JWKS host to itself, and (2) httpc:request/5 returns the
+%% supplied JWKS for the test IdP host, passing through anything else so the
+%% broker's own outbound calls are unaffected. Both mecks are passthrough.
+mock_oauth_network(JwksJson) ->
+    catch meck:unload(aws_auth_validate_net),
+    catch meck:unload(httpc),
+    ok = meck:new(aws_auth_validate_net, [passthrough, no_link]),
+    meck:expect(aws_auth_validate_net, resolve_and_pin, fun(#{host := Host} = Url, _Policy) ->
+        {ok, Url, Host}
+    end),
+    ok = meck:new(httpc, [passthrough, unstick, no_link]),
+    meck:expect(httpc, request, fun(Method, Req, HttpOpts, Opts, Profile) ->
+        Url = oauth_request_url(Req),
+        case string:find(Url, "idp.example.com") of
+            nomatch ->
+                meck:passthrough([Method, Req, HttpOpts, Opts, Profile]);
+            _ ->
+                {ok, {{"HTTP/1.1", 200, "OK"}, [], JwksJson}}
+        end
+    end),
+    ok.
+
+unmock_oauth_network() ->
+    catch meck:unload(httpc),
+    catch meck:unload(aws_auth_validate_net),
+    ok.
+
+%% Extract the URL string from an httpc Request tuple (GET or POST form). Runs on
+%% the broker node inside the httpc mock.
+oauth_request_url({Url, _Headers}) -> Url;
+oauth_request_url({Url, _Headers, _ContentType, _Body}) -> Url.
 
 setup_broker(Config0, ExtraEnv) ->
     Config1 = rabbit_ct_helpers:set_config(Config0, [
@@ -599,6 +758,23 @@ put_request(Config, Path, BodyMap) ->
 oauth_body() ->
     #{
         <<"jwks_uri">> => <<"https://idp.example.com/.well-known/jwks.json">>
+    }.
+
+%% An oauth validation body carrying a customer-supplied access_token plus an
+%% authz_check block. The scope config (resource_server_id + scope_prefix) mirrors
+%% the documented OAuth recipe; the minted token's scope is `rabbitmq.read:*/*'.
+%% Permission is parameterised so one helper drives both the grant (read) and the
+%% deny (configure) case against the same token.
+oauth_authz_body(Token, Permission) ->
+    (oauth_body())#{
+        <<"access_token">> => Token,
+        <<"resource_server_id">> => <<"rabbitmq">>,
+        <<"scope_prefix">> => <<"rabbitmq.">>,
+        <<"authz_check">> => #{
+            <<"vhost">> => <<"/">>,
+            <<"resource">> => <<"my-queue">>,
+            <<"permission">> => Permission
+        }
     }.
 
 decode(ResBody) ->

--- a/test/aws_auth_validate_mgmt_SUITE.erl
+++ b/test/aws_auth_validate_mgmt_SUITE.erl
@@ -53,12 +53,12 @@
 -export([mock_dispatch_ok/0, mock_dispatch_raise/1, unmock_dispatch/0]).
 
 %% Invoked on the broker node via rpc for the authz-through-the-pipeline cases:
-%% probe for the oauth2 backend, mint a token + matching JWKS with jose, and
-%% stub ONLY the network seam (DNS resolve-and-pin + the JWKS httpc GET) so the
-%% REAL backend + registry run end-to-end through the Cowboy handler.
+%% probe for the oauth2 backend and stub ONLY the network seam (DNS
+%% resolve-and-pin + the JWKS httpc GET) so the REAL backend + registry run
+%% end-to-end through the Cowboy handler. Token + JWKS minting is done via the
+%% shared aws_auth_validate_oauth_test_helpers module (rpc'd directly).
 -export([
     oauth2_backend_available/0,
-    oauth_authz_mint/0,
     mock_oauth_network/1,
     unmock_oauth_network/0
 ]).
@@ -258,7 +258,7 @@ init_per_testcase(TC, Config) when
                 Config, 0, application, set_env, [aws, auth_validation_max_body_size, 8192]
             ),
             {Token, JwksJson} = rabbit_ct_broker_helpers:rpc(
-                Config, 0, ?MODULE, oauth_authz_mint, []
+                Config, 0, aws_auth_validate_oauth_test_helpers, oauth_authz_mint, []
             ),
             ok = rabbit_ct_broker_helpers:rpc(
                 Config, 0, ?MODULE, mock_oauth_network, [JwksJson]
@@ -633,27 +633,6 @@ unmock_dispatch() ->
 oauth2_backend_available() ->
     aws_auth_validate_oauth_authz:available().
 
-%% Runs ON THE BROKER NODE. Mint a fresh RSA keypair with jose, sign an RS256
-%% token whose scope grants `read' on any vhost/resource (aud=rabbitmq so the
-%% backend's audience check passes), and return {Token, JwksJson} where JwksJson
-%% is the PUBLIC key as a one-key JWKS document the network stub will serve.
-%% Minting on the broker node guarantees the key that signs the token is the same
-%% one the backend fetches (no cross-node key/JWKS mismatch).
-oauth_authz_mint() ->
-    Priv = jose_jwk:generate_key({rsa, 2048}),
-    {_, PubMap0} = jose_jwk:to_public_map(Priv),
-    PubMap = PubMap0#{<<"kid">> => <<"k1">>},
-    Claims = #{
-        <<"sub">> => <<"alice">>,
-        <<"aud">> => <<"rabbitmq">>,
-        <<"exp">> => os:system_time(seconds) + 3600,
-        <<"scope">> => <<"rabbitmq.read:*/*">>
-    },
-    JWS = #{<<"alg">> => <<"RS256">>, <<"kid">> => <<"k1">>},
-    {_, Token} = jose_jws:compact(jose_jwt:sign(Priv, JWS, Claims)),
-    JwksJson = rabbit_json:encode(#{<<"keys">> => [PubMap]}),
-    {Token, JwksJson}.
-
 %% Runs ON THE BROKER NODE. Stub ONLY the network seam so the REAL backend +
 %% registry + authz layer run: (1) aws_auth_validate_net:resolve_and_pin/2 skips
 %% DNS and pins the JWKS host to itself, and (2) httpc:request/5 returns the
@@ -668,7 +647,7 @@ mock_oauth_network(JwksJson) ->
     end),
     ok = meck:new(httpc, [passthrough, unstick, no_link]),
     meck:expect(httpc, request, fun(Method, Req, HttpOpts, Opts, Profile) ->
-        Url = oauth_request_url(Req),
+        Url = aws_auth_validate_oauth_test_helpers:request_url(Req),
         case string:find(Url, "idp.example.com") of
             nomatch ->
                 meck:passthrough([Method, Req, HttpOpts, Opts, Profile]);
@@ -682,11 +661,6 @@ unmock_oauth_network() ->
     catch meck:unload(httpc),
     catch meck:unload(aws_auth_validate_net),
     ok.
-
-%% Extract the URL string from an httpc Request tuple (GET or POST form). Runs on
-%% the broker node inside the httpc mock.
-oauth_request_url({Url, _Headers}) -> Url;
-oauth_request_url({Url, _Headers, _ContentType, _Body}) -> Url.
 
 setup_broker(Config0, ExtraEnv) ->
     Config1 = rabbit_ct_helpers:set_config(Config0, [

--- a/test/aws_auth_validate_mgmt_SUITE.erl
+++ b/test/aws_auth_validate_mgmt_SUITE.erl
@@ -42,6 +42,7 @@
     oauth_disabled_by_default_returns_404/1,
     oauth_success_returns_204/1,
     oauth_response_no_secret/1,
+    oauth_authz_portability_tripwire/1,
     oauth_authz_grants_returns_204/1,
     oauth_authz_denies_returns_422/1
 ]).
@@ -122,6 +123,7 @@ groups() ->
             oauth_disabled_by_default_returns_404,
             oauth_success_returns_204,
             oauth_response_no_secret,
+            oauth_authz_portability_tripwire,
             oauth_authz_grants_returns_204,
             oauth_authz_denies_returns_422
         ]}
@@ -245,37 +247,15 @@ init_per_testcase(TC, Config) when
     %% the broker's own scope-decision functions, so it needs
     %% rabbitmq_auth_backend_oauth2 loadable on the broker; skip gracefully if it
     %% is not (mirrors the eunit maybe_skip_authz and the LDAP suite's slapd skip).
+    %% The available-but-should-not-be portability regression is caught separately
+    %% by oauth_authz_portability_tripwire, which fails from a test-case body so it
+    %% turns CI red regardless of the exit_status option (a ct:fail here, in
+    %% init_per_testcase, would only auto-skip).
     case rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, oauth2_backend_available, []) of
         false ->
-            %% available/0 is false. Distinguish the reasons (Luke's blocking
-            %% coverage-gap note). Only fail when the evaluator was compiled in
-            %% (the Makefile saw the arity-4 API) AND the backend is loaded, yet
-            %% available/0 is still false -- a genuine portability regression.
-            %% A pre-floor broker series (evaluator NOT compiled in) or a node
-            %% without the backend running is a legitimate skip, the same way the
-            %% LDAP suite skips without slapd. Gate on evaluator_compiled_in, not
-            %% backend_loaded alone: rabbitmq_auth_backend_oauth2 is in TEST_DEPS
-            %% and so loadable even on a pre-floor series.
-            EvaluatorCompiledIn = rabbit_ct_broker_helpers:rpc(
-                Config, 0, ?MODULE, oauth2_evaluator_compiled_in, []
-            ),
-            BackendLoaded = rabbit_ct_broker_helpers:rpc(
-                Config, 0, ?MODULE, oauth2_backend_loaded, []
-            ),
-            case EvaluatorCompiledIn andalso BackendLoaded of
-                true ->
-                    ct:fail(
-                        "rabbitmq_auth_backend_oauth2 is loaded on the broker node and "
-                        "the authz evaluator was compiled in, but "
-                        "aws_auth_validate_oauth_authz:available/0 is false: the backend "
-                        "does not export the arity-4 scope API this layer requires. The "
-                        "build guard admitted an unsupported broker series."
-                    );
-                false ->
-                    {skip,
-                        "OAuth authz evaluation unavailable on this broker node "
-                        "(pre-floor series or backend not loaded)"}
-            end;
+            {skip,
+                "OAuth authz evaluation unavailable on this broker node "
+                "(pre-floor series or backend not loaded)"};
         true ->
             rabbit_ct_broker_helpers:rpc(
                 Config,
@@ -596,6 +576,55 @@ oauth_response_no_secret(Config) ->
     Body = (oauth_body())#{<<"client_secret">> => Secret},
     {ok, {{_, _Code, _}, _, ResBody}} = put_request(Config, ?OAUTH_API, Body),
     ?assertEqual(nomatch, binary:match(iolist_to_binary(ResBody), Secret)).
+
+%% Portability tripwire for the build guard. When the evaluator was compiled in
+%% (the Makefile saw the arity-4 scope API in oauth2.hrl) and the oauth2 backend
+%% is loaded, available/0 MUST be true; if it is false, the build guard admitted
+%% a broker series whose backend lacks the arity-4 API this layer calls -- a
+%% portability regression. Every matrix arm exercises exactly one outcome: on
+%% v4.2.x/v4.3.x/main the evaluator is compiled in, the backend is loaded and
+%% available/0 is true, so this passes; on a pre-floor series (e.g. v3.13.7) the
+%% evaluator is not compiled in, so this skips like the two cases below.
+%%
+%% This fails from a TEST-CASE BODY, not init_per_testcase, on purpose: a
+%% ct:fail in an init clause auto-skips the case, which turns the run red only
+%% via Common Test's default exit_status (auto-skip -> non-zero). Under
+%% -exit_status ignore_config -- a common way to tolerate infra-dependent skips
+%% (this suite skips without slapd, without the backend, ...) -- that auto-skip
+%% would pass green and silence the regression. A failure from a test-case body
+%% increments the Failed count, which ct_run maps to a non-zero exit before the
+%% exit_status branch is consulted, so this tripwire stays red unconditionally.
+oauth_authz_portability_tripwire(Config) ->
+    Available = rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, oauth2_backend_available, []),
+    EvaluatorCompiledIn = rabbit_ct_broker_helpers:rpc(
+        Config, 0, ?MODULE, oauth2_evaluator_compiled_in, []
+    ),
+    BackendLoaded = rabbit_ct_broker_helpers:rpc(
+        Config, 0, ?MODULE, oauth2_backend_loaded, []
+    ),
+    case Available of
+        true ->
+            ok;
+        false ->
+            %% Gate the hard failure on evaluator_compiled_in, not backend_loaded
+            %% alone: rabbitmq_auth_backend_oauth2 is in TEST_DEPS and so loadable
+            %% even on a pre-floor series where the evaluator was correctly not
+            %% compiled in -- that is a legitimate skip, not a regression.
+            case EvaluatorCompiledIn andalso BackendLoaded of
+                true ->
+                    ct:fail(
+                        "rabbitmq_auth_backend_oauth2 is loaded on the broker node and "
+                        "the authz evaluator was compiled in, but "
+                        "aws_auth_validate_oauth_authz:available/0 is false: the backend "
+                        "does not export the arity-4 scope API this layer requires. The "
+                        "build guard admitted an unsupported broker series."
+                    );
+                false ->
+                    {skip,
+                        "OAuth authz evaluation unavailable on this broker node "
+                        "(pre-floor series or backend not loaded)"}
+            end
+    end.
 
 %% Optional authorization-evaluation layer, driven END-TO-END through the full
 %% Cowboy pipeline: auth gate -> body-size cap -> JSON decode -> semaphore ->

--- a/test/aws_auth_validate_mgmt_SUITE.erl
+++ b/test/aws_auth_validate_mgmt_SUITE.erl
@@ -60,6 +60,7 @@
 -export([
     oauth2_backend_available/0,
     oauth2_backend_loaded/0,
+    oauth2_evaluator_compiled_in/0,
     mock_oauth_network/1,
     unmock_oauth_network/0
 ]).
@@ -246,21 +247,34 @@ init_per_testcase(TC, Config) when
     %% is not (mirrors the eunit maybe_skip_authz and the LDAP suite's slapd skip).
     case rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, oauth2_backend_available, []) of
         false ->
-            %% available/0 is false. Distinguish the two reasons (Luke's blocking
-            %% coverage-gap note): if the oauth2 backend is not loaded at all,
-            %% skip legitimately (mirrors the LDAP suite's slapd skip); but if it
-            %% IS loaded and merely lacks the arity-4 scope API, that is the
-            %% build-guard portability bug and must FAIL rather than skip green.
-            case rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, oauth2_backend_loaded, []) of
-                false ->
-                    {skip, "rabbitmq_auth_backend_oauth2 is not loaded on the broker node"};
+            %% available/0 is false. Distinguish the reasons (Luke's blocking
+            %% coverage-gap note). Only fail when the evaluator was compiled in
+            %% (the Makefile saw the arity-4 API) AND the backend is loaded, yet
+            %% available/0 is still false -- a genuine portability regression.
+            %% A pre-floor broker series (evaluator NOT compiled in) or a node
+            %% without the backend running is a legitimate skip, the same way the
+            %% LDAP suite skips without slapd. Gate on evaluator_compiled_in, not
+            %% backend_loaded alone: rabbitmq_auth_backend_oauth2 is in TEST_DEPS
+            %% and so loadable even on a pre-floor series.
+            EvaluatorCompiledIn = rabbit_ct_broker_helpers:rpc(
+                Config, 0, ?MODULE, oauth2_evaluator_compiled_in, []
+            ),
+            BackendLoaded = rabbit_ct_broker_helpers:rpc(
+                Config, 0, ?MODULE, oauth2_backend_loaded, []
+            ),
+            case EvaluatorCompiledIn andalso BackendLoaded of
                 true ->
                     ct:fail(
-                        "rabbitmq_auth_backend_oauth2 is loaded on the broker node but "
+                        "rabbitmq_auth_backend_oauth2 is loaded on the broker node and "
+                        "the authz evaluator was compiled in, but "
                         "aws_auth_validate_oauth_authz:available/0 is false: the backend "
                         "does not export the arity-4 scope API this layer requires. The "
                         "build guard admitted an unsupported broker series."
-                    )
+                    );
+                false ->
+                    {skip,
+                        "OAuth authz evaluation unavailable on this broker node "
+                        "(pre-floor series or backend not loaded)"}
             end;
         true ->
             rabbit_ct_broker_helpers:rpc(
@@ -655,6 +669,13 @@ oauth2_backend_available() ->
 %% "backend present but too old" (hard failure) -- see Luke's coverage-gap note.
 oauth2_backend_loaded() ->
     aws_auth_validate_oauth_authz:backend_loaded().
+
+%% Runs ON THE BROKER NODE. True when the record-typed authz evaluator was
+%% compiled into the aws plugin build (the Makefile saw the arity-4 scope API in
+%% oauth2.hrl). Lets init_per_testcase scope the present-but-unusable hard
+%% failure to a genuine portability regression rather than a pre-floor series.
+oauth2_evaluator_compiled_in() ->
+    aws_auth_validate_oauth_authz:evaluator_compiled_in().
 
 %% Runs ON THE BROKER NODE. Stub ONLY the network seam so the REAL backend +
 %% registry + authz layer run: (1) aws_auth_validate_net:resolve_and_pin/2 skips

--- a/test/aws_auth_validate_mgmt_SUITE.erl
+++ b/test/aws_auth_validate_mgmt_SUITE.erl
@@ -59,6 +59,7 @@
 %% shared aws_auth_validate_oauth_test_helpers module (rpc'd directly).
 -export([
     oauth2_backend_available/0,
+    oauth2_backend_loaded/0,
     mock_oauth_network/1,
     unmock_oauth_network/0
 ]).
@@ -244,6 +245,23 @@ init_per_testcase(TC, Config) when
     %% rabbitmq_auth_backend_oauth2 loadable on the broker; skip gracefully if it
     %% is not (mirrors the eunit maybe_skip_authz and the LDAP suite's slapd skip).
     case rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, oauth2_backend_available, []) of
+        false ->
+            %% available/0 is false. Distinguish the two reasons (Luke's blocking
+            %% coverage-gap note): if the oauth2 backend is not loaded at all,
+            %% skip legitimately (mirrors the LDAP suite's slapd skip); but if it
+            %% IS loaded and merely lacks the arity-4 scope API, that is the
+            %% build-guard portability bug and must FAIL rather than skip green.
+            case rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, oauth2_backend_loaded, []) of
+                false ->
+                    {skip, "rabbitmq_auth_backend_oauth2 is not loaded on the broker node"};
+                true ->
+                    ct:fail(
+                        "rabbitmq_auth_backend_oauth2 is loaded on the broker node but "
+                        "aws_auth_validate_oauth_authz:available/0 is false: the backend "
+                        "does not export the arity-4 scope API this layer requires. The "
+                        "build guard admitted an unsupported broker series."
+                    )
+            end;
         true ->
             rabbit_ct_broker_helpers:rpc(
                 Config,
@@ -264,9 +282,7 @@ init_per_testcase(TC, Config) when
                 Config, 0, ?MODULE, mock_oauth_network, [JwksJson]
             ),
             Config1 = rabbit_ct_helpers:set_config(Config, [{oauth_token, Token}]),
-            rabbit_ct_helpers:testcase_started(Config1, TC);
-        false ->
-            {skip, "rabbitmq_auth_backend_oauth2 is not loaded on the broker node"}
+            rabbit_ct_helpers:testcase_started(Config1, TC)
     end;
 init_per_testcase(TC, Config) ->
     rabbit_ct_helpers:testcase_started(Config, TC).
@@ -632,6 +648,13 @@ unmock_dispatch() ->
 %% so this matches exactly what the request path checks at runtime.
 oauth2_backend_available() ->
     aws_auth_validate_oauth_authz:available().
+
+%% Runs ON THE BROKER NODE. True when rabbitmq_auth_backend_oauth2 is loaded at
+%% all, regardless of whether it exposes the arity-4 scope API. Lets
+%% init_per_testcase tell "backend genuinely absent" (legitimate skip) from
+%% "backend present but too old" (hard failure) -- see Luke's coverage-gap note.
+oauth2_backend_loaded() ->
+    aws_auth_validate_oauth_authz:backend_loaded().
 
 %% Runs ON THE BROKER NODE. Stub ONLY the network seam so the REAL backend +
 %% registry + authz layer run: (1) aws_auth_validate_net:resolve_and_pin/2 skips

--- a/test/aws_auth_validate_oauth_test_helpers.erl
+++ b/test/aws_auth_validate_oauth_test_helpers.erl
@@ -1,0 +1,51 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% Shared OAuth test helpers used by both the eunit suite
+%% (aws_auth_validate_oauth_tests, on the CT node) and the management CT suite
+%% (aws_auth_validate_mgmt_SUITE, whose authz cases run these on the broker node
+%% via rpc). Kept in a helper module -- not duplicated per suite -- so the JWT
+%% minting recipe and the httpc-request-tuple destructuring live in one place.
+%% This module carries no test cases; it is not an eunit suite.
+-module(aws_auth_validate_oauth_test_helpers).
+
+-export([rsa_signer/1, oauth_authz_mint/0, request_url/1]).
+
+%% Generate a fresh RSA keypair via jose and return:
+%%   * jwk_pub -- the PUBLIC key as a JWKS-style map, tagged with Kid, and
+%%   * sign    -- a fun(ClaimsMap) -> compact RS256 JWT signed by the private key.
+%% Each call produces a DISTINCT key, so "wrong key" tests just call it twice.
+rsa_signer(Kid) ->
+    Priv = jose_jwk:generate_key({rsa, 2048}),
+    {_, PubMap0} = jose_jwk:to_public_map(Priv),
+    PubMap = PubMap0#{<<"kid">> => Kid},
+    Sign = fun(Claims) ->
+        JWS = #{<<"alg">> => <<"RS256">>, <<"kid">> => Kid},
+        {_, Token} = jose_jws:compact(jose_jwt:sign(Priv, JWS, Claims)),
+        Token
+    end,
+    #{jwk_pub => PubMap, sign => Sign}.
+
+%% Mint a fresh RS256 token whose scope grants `read' on any vhost/resource
+%% (aud=rabbitmq so the backend's audience check passes), returning
+%% {Token, JwksJson} where JwksJson is the PUBLIC key as a one-key JWKS document
+%% the network stub serves. Built on rsa_signer/1 so the keypair + signing recipe
+%% is not re-implemented. Intended to run ON THE BROKER NODE: minting there
+%% guarantees the signing key matches the JWKS the backend fetches.
+oauth_authz_mint() ->
+    #{jwk_pub := PubMap, sign := Sign} = rsa_signer(<<"k1">>),
+    Claims = #{
+        <<"sub">> => <<"alice">>,
+        <<"aud">> => <<"rabbitmq">>,
+        <<"exp">> => os:system_time(seconds) + 3600,
+        <<"scope">> => <<"rabbitmq.read:*/*">>
+    },
+    Token = Sign(Claims),
+    JwksJson = rabbit_json:encode(#{<<"keys">> => [PubMap]}),
+    {Token, JwksJson}.
+
+%% Extract the URL string from an httpc Request tuple (GET or POST form).
+request_url({Url, _Headers}) -> Url;
+request_url({Url, _Headers, _ContentType, _Body}) -> Url.

--- a/test/aws_auth_validate_oauth_tests.erl
+++ b/test/aws_auth_validate_oauth_tests.erl
@@ -1040,6 +1040,26 @@ authz_check_bad_permission_rejected_test() ->
     },
     ?assertMatch({error, input_invalid, _}, aws_auth_validate_oauth:validate(Body)).
 
+%% A non-binary authz_check.vhost is rejected in the pure phase. Without this
+%% guard the value would reach the broker's scope matcher as
+%% #resource{virtual_host = VHost} and crash it, a crash the network catch would
+%% misreport as a connection failure. resource_server_id is supplied so the
+%% check reaches the vhost validation rather than the earlier
+%% resource_server_id guard.
+authz_check_non_binary_vhost_rejected_test() ->
+    #{sign := Sign} = rsa_signer(<<"k1">>),
+    Token = Sign(#{<<"exp">> => future()}),
+    Body = (jwks_body())#{
+        <<"access_token">> => Token,
+        <<"resource_server_id">> => <<"rabbitmq">>,
+        <<"authz_check">> => #{
+            <<"vhost">> => 1.5,
+            <<"resource">> => <<"q">>,
+            <<"permission">> => <<"read">>
+        }
+    },
+    ?assertMatch({error, input_invalid, _}, aws_auth_validate_oauth:validate(Body)).
+
 %% Run Fun only if the oauth2 backend is loaded; otherwise return an empty test
 %% list (graceful skip), mirroring how the LDAP integration suite skips without
 %% slapd.

--- a/test/aws_auth_validate_oauth_tests.erl
+++ b/test/aws_auth_validate_oauth_tests.erl
@@ -1011,6 +1011,23 @@ authz_check_without_token_rejected_test() ->
     },
     ?assertMatch({error, input_invalid, _}, aws_auth_validate_oauth:validate(Body)).
 
+%% authz_check without a resource_server_id is rejected in the pure phase.
+%% The evaluator builds the broker's #resource_server{} from resource_server_id
+%% (it seeds the record id and default scope_prefix); without it,
+%% new_resource_server(undefined) would crash on iolist_to_binary([undefined,
+%% <<".">>]) and be misreported by the network catch as connection_failed. The
+%% pure-phase guard turns that into a clean input_invalid before any JWKS fetch.
+authz_check_without_resource_server_id_rejected_test() ->
+    #{sign := Sign} = rsa_signer(<<"k1">>),
+    Token = Sign(#{<<"exp">> => future()}),
+    Body = (jwks_body())#{
+        <<"access_token">> => Token,
+        <<"authz_check">> => #{
+            <<"resource">> => <<"q">>, <<"permission">> => <<"read">>
+        }
+    },
+    ?assertMatch({error, input_invalid, _}, aws_auth_validate_oauth:validate(Body)).
+
 %% A malformed authz_check (bad permission verb) is rejected in the pure phase.
 authz_check_bad_permission_rejected_test() ->
     #{sign := Sign} = rsa_signer(<<"k1">>),

--- a/test/aws_auth_validate_oauth_tests.erl
+++ b/test/aws_auth_validate_oauth_tests.erl
@@ -1064,6 +1064,55 @@ authz_check_non_binary_vhost_rejected_test() ->
     },
     ?assertMatch({error, input_invalid, _}, aws_auth_validate_oauth:validate(Body)).
 
+%% scope_aliases must be a map of alias-name => list-of-scope-strings (the shape
+%% the broker's #resource_server{} record holds). These pure-phase tests assert
+%% the malformed shapes that would otherwise reach the broker matcher and crash
+%% rabbit_data_coercion:to_binary/1 (float / map values), or describe a config
+%% the broker could never hold, are rejected as input_invalid before any network
+%% or crypto. A valid authz_check + resource_server_id + access_token are
+%% supplied so the request reaches parse_authz_scope_config rather than an
+%% earlier guard.
+authz_scope_aliases_helper_body(Aliases) ->
+    #{sign := Sign} = rsa_signer(<<"k1">>),
+    Token = Sign(#{<<"exp">> => future()}),
+    (jwks_body())#{
+        <<"access_token">> => Token,
+        <<"resource_server_id">> => <<"rabbitmq">>,
+        <<"scope_aliases">> => Aliases,
+        <<"authz_check">> => #{
+            <<"resource">> => <<"q">>,
+            <<"permission">> => <<"read">>
+        }
+    }.
+
+%% A float alias value would crash to_binary/1 on a matching scope; reject it.
+authz_scope_aliases_float_value_rejected_test() ->
+    Body = authz_scope_aliases_helper_body(#{<<"admin">> => 1.5}),
+    ?assertMatch({error, input_invalid, _}, aws_auth_validate_oauth:validate(Body)).
+
+%% A nested-object alias value would crash to_binary/1; reject it.
+authz_scope_aliases_object_value_rejected_test() ->
+    Body = authz_scope_aliases_helper_body(#{<<"admin">> => #{<<"x">> => 1}}),
+    ?assertMatch({error, input_invalid, _}, aws_auth_validate_oauth:validate(Body)).
+
+%% A bare-string alias value is not the record shape (broker holds a list);
+%% require the caller to supply the already-split list, so reject a string.
+authz_scope_aliases_bare_string_value_rejected_test() ->
+    Body = authz_scope_aliases_helper_body(#{<<"admin">> => <<"rabbitmq.read:*/*">>}),
+    ?assertMatch({error, input_invalid, _}, aws_auth_validate_oauth:validate(Body)).
+
+%% A list containing a non-binary (mixed list) crashes to_binary/1 element-wise;
+%% reject the whole value.
+authz_scope_aliases_mixed_list_rejected_test() ->
+    Body = authz_scope_aliases_helper_body(#{<<"admin">> => [<<"ok">>, 1.5]}),
+    ?assertMatch({error, input_invalid, _}, aws_auth_validate_oauth:validate(Body)).
+
+%% Note: the valid scope_aliases shape (alias => list of scope strings) is
+%% already exercised end-to-end through the JWKS mock by
+%% authz_iam_scope_alias_grants_access_test_/0, which asserts a grant, so no
+%% separate positive shape test is added here (a bare validate/1 without the
+%% network mock would attempt a real JWKS fetch).
+
 %% Run Fun only if the oauth2 backend's arity-4 scope API is available.
 %%
 %% Distinct states, deliberately handled differently (Luke's blocking

--- a/test/aws_auth_validate_oauth_tests.erl
+++ b/test/aws_auth_validate_oauth_tests.erl
@@ -1064,13 +1064,35 @@ authz_check_non_binary_vhost_rejected_test() ->
     },
     ?assertMatch({error, input_invalid, _}, aws_auth_validate_oauth:validate(Body)).
 
-%% Run Fun only if the oauth2 backend is loaded; otherwise return an empty test
-%% list (graceful skip), mirroring how the LDAP integration suite skips without
-%% slapd.
+%% Run Fun only if the oauth2 backend's arity-4 scope API is available.
+%%
+%% Three distinct states, deliberately handled differently (Luke's blocking
+%% coverage-gap note): a bare `available() -> false' skip would collapse the two
+%% false cases together and let a portability regression pass CI green.
+%%   * available()                       -> run the tests.
+%%   * NOT available, backend not loaded -> legitimate skip (return []), the same
+%%     way the LDAP suite skips without slapd. The feature genuinely cannot run.
+%%   * NOT available, backend IS loaded  -> HARD FAILURE. The oauth2 backend is
+%%     present but too old to expose resource_access/4 etc.; that is exactly the
+%%     build-guard portability bug. It must turn CI red, not silently skip.
 maybe_skip_authz(Fun) ->
     case aws_auth_validate_oauth_authz:available() of
-        true -> Fun();
-        false -> []
+        true ->
+            Fun();
+        false ->
+            case aws_auth_validate_oauth_authz:backend_loaded() of
+                false ->
+                    %% Backend genuinely absent -- legitimate skip.
+                    [];
+                true ->
+                    %% Present-but-unusable: fail loudly rather than skip.
+                    [
+                        ?_assertEqual(
+                            backend_loaded_but_authz_api_absent,
+                            available_with_loaded_backend
+                        )
+                    ]
+            end
     end.
 
 %% True when an {error, _, Reason} result's Reason binary contains Substr. Used

--- a/test/aws_auth_validate_oauth_tests.erl
+++ b/test/aws_auth_validate_oauth_tests.erl
@@ -10,6 +10,10 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
+%% Shared JWT-minting and httpc-request helpers (see the helper module). Imported
+%% so the existing rsa_signer/1 and request_url/1 call sites need no changes.
+-import(aws_auth_validate_oauth_test_helpers, [rsa_signer/1, request_url/1]).
+
 %%--------------------------------------------------------------------
 %% Method identity
 %%--------------------------------------------------------------------
@@ -1100,21 +1104,6 @@ compact_token(Header, Claims, SigBytes) ->
 
 b64url(Bin) -> base64:encode(Bin, #{mode => urlsafe, padding => false}).
 
-%% Generate a fresh RSA keypair via jose and return:
-%%   * jwk_pub -- the PUBLIC key as a JWKS-style map, tagged with Kid, and
-%%   * sign    -- a fun(ClaimsMap) -> compact RS256 JWT signed by the private key.
-%% Each call produces a DISTINCT key, so "wrong key" tests just call it twice.
-rsa_signer(Kid) ->
-    Priv = jose_jwk:generate_key({rsa, 2048}),
-    {_, PubMap0} = jose_jwk:to_public_map(Priv),
-    PubMap = PubMap0#{<<"kid">> => Kid},
-    Sign = fun(Claims) ->
-        JWS = #{<<"alg">> => <<"RS256">>, <<"kid">> => Kid},
-        {_, Token} = jose_jws:compact(jose_jwt:sign(Priv, JWS, Claims)),
-        Token
-    end,
-    #{jwk_pub => PubMap, sign => Sign}.
-
 %% A minimal body with only issuer (triggers OIDC discovery).
 issuer_body() ->
     #{<<"issuer">> => <<"https://idp.example.com">>}.
@@ -1173,7 +1162,3 @@ mock_arn_resolve_noop() ->
     %% override resolve_arn. Kept as a helper so the pure-phase tests read clearly.
     meck:expect(aws_arn_util, resolve_arn, fun(_Arn, State) -> {ok, <<"noop">>, State} end),
     ok.
-
-%% Extract the URL string from an httpc Request tuple (GET or POST form).
-request_url({Url, _Headers}) -> Url;
-request_url({Url, _Headers, _ContentType, _Body}) -> Url.

--- a/test/aws_auth_validate_oauth_tests.erl
+++ b/test/aws_auth_validate_oauth_tests.erl
@@ -833,7 +833,7 @@ access_token_no_leak_test_() ->
     end}.
 
 %%--------------------------------------------------------------------
-%% PROTOTYPE: optional authorization-evaluation layer (runtime soft dependency
+%% Optional authorization-evaluation layer (runtime soft dependency
 %% on rabbitmq_auth_backend_oauth2). These tests only run when that backend is
 %% loaded on the node (it is a TEST_DEPS-style presence, not a build DEPS);
 %% each test skips gracefully via availability/0 so the suite passes whether or

--- a/test/aws_auth_validate_oauth_tests.erl
+++ b/test/aws_auth_validate_oauth_tests.erl
@@ -1066,33 +1066,57 @@ authz_check_non_binary_vhost_rejected_test() ->
 
 %% Run Fun only if the oauth2 backend's arity-4 scope API is available.
 %%
-%% Three distinct states, deliberately handled differently (Luke's blocking
-%% coverage-gap note): a bare `available() -> false' skip would collapse the two
-%% false cases together and let a portability regression pass CI green.
-%%   * available()                       -> run the tests.
-%%   * NOT available, backend not loaded -> legitimate skip (return []), the same
-%%     way the LDAP suite skips without slapd. The feature genuinely cannot run.
-%%   * NOT available, backend IS loaded  -> HARD FAILURE. The oauth2 backend is
-%%     present but too old to expose resource_access/4 etc.; that is exactly the
-%%     build-guard portability bug. It must turn CI red, not silently skip.
+%% Distinct states, deliberately handled differently (Luke's blocking
+%% coverage-gap note): a bare `available() -> false' skip would let a
+%% portability regression pass CI green.
+%%   * available()                                 -> run the tests.
+%%   * NOT available, evaluator NOT compiled in    -> legitimate skip ([]). This
+%%     is a pre-floor broker series (oauth2.hrl lacks the arity-4 scope API), so
+%%     the feature is genuinely unavailable by design -- same as the LDAP suite
+%%     skipping without slapd.
+%%   * NOT available, evaluator compiled in, but
+%%     backend loaded                              -> HARD FAILURE. The evaluator
+%%     was built (the Makefile saw the arity-4 API) and the backend is loaded,
+%%     yet available/0 is false at runtime: a genuine portability regression. It
+%%     must turn CI red, not silently skip.
+%%   * NOT available, evaluator compiled in,
+%%     backend NOT loaded                          -> legitimate skip ([]): the
+%%     backend simply is not running on this node.
+%%
+%% NOTE: gate the hard failure on evaluator_compiled_in/0, not backend_loaded/0
+%% alone. rabbitmq_auth_backend_oauth2 is in TEST_DEPS, so the module is loadable
+%% even on a pre-floor series where the evaluator was correctly NOT compiled in;
+%% keying the hard failure on backend_loaded alone would wrongly fail that
+%% legitimate case.
 maybe_skip_authz(Fun) ->
     case aws_auth_validate_oauth_authz:available() of
         true ->
             Fun();
         false ->
-            case aws_auth_validate_oauth_authz:backend_loaded() of
-                false ->
-                    %% Backend genuinely absent -- legitimate skip.
-                    [];
-                true ->
-                    %% Present-but-unusable: fail loudly rather than skip.
-                    [
-                        ?_assertEqual(
-                            backend_loaded_but_authz_api_absent,
-                            available_with_loaded_backend
-                        )
-                    ]
-            end
+            maybe_skip_authz_unavailable(),
+            []
+    end.
+
+%% available/0 is false. If the evaluator was compiled in AND the backend is
+%% loaded, that is the portability regression -- fail loudly (a runtime error,
+%% not a two-literal ?assertEqual, which erlc rejects with a "guard evaluates to
+%% false" warning under warnings-as-errors). Otherwise the unavailability is
+%% legitimate and the caller skips.
+maybe_skip_authz_unavailable() ->
+    case
+        aws_auth_validate_oauth_authz:evaluator_compiled_in() andalso
+            aws_auth_validate_oauth_authz:backend_loaded()
+    of
+        true ->
+            erlang:error(
+                {backend_loaded_but_authz_api_absent,
+                    "rabbitmq_auth_backend_oauth2 is loaded and the authz evaluator "
+                    "was compiled in, but available/0 is false: the arity-4 scope API "
+                    "this layer requires is missing. The build guard admitted an "
+                    "unsupported broker series."}
+            );
+        false ->
+            ok
     end.
 
 %% True when an {error, _, Reason} result's Reason binary contains Substr. Used

--- a/test/aws_auth_validate_oauth_tests.erl
+++ b/test/aws_auth_validate_oauth_tests.erl
@@ -833,6 +833,214 @@ access_token_no_leak_test_() ->
     end}.
 
 %%--------------------------------------------------------------------
+%% PROTOTYPE: optional authorization-evaluation layer (runtime soft dependency
+%% on rabbitmq_auth_backend_oauth2). These tests only run when that backend is
+%% loaded on the node (it is a TEST_DEPS-style presence, not a build DEPS);
+%% each test skips gracefully via availability/0 so the suite passes whether or
+%% not the oauth2 modules are present.
+%%--------------------------------------------------------------------
+
+%% The soft-dependency probe returns a boolean and never raises, regardless of
+%% whether the oauth2 backend is loaded.
+authz_available_is_boolean_test() ->
+    ?assert(is_boolean(aws_auth_validate_oauth_authz:available())).
+
+%% A verified token whose scopes grant the requested permission -> 204. Uses a
+%% direct `scope' claim (no alias) so it exercises the scope->permission match.
+authz_direct_scope_grants_access_test_() ->
+    {setup, fun setup_httpc_mock/0, fun teardown_httpc_mock/1, fun(_) ->
+        maybe_skip_authz(fun() ->
+            #{jwk_pub := PubJwk, sign := Sign} = rsa_signer(<<"k1">>),
+            Token = Sign(#{
+                <<"exp">> => future(),
+                <<"aud">> => <<"rabbitmq">>,
+                <<"scope">> => <<"rabbitmq.configure:*/* rabbitmq.write:*/* rabbitmq.read:*/*">>
+            }),
+            JwksBody = rabbit_json:encode(#{<<"keys">> => [PubJwk]}),
+            mock_httpc_response(200, JwksBody),
+            Body = (jwks_body())#{
+                <<"access_token">> => Token,
+                <<"resource_server_id">> => <<"rabbitmq">>,
+                <<"scope_prefix">> => <<"rabbitmq.">>,
+                <<"authz_check">> => #{
+                    <<"vhost">> => <<"/">>,
+                    <<"resource">> => <<"my-queue">>,
+                    <<"permission">> => <<"configure">>
+                }
+            },
+            [?_assertEqual(ok, aws_auth_validate_oauth:validate(Body))]
+        end)
+    end}.
+
+%% scope_pattern_syntax => regex is accepted and runs the broker's bounded regex
+%% matcher (A2). A regex scope granting configure on any vhost/resource -> 204.
+%% Proves the regex path is wired through and functional (its ReDoS bounds are
+%% the broker's own -- see the aws_auth_validate_oauth_authz header).
+authz_regex_syntax_grants_access_test_() ->
+    {setup, fun setup_httpc_mock/0, fun teardown_httpc_mock/1, fun(_) ->
+        maybe_skip_authz(fun() ->
+            #{jwk_pub := PubJwk, sign := Sign} = rsa_signer(<<"k1">>),
+            Token = Sign(#{
+                <<"exp">> => future(),
+                <<"aud">> => <<"rabbitmq">>,
+                <<"scope">> => <<"rabbitmq.configure:.*/.*">>
+            }),
+            JwksBody = rabbit_json:encode(#{<<"keys">> => [PubJwk]}),
+            mock_httpc_response(200, JwksBody),
+            Body = (jwks_body())#{
+                <<"access_token">> => Token,
+                <<"resource_server_id">> => <<"rabbitmq">>,
+                <<"scope_prefix">> => <<"rabbitmq.">>,
+                <<"scope_pattern_syntax">> => <<"regex">>,
+                <<"authz_check">> => #{
+                    <<"vhost">> => <<"/">>,
+                    <<"resource">> => <<"my-queue">>,
+                    <<"permission">> => <<"configure">>
+                }
+            },
+            [?_assertEqual(ok, aws_auth_validate_oauth:validate(Body))]
+        end)
+    end}.
+
+%% A verified token that HAS an effective scope but it does NOT grant the
+%% requested permission -> authz_unverified with the "none grant" message (the
+%% genuine mapping mismatch). Token grants read; we ask for configure. The
+%% category stays authz_unverified; the message distinguishes this from the
+%% no-effective-scopes case below.
+authz_present_scope_no_match_test_() ->
+    {setup, fun setup_httpc_mock/0, fun teardown_httpc_mock/1, fun(_) ->
+        maybe_skip_authz(fun() ->
+            #{jwk_pub := PubJwk, sign := Sign} = rsa_signer(<<"k1">>),
+            Token = Sign(#{
+                <<"exp">> => future(),
+                <<"aud">> => <<"rabbitmq">>,
+                <<"scope">> => <<"rabbitmq.read:*/*">>
+            }),
+            JwksBody = rabbit_json:encode(#{<<"keys">> => [PubJwk]}),
+            mock_httpc_response(200, JwksBody),
+            Body = (jwks_body())#{
+                <<"access_token">> => Token,
+                <<"resource_server_id">> => <<"rabbitmq">>,
+                <<"scope_prefix">> => <<"rabbitmq.">>,
+                <<"authz_check">> => #{
+                    <<"resource">> => <<"my-queue">>,
+                    <<"permission">> => <<"configure">>
+                }
+            },
+            Result = aws_auth_validate_oauth:validate(Body),
+            [
+                ?_assertMatch({error, authz_unverified, _}, Result),
+                ?_assert(reason_contains(Result, "none grant"))
+            ]
+        end)
+    end}.
+
+%% A verified token whose scopes ALL have the wrong prefix -> nothing survives
+%% scope_prefix filtering -> authz_unverified with the no-effective-scopes
+%% message (the prefix/alias-typo footgun that generates "my token is broken"
+%% tickets). Token carries `other.read:*/*'; prefix is `rabbitmq.'.
+authz_no_effective_scopes_after_prefix_test_() ->
+    {setup, fun setup_httpc_mock/0, fun teardown_httpc_mock/1, fun(_) ->
+        maybe_skip_authz(fun() ->
+            #{jwk_pub := PubJwk, sign := Sign} = rsa_signer(<<"k1">>),
+            Token = Sign(#{
+                <<"exp">> => future(),
+                <<"aud">> => <<"rabbitmq">>,
+                <<"scope">> => <<"other.configure:*/*">>
+            }),
+            JwksBody = rabbit_json:encode(#{<<"keys">> => [PubJwk]}),
+            mock_httpc_response(200, JwksBody),
+            Body = (jwks_body())#{
+                <<"access_token">> => Token,
+                <<"resource_server_id">> => <<"rabbitmq">>,
+                <<"scope_prefix">> => <<"rabbitmq.">>,
+                <<"authz_check">> => #{
+                    <<"resource">> => <<"my-queue">>,
+                    <<"permission">> => <<"configure">>
+                }
+            },
+            Result = aws_auth_validate_oauth:validate(Body),
+            [
+                ?_assertMatch({error, authz_unverified, _}, Result),
+                ?_assert(reason_contains(Result, "no scopes for this resource_server"))
+            ]
+        end)
+    end}.
+
+%% IAM-style path: the token carries the role ARN in `sub', additional_scopes_key
+%% points at `sub', and scope_aliases maps that ARN to concrete RabbitMQ scopes.
+%% Proves the alias expansion (the actual MQ IAM mechanism) reaches an allow.
+authz_iam_scope_alias_grants_access_test_() ->
+    {setup, fun setup_httpc_mock/0, fun teardown_httpc_mock/1, fun(_) ->
+        maybe_skip_authz(fun() ->
+            RoleArn = <<"arn:aws:iam::123456789012:role/RabbitMqAdminRole">>,
+            #{jwk_pub := PubJwk, sign := Sign} = rsa_signer(<<"k1">>),
+            Token = Sign(#{
+                <<"exp">> => future(), <<"aud">> => <<"rabbitmq">>, <<"sub">> => RoleArn
+            }),
+            JwksBody = rabbit_json:encode(#{<<"keys">> => [PubJwk]}),
+            mock_httpc_response(200, JwksBody),
+            Body = (jwks_body())#{
+                <<"access_token">> => Token,
+                <<"resource_server_id">> => <<"rabbitmq">>,
+                <<"scope_prefix">> => <<"rabbitmq.">>,
+                <<"additional_scopes_key">> => <<"sub">>,
+                <<"scope_aliases">> => #{
+                    RoleArn => [
+                        <<"rabbitmq.tag:administrator">>,
+                        <<"rabbitmq.read:*/*">>,
+                        <<"rabbitmq.write:*/*">>,
+                        <<"rabbitmq.configure:*/*">>
+                    ]
+                },
+                <<"authz_check">> => #{
+                    <<"resource">> => <<"my-queue">>,
+                    <<"permission">> => <<"write">>
+                }
+            },
+            [?_assertEqual(ok, aws_auth_validate_oauth:validate(Body))]
+        end)
+    end}.
+
+%% authz_check without an access_token is rejected in the pure phase.
+authz_check_without_token_rejected_test() ->
+    Body = (jwks_body())#{
+        <<"authz_check">> => #{
+            <<"resource">> => <<"q">>, <<"permission">> => <<"read">>
+        }
+    },
+    ?assertMatch({error, input_invalid, _}, aws_auth_validate_oauth:validate(Body)).
+
+%% A malformed authz_check (bad permission verb) is rejected in the pure phase.
+authz_check_bad_permission_rejected_test() ->
+    #{sign := Sign} = rsa_signer(<<"k1">>),
+    Token = Sign(#{<<"exp">> => future()}),
+    Body = (jwks_body())#{
+        <<"access_token">> => Token,
+        <<"authz_check">> => #{
+            <<"resource">> => <<"q">>, <<"permission">> => <<"admin">>
+        }
+    },
+    ?assertMatch({error, input_invalid, _}, aws_auth_validate_oauth:validate(Body)).
+
+%% Run Fun only if the oauth2 backend is loaded; otherwise return an empty test
+%% list (graceful skip), mirroring how the LDAP integration suite skips without
+%% slapd.
+maybe_skip_authz(Fun) ->
+    case aws_auth_validate_oauth_authz:available() of
+        true -> Fun();
+        false -> []
+    end.
+
+%% True when an {error, _, Reason} result's Reason binary contains Substr. Used
+%% to assert the specific authz_unverified message (the category is constant;
+%% the message is what distinguishes the failure stage).
+reason_contains({error, _Cat, Reason}, Substr) when is_binary(Reason) ->
+    string:find(Reason, Substr) =/= nomatch;
+reason_contains(_Other, _Substr) ->
+    false.
+
+%%--------------------------------------------------------------------
 %% Helpers
 %%--------------------------------------------------------------------
 


### PR DESCRIPTION
Follow-up enhancement for *Issue #144*

## Summary

Base OAuth validation proves reachability + JWKS well-formedness and (when a customer supplies their own `access_token`) signature + `exp`/`aud`. It stops at **authentication**: it never answers "would the broker grant this principal a permission?" That authorization gap is the #1 source of "my token is broken (it isn't)" support tickets, where the real fault is a `scope_prefix` / `scope_aliases` typo, not the token.

This adds an **optional** authorization-evaluation step that closes the gap without a broker restart and without accepting any secret. It is a **triage aid**, not an authorization gate: it localizes *which* layer of an OAuth config is wrong (reachability vs. authentication vs. authorization) and, for authz, names the failing stage.

## How it works

`aws_auth_validate_oauth_authz` (new): given an already-verified token's claims and a customer-supplied `authz_check` `{vhost, resource, permission}`, it answers whether the broker would grant it. Implemented as a **runtime soft dependency** on `rabbitmq_auth_backend_oauth2`:

- It **calls the backend's own pure decision functions** (`normalize_token_scope/2`, `get_expanded_scopes/3`, `rabbit_oauth2_scope:resource_access/4`) when-and-only-when the module is loaded, guarded by `code:ensure_loaded/1` + `function_exported/3`.
- It is **not** added to `DEPS`, so aws-plugin users who never run OAuth are unaffected.
- Because it **executes the broker's code rather than mirroring it, drift is impossible by construction** -- there is nothing to keep in sync.
- When the backend is absent, authz is unavailable and says so (`config_conflict`); it never falls back to a home-grown matcher.

## Example request

```
PUT /api/aws/auth/validate/oauth
{
  "jwks_uri": "https://idp.example.com/.well-known/jwks.json",
  "access_token": "<customer-minted JWT>",
  "resource_server_id": "rabbitmq",
  "scope_prefix": "rabbitmq.",
  "authz_check": { "vhost": "/", "resource": "my-queue", "permission": "read" }
}
```

`204` = the broker would grant it. `422 authz_unverified` = it would not (with a message naming the failing stage). The `access_token` / `authz_check` fields are entirely optional; omitting them leaves the base reachability behaviour unchanged.

## Non-goals / out of scope (unchanged by this PR)

- This does **not** turn the endpoint into an authorization gate; the base check still asserts reachability + authentication only.
- `assume_role` from request input remains **excluded** (confused-deputy); no change here.
- No broker-side `client_credentials` grant -- the customer-supplied token path already gives end-to-end confidence with no secret transiting the endpoint.

## Changes

- **`aws_auth_validate_oauth`:** wire the optional layer in. New `allowed_fields` (`scope_aliases`, `additional_scopes_key`, `scope_prefix`, `scope_pattern_syntax`, `authz_check`); pure-phase shape checks that require an `access_token` and reject a malformed check before any network/crypto; `verify_token_claims/3` now returns the decoded claims so `maybe_check/2` can run against them after verification.
- **`Makefile`:** add `rabbitmq_auth_backend_oauth2` to `TEST_DEPS` so the layer's decision functions are loadable under test.

## Testing

- **CT (`aws_auth_validate_mgmt_SUITE`): 22/22** against the umbrella (`gmake`), including two new cases that drive the authz layer **end-to-end through the Cowboy handler** -- dispatch is **not** mocked; only the JWKS network seam is stubbed, and the token + JWKS are minted on the broker node. `oauth_authz_grants_returns_204` and `oauth_authz_denies_returns_422` use the **same** verified token (grants `read`) and differ only in the requested permission, so the 204-vs-422 split proves the `authz_check` field survives the registry allowlist filter and the config is genuinely consumed -- not a no-op.
- **eunit:** availability probe; direct-scope grant; regex-syntax grant; present-scope-no-match and no-effective-scopes-after-prefix denials (asserting the distinct messages); IAM `scope_aliases` expansion grant; `authz_check`-without-token and bad-permission rejections.
- Both the eunit and CT authz cases **skip gracefully** when `rabbitmq_auth_backend_oauth2` is not loaded on the node (mirroring the LDAP suite's slapd skip). With it in `TEST_DEPS` the backend is loaded in CI, so the cases run rather than skip.
- `erlfmt -c` clean; clean release build.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
