### PR TITLE
Feature: UI for Auth Validation Endpoint

### DIFF
--- a/priv/www/js/aws_auth_validate.js
+++ b/priv/www/js/aws_auth_validate.js
@@ -397,12 +397,21 @@ function aws_auth_validate_merge_conf(method, existingText, body) {
     var spec = AWS_AUTH_VALIDATE_CONF[method];
 
     // Desired scalar key -> rendered value, for managed keys the form supplies.
+    // remove holds boolean keys the form does NOT supply: an unchecked checkbox
+    // is omitted from the body, and for booleans that means "off", so any stale
+    // line for it must be dropped rather than preserved. (Empty string/int fields
+    // are left absent from both maps and preserved verbatim below, so we never
+    // wipe config the operator did not touch.)
     var desired = {};
+    var remove = {};
     for (var key in spec.map) {
         if (!Object.prototype.hasOwnProperty.call(spec.map, key)) { continue; }
         var desc = spec.map[key];
         var v = aws_auth_validate_get_path(body, desc.path);
-        if (v === undefined || v === null || ('' + v).length === 0) { continue; }
+        if (v === undefined || v === null || ('' + v).length === 0) {
+            if (desc.type === 'bool') { remove[key.toLowerCase()] = true; }
+            continue;
+        }
         if (desc.type === 'bool') { v = v ? 'true' : 'false'; }
         desired[key.toLowerCase()] = {canonical: key, value: '' + v};
     }
@@ -461,8 +470,14 @@ function aws_auth_validate_merge_conf(method, existingText, body) {
             continue;
         }
 
-        // Any other line (unrelated config, another method's keys, a managed key
-        // the form left empty, assume_role) is preserved verbatim.
+        // Managed boolean key the form left unchecked ("off"): drop the stale
+        // line so unchecking (e.g. use_starttls) removes it from the config.
+        if (Object.prototype.hasOwnProperty.call(remove, k)) {
+            continue;
+        }
+
+        // Any other line (unrelated config, another method's keys, a managed
+        // string/int key the form left empty, assume_role) is preserved verbatim.
         out.push(line);
     }
 
@@ -558,33 +573,84 @@ function aws_auth_validate_config_status(text, cls) {
         .attr('class', 'argument' + (cls ? ' ' + cls : ''));
 }
 
-// Submit the current method. The rabbitmq.conf textarea is authoritative when it
-// holds content (an operator may have pasted or hand-edited config lines), so we
-// parse and send that; otherwise we build the body from the visible form and
-// reflect it back into the textarea as conf so what was validated is always
-// visible. Form-only fields (oauth access_token, tls target) have no conf key,
-// so they are always overlaid from the form. Bound as a delegated click so it
+// Submit the current method. The left-hand fields are the single source of
+// truth for validation; the rabbitmq.conf box is a paste/copy convenience that
+// never drives the request. This prevents the source-of-truth trap where the
+// fields are invalid but a differing pasted config looks valid -- we would
+// otherwise validate one thing while the operator reads another. If the box has
+// content that diverges from the fields, we block and point the operator at the
+// Parse / Update buttons to reconcile first. Bound as a delegated click so it
 // survives re-renders. Never a GET/route param -- the body may carry an ARN.
 $(document).on('click', '#aws-auth-validate-submit', function() {
     var method = $('#aws-auth-validate-method').val();
+    // Always build the request from the visible fields.
+    var body = aws_auth_validate_build_body(method);
+
     var raw = ('' + $('#aws-auth-validate-config').val()).trim();
-    var body;
     if (raw.length > 0) {
-        var parsed = aws_auth_validate_conf_to_body(method, raw);
-        body = parsed.body;
-        // Form-only fields never appear in conf; take them from the form.
-        aws_auth_validate_overlay_form_only(method, body);
+        // The box is non-empty: make sure it matches the fields before we run,
+        // so what is validated is exactly what is displayed. Overlay form-only
+        // fields (oauth access_token, tls target) onto the parsed body since
+        // they have no conf key and would otherwise read as a false divergence.
+        var pastedBody = aws_auth_validate_conf_to_body(method, raw).body;
+        aws_auth_validate_overlay_form_only(method, pastedBody);
+        if (aws_auth_validate_normalize_body(pastedBody) !==
+            aws_auth_validate_normalize_body(body)) {
+            aws_auth_validate_config_status(
+                'The config box differs from the fields. Validation runs on the ' +
+                'fields -- click "Parse into fields" to use the pasted config, or ' +
+                '"Update config from fields" to sync the box, then Validate again.',
+                'status-yellow');
+            return false;
+        }
     } else {
-        body = aws_auth_validate_build_body(method);
+        // Nothing pasted: reflect the fields into the box so the validated
+        // config is always visible and copyable.
         aws_auth_validate_set_config_text(aws_auth_validate_body_to_conf(method, body));
     }
+
     // Remember the exact conf text on screen so a 204 can mark it validated and
-    // the copy button can flag later edits. If the operator pasted conf we keep
-    // their text verbatim (comments and all); otherwise it is the generated conf.
+    // the copy button can flag later edits. It is now guaranteed consistent with
+    // the fields (verified above, or generated from them).
     var confText = '' + $('#aws-auth-validate-config').val();
+    // Clear any prior result and show a spinner immediately. A slow failure can
+    // take several seconds, during which a stale success banner would otherwise
+    // linger and mislead; the spinner makes "in progress" unambiguous.
+    aws_auth_validate_show_loading();
     aws_auth_validate_req(method, body, confText);
     return false;
 });
+
+// Stable stringification of a request body for divergence comparison: object
+// keys are sorted recursively so key order and whitespace never trigger a false
+// mismatch. Array order is preserved (the ldap servers list is meaningful).
+function aws_auth_validate_normalize_body(body) {
+    return JSON.stringify(aws_auth_validate_sort_keys(body));
+}
+function aws_auth_validate_sort_keys(v) {
+    if (Object.prototype.toString.call(v) === '[object Array]') {
+        return v.map(aws_auth_validate_sort_keys);
+    }
+    if (v && typeof v === 'object') {
+        var out = {};
+        Object.keys(v).sort().forEach(function(k) {
+            out[k] = aws_auth_validate_sort_keys(v[k]);
+        });
+        return out;
+    }
+    return v;
+}
+
+// Replace the result area with a spinner while a request is in flight. Cleared
+// by aws_auth_validate_render_result when the response (or transport error)
+// arrives.
+function aws_auth_validate_show_loading() {
+    $('#aws-auth-validate-result').html(
+        '<div class="status-grey" style="padding:8px;">' +
+        '<span class="aws-av-spinner"></span>' +
+        '<span class="argument">Validating&hellip;</span></div>'
+    );
+}
 
 // Parse the textarea rabbitmq.conf into the form fields. Lines that do not apply
 // to the selected method are ignored; aws.arns.assume_role_arn is skipped (read

--- a/priv/www/js/aws_auth_validate.js
+++ b/priv/www/js/aws_auth_validate.js
@@ -57,8 +57,10 @@ var AWS_AUTH_VALIDATE_CATEGORY = {
     tls_failed:         {cls: 'status-red',    text: 'TLS failed: handshake or certificate verification did not succeed.'},
     query_invalid:      {cls: 'status-red',    text: 'Query invalid: an authorization query could not be parsed.'},
     auth_failed:        {cls: 'status-yellow', text: 'Auth failed: the server was reached but did not authenticate/respond as expected.'},
-    config_conflict:    {cls: 'status-yellow', text: 'Config conflict: the supplied options are mutually inconsistent (for example an ARN is referenced with no assume_role configured).'},
-    authz_unverified:   {cls: 'status-yellow', text: 'Authorization unverified: a configured authorization check could not be confirmed.'},
+    token_invalid:      {cls: 'status-red',    text: 'Token invalid: the supplied access token failed signature verification, or no fetched JWKS key matched its key id -- the broker would also reject it.'},
+    token_expired:      {cls: 'status-yellow', text: 'Token expired: the supplied access token is past its exp (transient -- re-mint the token and retry).'},
+    config_conflict:    {cls: 'status-yellow', text: 'Config conflict: the supplied options are mutually inconsistent (for example an ARN is referenced with no assume_role configured, or an authorization check was requested but the oauth2 backend is not loaded on this broker).'},
+    authz_unverified:   {cls: 'status-yellow', text: 'Authorization unverified: the token is authentic but the requested permission could not be confirmed on the vhost/resource. Check scope_prefix, resource_server_id, additional_scopes_key, and scope_aliases.'},
     method_disabled:    {cls: 'status-yellow', text: 'Method disabled: enable it with aws.auth_validation.enabled_methods.<method> = true (every method is opt-in).'},
     unknown_method:     {cls: 'status-red',    text: 'Unknown method.'},
     insufficient_user_tag: {cls: 'status-red', text: 'Your user lacks the tag required to call this endpoint.'},
@@ -69,16 +71,27 @@ var AWS_AUTH_VALIDATE_CATEGORY = {
 
 // Read the visible method form into a JSON request body. Only non-empty fields
 // are included so an omitted optional field keeps the backend default. ssl_options
-// is collected from a small fixed set of sub-fields; ARN fields nest under it to
-// match the backend shape (ssl_options.cacertfile_arn etc.).
+// is collected from the selected method's own ssl sub-fields; ARN fields nest
+// under it to match the backend shape (ssl_options.cacertfile_arn etc.).
+//
+// The scan is scoped to the SELECTED method's field container
+// (#aws-av-fields-<method>), never the whole form. Each method group carries its
+// own data-av-field / data-av-ssl inputs (the ssl_options key set differs per
+// backend -- e.g. ldap wants server_name_indication and has no client cert,
+// while http/oauth want sni + certfile/keyfile), and switching methods only
+// HIDES the other groups. A whole-form scan would therefore merge a previously-
+// selected method's (now hidden) values into this body -- producing a request
+// with foreign keys the backend rejects as input_invalid, and a permanent
+// divergence from the conf box. Scoping to the active group is what keeps the
+// body method-pure.
 function aws_auth_validate_build_body(method) {
     var body = {};
-    var $form = $('#aws-auth-validate-form');
+    var $scope = $('#aws-av-fields-' + method);
 
-    // Flat top-level fields per method. A checkbox contributes a boolean true
-    // only when checked (an unchecked box is omitted so the backend keeps its
-    // default); every other input contributes its non-empty value.
-    $form.find('[data-av-field]').each(function() {
+    // Flat top-level fields for THIS method. A checkbox contributes a boolean
+    // true only when checked (an unchecked box is omitted so the backend keeps
+    // its default); every other input contributes its non-empty value.
+    $scope.find('[data-av-field]').each(function() {
         var el = $(this);
         var key = el.attr('data-av-field');
         if (el.is(':checkbox')) {
@@ -101,9 +114,9 @@ function aws_auth_validate_build_body(method) {
         if (!isNaN(p)) { body.port = p; } else { delete body.port; }
     }
 
-    // ssl_options sub-object (shared shape across methods that support TLS).
+    // ssl_options sub-object, collected from THIS method's ssl sub-fields only.
     var ssl = {};
-    $form.find('[data-av-ssl]').each(function() {
+    $scope.find('[data-av-ssl]').each(function() {
         var key = $(this).attr('data-av-ssl');
         var el = $(this);
         var val = el.is(':checkbox') ? el.is(':checked') : el.val();
@@ -116,7 +129,103 @@ function aws_auth_validate_build_body(method) {
     if (Object.keys(ssl).length > 0) {
         body.ssl_options = ssl;
     }
+
+    // LDAP authorization queries: a map of {query_name: dsl_string} assembled
+    // from the four data-av-query textareas. Each value is sent as a raw DSL
+    // string; the backend parses it (query_invalid on failure) and, when a
+    // username was supplied, evaluates it for that principal. An empty box
+    // contributes no entry so the backend keeps that query unset.
+    if (method === 'ldap') {
+        var queries = aws_auth_validate_build_queries($scope);
+        if (Object.keys(queries).length > 0) {
+            body.queries = queries;
+        }
+    }
+
+    // OAuth authorization-evaluation layer. The generic loop above collected the
+    // scalar authz-config fields (scope_prefix, additional_scopes_key,
+    // scope_pattern_syntax) as-is. Two shapes need building by hand: scope_aliases
+    // is a map the backend expects as {alias: [scopes]} (entered as lines here),
+    // and authz_check is assembled from its own data-av-authz inputs. Everything
+    // here is optional -- an empty permission means "no authz check", matching the
+    // backend, which treats authz_check as absent unless a check block is present.
+    if (method === 'oauth') {
+        if (typeof body.scope_aliases === 'string') {
+            var aliases = aws_auth_validate_parse_scope_aliases(body.scope_aliases);
+            if (aliases && Object.keys(aliases).length > 0) {
+                body.scope_aliases = aliases;
+            } else {
+                // Blank or comment-only text: omit the field entirely so the
+                // backend keeps its default rather than seeing an empty object.
+                delete body.scope_aliases;
+            }
+        }
+        var authz = aws_auth_validate_build_authz_check($scope);
+        if (authz !== null) {
+            body.authz_check = authz;
+        }
+    }
     return body;
+}
+
+// Assemble the LDAP `queries` map from the four data-av-query textareas within
+// the ldap field group. Each non-empty box contributes {query_name: dsl_string}
+// where the value is the raw DSL text (trimmed); the backend parses and, when a
+// username is present, evaluates it. An empty box is omitted so the backend
+// keeps that query unset. The DSL string is sent verbatim -- the backend owns
+// the grammar (query_invalid on a parse failure), so the UI does not pre-parse.
+function aws_auth_validate_build_queries($scope) {
+    var queries = {};
+    $scope.find('[data-av-query]').each(function() {
+        var el = $(this);
+        var name = el.attr('data-av-query');
+        var val = ('' + el.val()).trim();
+        if (val.length > 0) { queries[name] = val; }
+    });
+    return queries;
+}
+
+// Parse the scope_aliases textarea (one "alias = scope1 scope2 ..." per line)
+// into the map shape the backend requires: {alias: [scope, ...]}. Blank lines
+// and #-comment lines are ignored. A line with no '=' or no scopes is skipped
+// (the backend rejects a malformed scope_aliases with input_invalid; we simply
+// do not emit an ill-formed entry, so the operator sees their real typo rather
+// than a silently-mangled value). Values are kept case-sensitive.
+function aws_auth_validate_parse_scope_aliases(text) {
+    var out = {};
+    var lines = ('' + text).split(/\r?\n/);
+    for (var i = 0; i < lines.length; i++) {
+        var line = lines[i].trim();
+        if (line.length === 0 || line.charAt(0) === '#') { continue; }
+        var eq = line.indexOf('=');
+        if (eq === -1) { continue; }
+        var alias = line.substring(0, eq).trim();
+        var scopes = line.substring(eq + 1).trim().split(/\s+/)
+            .filter(function(s) { return s.length > 0; });
+        if (alias.length === 0 || scopes.length === 0) { continue; }
+        out[alias] = scopes;
+    }
+    return out;
+}
+
+// Assemble the authz_check object from its form inputs. Returns null when no
+// permission is selected (the check is opt-in: no permission means the operator
+// is not asking for an authorization decision, so the field is omitted and the
+// backend runs reachability + token verification only). vhost is omitted when
+// blank so the backend applies its documented default ("/").
+function aws_auth_validate_build_authz_check($form) {
+    var perm = $form.find('[data-av-authz="permission"]').val();
+    if (!perm || ('' + perm).length === 0) { return null; }
+    var check = {permission: perm};
+    var resource = $form.find('[data-av-authz="resource"]').val();
+    if (resource !== null && resource !== undefined && ('' + resource).length > 0) {
+        check.resource = resource;
+    }
+    var vhost = $form.find('[data-av-authz="vhost"]').val();
+    if (vhost !== null && vhost !== undefined && ('' + vhost).length > 0) {
+        check.vhost = vhost;
+    }
+    return check;
 }
 
 // The JSON body that most recently returned 204, as a normalized string. Used
@@ -131,24 +240,35 @@ var AWS_AUTH_VALIDATE_LAST_VALID = null;
 // A "method" key, if present, selects the matching method tab and is not treated
 // as a form field (the real endpoint takes the method from the URL, not the body).
 function aws_auth_validate_populate_form(method, body) {
-    var $form = $('#aws-auth-validate-form');
+    var $scope = $('#aws-av-fields-' + method);
 
-    // Clear the currently-visible method's fields and the shared ssl_options.
-    $('#aws-av-fields-' + method).find('[data-av-field]').each(function() {
+    // Fields with no rabbitmq.conf representation (oauth scope_aliases /
+    // authz_check, ldap username / queries) carry runtime validation intent the
+    // pasted conf knows nothing about. A parse must NOT silently wipe them, so
+    // snapshot their current values and restore them after the clear-and-
+    // repopulate below.
+    var preservedNonConf = aws_auth_validate_snapshot_nonconf(method);
+
+    // Clear the selected method's fields and its own ssl_options. Both scans are
+    // scoped to this method's group: ssl inputs now live per-method (the key set
+    // differs per backend), so a form-wide clear would wipe another method's
+    // values.
+    $scope.find('[data-av-field]').each(function() {
         var el = $(this);
         if (el.is(':checkbox')) { el.prop('checked', false); } else { el.val(''); }
     });
-    $form.find('[data-av-ssl]').each(function() {
+    $scope.find('[data-av-ssl]').each(function() {
         var el = $(this);
         if (el.is(':checkbox')) { el.prop('checked', false); } else { el.val(''); }
     });
+    aws_auth_validate_restore_nonconf(method, preservedNonConf);
 
     if (!body || typeof body !== 'object') { return; }
 
     var ssl = (body.ssl_options && typeof body.ssl_options === 'object') ? body.ssl_options : {};
 
     // Top-level fields for the selected method.
-    $('#aws-av-fields-' + method).find('[data-av-field]').each(function() {
+    $scope.find('[data-av-field]').each(function() {
         var el = $(this);
         var key = el.attr('data-av-field');
         if (!Object.prototype.hasOwnProperty.call(body, key)) { return; }
@@ -162,8 +282,8 @@ function aws_auth_validate_populate_form(method, body) {
         }
     });
 
-    // Shared ssl_options sub-fields.
-    $form.find('[data-av-ssl]').each(function() {
+    // This method's ssl_options sub-fields.
+    $scope.find('[data-av-ssl]').each(function() {
         var el = $(this);
         var key = el.attr('data-av-ssl');
         if (!Object.prototype.hasOwnProperty.call(ssl, key)) { return; }
@@ -204,11 +324,11 @@ var AWS_AUTH_VALIDATE_CONF = {
             'auth_ldap.dn_lookup_base':                         {path: ['dn_lookup_base'], type: 'string', ex: 'dc=example,dc=com'},
             'auth_ldap.dn_lookup_attribute':                    {path: ['dn_lookup_attribute'], type: 'string', ex: 'sAMAccountName'},
             'auth_ldap.ssl_options.verify':                     {path: ['ssl_options', 'verify'], type: 'string', ex: 'verify_peer'},
-            'auth_ldap.ssl_options.sni':                        {path: ['ssl_options', 'sni'], type: 'string', ex: 'ldap.example.com'},
+            // LDAP's ssl_options accepts server_name_indication (NOT sni) and has
+            // no client-cert/mTLS material, so no certfile/keyfile ARN lines.
+            'auth_ldap.ssl_options.server_name_indication':     {path: ['ssl_options', 'server_name_indication'], type: 'string', ex: 'ldap.example.com'},
             'aws.arns.auth_ldap.dn_lookup_bind.password':       {path: ['password_arn'], type: 'string', ex: 'arn:aws:secretsmanager:us-west-2:111122223333:secret:RabbitMqDnLookupUserPassword'},
-            'aws.arns.auth_ldap.ssl_options.cacertfile':        {path: ['ssl_options', 'cacertfile_arn'], type: 'string', ex: 'arn:aws:s3:::my-bucket/ca-cert.pem'},
-            'aws.arns.auth_ldap.ssl_options.certfile':          {path: ['ssl_options', 'certfile_arn'], type: 'string', ex: 'arn:aws:s3:::my-bucket/client-cert.pem'},
-            'aws.arns.auth_ldap.ssl_options.keyfile':           {path: ['ssl_options', 'keyfile_arn'], type: 'string', ex: 'arn:aws:secretsmanager:us-west-2:111122223333:secret:RabbitMqClientKey'}
+            'aws.arns.auth_ldap.ssl_options.cacertfile':        {path: ['ssl_options', 'cacertfile_arn'], type: 'string', ex: 'arn:aws:s3:::my-bucket/ca-cert.pem'}
         },
         formOnly: []
     },
@@ -234,6 +354,9 @@ var AWS_AUTH_VALIDATE_CONF = {
             'auth_oauth2.jwks_uri':                             {path: ['jwks_uri'], type: 'string', ex: 'https://idp.example.com/.well-known/jwks.json'},
             'auth_oauth2.issuer':                               {path: ['issuer'], type: 'string', ex: 'https://idp.example.com/'},
             'auth_oauth2.resource_server_id':                   {path: ['resource_server_id'], type: 'string', ex: 'rabbitmq'},
+            'auth_oauth2.scope_prefix':                         {path: ['scope_prefix'], type: 'string', ex: 'rabbitmq.'},
+            'auth_oauth2.additional_scopes_key':               {path: ['additional_scopes_key'], type: 'string', ex: 'roles'},
+            'auth_oauth2.scope_pattern_syntax':                 {path: ['scope_pattern_syntax'], type: 'string', ex: 'wildcard'},
             'auth_oauth2.ssl_options.verify':                   {path: ['ssl_options', 'verify'], type: 'string', ex: 'verify_peer'},
             'auth_oauth2.ssl_options.sni':                      {path: ['ssl_options', 'sni'], type: 'string', ex: 'idp.example.com'},
             'aws.arns.auth_oauth2.ssl_options.cacertfile':      {path: ['ssl_options', 'cacertfile_arn'], type: 'string', ex: 'arn:aws:s3:::my-bucket/ca-cert.pem'},
@@ -247,18 +370,19 @@ var AWS_AUTH_VALIDATE_CONF = {
     tls: {
         // TLS validation targets a broker listener; the mTLS/SSL tutorials
         // configure ssl_options at the top level (no auth_<backend> prefix).
+        // The material is inbound-listener trust config: cacertfile_arn, verify,
+        // and fail_if_no_peer_cert only -- no sni and no client cert/key (the
+        // server cert is AWS-managed).
         backend: null,
         map: {
             'ssl_options.verify':                               {path: ['ssl_options', 'verify'], type: 'string', ex: 'verify_peer'},
-            'ssl_options.sni':                                  {path: ['ssl_options', 'sni'], type: 'string', ex: 'listener.example.com'},
-            'aws.arns.ssl_options.cacertfile':                  {path: ['ssl_options', 'cacertfile_arn'], type: 'string', ex: 'arn:aws:s3:::my-bucket/ca-cert.pem'},
-            'aws.arns.ssl_options.certfile':                    {path: ['ssl_options', 'certfile_arn'], type: 'string', ex: 'arn:aws:s3:::my-bucket/client-cert.pem'},
-            'aws.arns.ssl_options.keyfile':                     {path: ['ssl_options', 'keyfile_arn'], type: 'string', ex: 'arn:aws:secretsmanager:us-west-2:111122223333:secret:RabbitMqClientKey'}
+            'ssl_options.fail_if_no_peer_cert':                 {path: ['ssl_options', 'fail_if_no_peer_cert'], type: 'bool', ex: 'true'},
+            'aws.arns.ssl_options.cacertfile':                  {path: ['ssl_options', 'cacertfile_arn'], type: 'string', ex: 'arn:aws:s3:::my-bucket/ca-cert.pem'}
         },
         // `target` names the listener under test; it is a validation concept,
         // not a rabbitmq.conf key.
         formOnly: ['target'],
-        notes: ['# target: enter the listener name in the "Target" form field above (a validation concept, not a rabbitmq.conf key).']
+        notes: ['# target: enter "listener" or "management" in the "Target" form field above (a validation concept, not a rabbitmq.conf key).']
     }
 };
 
@@ -455,18 +579,27 @@ function aws_auth_validate_merge_conf(method, existingText, body) {
                 }
                 // Drop the original server line (replaced by the block above).
             } else {
-                out.push(line); // form has no servers -- leave existing untouched
+                // Form has no servers -- leave the existing line untouched.
+                out.push(line);
             }
             continue;
         }
 
-        // Managed scalar key the form supplies: update value in place, keeping
-        // the operator's original indentation and key spelling.
+        // Managed scalar key the form supplies: update the FIRST occurrence in
+        // place, keeping the operator's original indentation and key spelling.
         if (Object.prototype.hasOwnProperty.call(desired, k) && !seen[k]) {
             var leadingWs = line.match(/^\s*/)[0];
             var origKey = trimmed.substring(0, eq).trim();
             out.push(leadingWs + origKey + ' = ' + desired[k].value);
             seen[k] = true;
+            continue;
+        }
+        // A LATER duplicate of a managed key we already updated: drop it. cuttlefish
+        // is last-wins, so a stale duplicate left after the updated line would
+        // override our value at config-load time -- the exact silent-drift this
+        // sync is meant to prevent. Only managed keys are de-duplicated; unrelated
+        // duplicate config is none of our business and is preserved below.
+        if (Object.prototype.hasOwnProperty.call(desired, k) && seen[k]) {
             continue;
         }
 
@@ -527,6 +660,87 @@ function aws_auth_validate_overlay_form_only(method, body) {
         } else if (val !== null && val !== undefined && ('' + val).length > 0) {
             body[key] = val;
         }
+    }
+}
+
+// Body fields that have NO rabbitmq.conf representation and so must be ignored
+// when comparing the fields against the conf box (they can only ever live in the
+// form):
+//   * oauth scope_aliases (encoded in conf as dynamic sub-keys, not a single
+//     line) and authz_check (a runtime validation concept, never broker config).
+//   * ldap username (a runtime principal identifier, not config) and queries
+//     (the conf map has no auth_ldap.queries.* entries, so the query DSL is only
+//     ever entered in the form).
+// access_token / target are already handled via formOnly + overlay, so they are
+// not repeated here. Returns a shallow copy with these keys removed.
+var AWS_AUTH_VALIDATE_NONCONF_FIELDS = {
+    oauth: ['scope_aliases', 'authz_check'],
+    ldap: ['username', 'queries']
+};
+function aws_auth_validate_strip_nonconf(method, body) {
+    var drop = AWS_AUTH_VALIDATE_NONCONF_FIELDS[method] || [];
+    if (drop.length === 0 || !body || typeof body !== 'object') { return body; }
+    var out = {};
+    for (var k in body) {
+        if (!Object.prototype.hasOwnProperty.call(body, k)) { continue; }
+        if (drop.indexOf(k) !== -1) { continue; }
+        out[k] = body[k];
+    }
+    return out;
+}
+
+// Return a shallow copy of `body` with any top-level key whose value is boolean
+// `false` removed. Used ONLY to normalize the divergence comparison (see the
+// submit handler): to every backend an absent boolean equals an explicit
+// `false', so an unchecked box (key omitted) and a pasted `= false' (key present
+// as false) must compare equal. Non-boolean values and `true' are left as-is, so
+// this never masks a real difference. Nested objects (ssl_options) are not
+// descended into: their booleans (e.g. tls fail_if_no_peer_cert) are only ever
+// present when the operator set them, so the omit-vs-false asymmetry does not
+// arise there.
+function aws_auth_validate_strip_false_bools(body) {
+    if (!body || typeof body !== 'object') { return body; }
+    var out = {};
+    for (var k in body) {
+        if (!Object.prototype.hasOwnProperty.call(body, k)) { continue; }
+        if (body[k] === false) { continue; }
+        out[k] = body[k];
+    }
+    return out;
+}
+
+// The DOM inputs backing the non-conf fields for a method. Snapshot/restore lets
+// "Parse into fields" reload the conf-backed fields without discarding work the
+// pasted conf cannot express:
+//   * oauth: the scope_aliases textarea (a data-av-field with no conf key) and
+//     the authz_check sub-inputs (data-av-authz).
+//   * ldap: the username field and the four query textareas (data-av-query).
+function aws_auth_validate_nonconf_inputs(method) {
+    var $group = $('#aws-av-fields-' + method);
+    if (method === 'oauth') {
+        return $group.find('[data-av-field="scope_aliases"]')
+                     .add($group.find('[data-av-authz]'));
+    }
+    if (method === 'ldap') {
+        return $group.find('[data-av-field="username"]')
+                     .add($group.find('[data-av-query]'));
+    }
+    return $();
+}
+function aws_auth_validate_snapshot_nonconf(method) {
+    var snap = [];
+    aws_auth_validate_nonconf_inputs(method).each(function() {
+        var el = $(this);
+        snap.push({el: el, checkbox: el.is(':checkbox'),
+                   value: el.is(':checkbox') ? el.is(':checked') : el.val()});
+    });
+    return snap;
+}
+function aws_auth_validate_restore_nonconf(_method, snap) {
+    if (!snap) { return; }
+    for (var i = 0; i < snap.length; i++) {
+        var s = snap[i];
+        if (s.checkbox) { s.el.prop('checked', !!s.value); } else { s.el.val(s.value); }
     }
 }
 
@@ -594,8 +808,25 @@ $(document).on('click', '#aws-auth-validate-submit', function() {
         // they have no conf key and would otherwise read as a false divergence.
         var pastedBody = aws_auth_validate_conf_to_body(method, raw).body;
         aws_auth_validate_overlay_form_only(method, pastedBody);
-        if (aws_auth_validate_normalize_body(pastedBody) !==
-            aws_auth_validate_normalize_body(body)) {
+        // Some fields have no rabbitmq.conf representation at all (oauth
+        // scope_aliases uses dynamic sub-keys; authz_check is a runtime
+        // validation concept, not config). The conf box can never carry them, so
+        // comparing them would always read as divergence. Drop them from BOTH
+        // sides for the comparison only -- the real request body keeps them.
+        //
+        // Booleans are also normalized away when false: an unchecked box omits
+        // the key entirely while a pasted `use_ssl = false' parses to
+        // {use_ssl:false}. To the backend an absent boolean and an explicit
+        // `false' are identical (both mean "off"), so treating that difference as
+        // divergence would wrongly block Validate. Stripping false-valued keys
+        // from both sides makes the comparison match the backend's semantics
+        // without altering the request body actually sent.
+        var pastedCmp = aws_auth_validate_strip_false_bools(
+            aws_auth_validate_strip_nonconf(method, pastedBody));
+        var fieldsCmp = aws_auth_validate_strip_false_bools(
+            aws_auth_validate_strip_nonconf(method, body));
+        if (aws_auth_validate_normalize_body(pastedCmp) !==
+            aws_auth_validate_normalize_body(fieldsCmp)) {
             aws_auth_validate_config_status(
                 'The config box differs from the fields. Validation runs on the ' +
                 'fields -- click "Parse into fields" to use the pasted config, or ' +
@@ -768,11 +999,27 @@ function aws_auth_validate_req(method, body, confText) {
         req.setRequestHeader('authorization', header);
     }
     req.setRequestHeader('content-type', 'application/json');
+    // Register with the console's in-flight request list (when present) so a
+    // navigate-away aborts this PUT along with every other pending request --
+    // main.js abort loop walks outstanding_reqs. Guarded because it is an
+    // external console global; a standalone/older console without it still works
+    // (the request just is not centrally abortable, as before).
+    if (typeof outstanding_reqs !== 'undefined' && outstanding_reqs &&
+        typeof outstanding_reqs.push === 'function') {
+        outstanding_reqs.push(req);
+    }
     // The conf text on screen; on 204 this becomes the "last validated config"
     // so the copy button can flag later edits. The wire body stays JSON (the
     // endpoint's contract) -- only the textarea and clipboard use conf.
     req.onreadystatechange = function() {
         if (req.readyState !== 4) return;
+        // De-register from the console's in-flight list before rendering, so a
+        // completed request is not left for a later navigate-away to abort.
+        if (typeof outstanding_reqs !== 'undefined' && outstanding_reqs &&
+            typeof jQuery !== 'undefined') {
+            var ix = jQuery.inArray(req, outstanding_reqs);
+            if (ix !== -1) { outstanding_reqs.splice(ix, 1); }
+        }
         aws_auth_validate_render_result(req, confText);
     };
     req.send(JSON.stringify(body));
@@ -803,20 +1050,24 @@ function aws_auth_validate_render_result(req, confText) {
     var info = AWS_AUTH_VALIDATE_CATEGORY[category] ||
         {cls: 'status-red', text: 'Unexpected response (' + req.status + ').'};
     var html = '<div class="' + info.cls + '" style="padding:8px;">' +
-        '<strong>' + fmt_escape_html(category) + '</strong> &mdash; ' +
-        fmt_escape_html(info.text);
+        '<strong>' + aws_av_escape_html(category) + '</strong> &mdash; ' +
+        aws_av_escape_html(info.text);
     // The backend message is a fixed, non-secret string; safe to show, still escaped.
     if (message) {
-        html += '<br/><span class="argument">' + fmt_escape_html(message) + '</span>';
+        html += '<br/><span class="argument">' + aws_av_escape_html(message) + '</span>';
     }
     html += ' <span class="argument">(HTTP ' + (req.status || 'n/a') + ')</span></div>';
     $('#aws-auth-validate-result').html(html);
 }
 
-// Minimal HTML escaper (the console bundles fmt_escape_html in newer releases;
-// fall back to a local one so this works across broker versions).
-function fmt_escape_html(s) {
-    if (typeof window.fmt_escape_html === 'function' && window.fmt_escape_html !== fmt_escape_html) {
+// Minimal HTML escaper, private to this view. Named with the aws_av_ prefix (not
+// fmt_escape_html) so it never shadows the console's own global fmt_escape_html
+// (defined in the management plugin's formatters.js and relied on by other
+// views, e.g. for \n -> <br/> rendering). Prefer the console's global when it is
+// present so behavior matches the rest of the UI; fall back to this local
+// implementation on older brokers that do not bundle it.
+function aws_av_escape_html(s) {
+    if (typeof window.fmt_escape_html === 'function') {
         return window.fmt_escape_html(s);
     }
     return ('' + s).replace(/&/g, '&amp;').replace(/</g, '&lt;')

--- a/priv/www/js/aws_auth_validate.js
+++ b/priv/www/js/aws_auth_validate.js
@@ -1071,5 +1071,6 @@ function aws_av_escape_html(s) {
         return window.fmt_escape_html(s);
     }
     return ('' + s).replace(/&/g, '&amp;').replace(/</g, '&lt;')
-                   .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+                   .replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+                   .replace(/'/g, '&#39;');
 }

--- a/priv/www/js/aws_auth_validate.js
+++ b/priv/www/js/aws_auth_validate.js
@@ -9,14 +9,31 @@
 // The endpoint returns a fixed, category-only result (never raw backend detail,
 // per the endpoint's R4 invariant): 204 success, or 4xx/5xx with a JSON body
 // {error: <category>, message: <fixed text>}. This UI submits a per-method form
-// as a JSON body and renders that category as a friendly banner. It never puts
-// secrets (password_arn, client_secret, ARNs) in the URL/hash or localStorage.
+// as a JSON body and renders that category as a friendly banner. Operators can
+// also paste/edit the request in rabbitmq.conf dotted-key form (the same lines
+// as the tutorials); the UI converts between that and the JSON wire body. It
+// never puts secrets (password_arn, client_secret, ARNs) in the URL/hash or
+// localStorage.
 
 dispatcher_add(function(sammy) {
     sammy.get('#/auth-validate', function() {
+        // Fresh page: no config has been validated yet in this view. render() is
+        // async (it fetches + injects the template), so the actual preview
+        // priming happens in aws_auth_validate_on_render, invoked by an inline
+        // script at the bottom of the template once the DOM exists.
+        AWS_AUTH_VALIDATE_LAST_VALID = null;
         render({}, 'aws_auth_validate', '#/auth-validate');
     });
 });
+
+// Invoked by the template's inline script after the console injects it. Sets the
+// preview placeholder to the full field template for the initially-selected
+// method so every possible field is visible up front as a hint.
+function aws_auth_validate_on_render() {
+    AWS_AUTH_VALIDATE_LAST_VALID = null;
+    aws_auth_validate_config_status('', '');
+    aws_auth_validate_show_template($('#aws-auth-validate-method').val());
+}
 
 // Admin-gated tab. The tag matches the endpoint's default required_user_tag
 // (administrator). This is a client-side visibility hint only; the endpoint's
@@ -102,14 +119,557 @@ function aws_auth_validate_build_body(method) {
     return body;
 }
 
-// Submit the current method form. Bound as a delegated click so it survives
-// re-renders. Never a GET/route param -- the body may carry an ARN.
+// The JSON body that most recently returned 204, as a normalized string. Used
+// so the "Copy config" button can tell the operator whether the text they are
+// about to copy is still the exact body that passed validation, or whether they
+// have edited it since. Reset on every render (see the sammy route).
+var AWS_AUTH_VALIDATE_LAST_VALID = null;
+
+// Populate the visible method form from a request-body object -- the inverse of
+// aws_auth_validate_build_body. Existing field values for the method are cleared
+// first so the form reflects exactly what is in the object (no stale leftovers).
+// A "method" key, if present, selects the matching method tab and is not treated
+// as a form field (the real endpoint takes the method from the URL, not the body).
+function aws_auth_validate_populate_form(method, body) {
+    var $form = $('#aws-auth-validate-form');
+
+    // Clear the currently-visible method's fields and the shared ssl_options.
+    $('#aws-av-fields-' + method).find('[data-av-field]').each(function() {
+        var el = $(this);
+        if (el.is(':checkbox')) { el.prop('checked', false); } else { el.val(''); }
+    });
+    $form.find('[data-av-ssl]').each(function() {
+        var el = $(this);
+        if (el.is(':checkbox')) { el.prop('checked', false); } else { el.val(''); }
+    });
+
+    if (!body || typeof body !== 'object') { return; }
+
+    var ssl = (body.ssl_options && typeof body.ssl_options === 'object') ? body.ssl_options : {};
+
+    // Top-level fields for the selected method.
+    $('#aws-av-fields-' + method).find('[data-av-field]').each(function() {
+        var el = $(this);
+        var key = el.attr('data-av-field');
+        if (!Object.prototype.hasOwnProperty.call(body, key)) { return; }
+        var val = body[key];
+        if (el.is(':checkbox')) {
+            el.prop('checked', val === true || val === 'true');
+        } else if (key === 'servers' && $.isArray(val)) {
+            el.val(val.join(' '));
+        } else if (val !== null && val !== undefined) {
+            el.val('' + val);
+        }
+    });
+
+    // Shared ssl_options sub-fields.
+    $form.find('[data-av-ssl]').each(function() {
+        var el = $(this);
+        var key = el.attr('data-av-ssl');
+        if (!Object.prototype.hasOwnProperty.call(ssl, key)) { return; }
+        var val = ssl[key];
+        if (el.is(':checkbox')) {
+            el.prop('checked', val === true || val === 'true');
+        } else if (val !== null && val !== undefined) {
+            el.val('' + val);
+        }
+    });
+}
+
+// Mapping between rabbitmq.conf dotted keys (what operators paste from the
+// tutorials) and the endpoint's request-body fields. The conf format is NOT 1:1
+// with the request body -- e.g. the user DN lives at auth_ldap.dn_lookup_bind.user_dn
+// in conf but is just "user_dn" in the body, and secret/cert ARNs are namespaced
+// under aws.arns.* -- so each method carries an explicit table.
+//
+// Each entry maps an exact (lower-cased) conf key to a body descriptor:
+//   path: nested location in the request body
+//   type: 'string' | 'int' | 'bool' (drives parsing and rendering)
+// `list` handles the indexed server list (auth_ldap.servers.1, .2, ...).
+// `formOnly` lists fields that have no rabbitmq.conf representation (a runtime
+// access token, a listener name) -- they are collected from the form but never
+// emitted into or read from the conf text.
+// The `ex` on each descriptor is a placeholder example used only to build the
+// editable template shown in the preview (see aws_auth_validate_template). It is
+// never sent -- the operator replaces it before validating.
+var AWS_AUTH_VALIDATE_CONF = {
+    ldap: {
+        backend: 'ldap',
+        list: {re: /^auth_ldap\.servers\.\d+$/, idxRe: /\.(\d+)$/, path: ['servers'], keyBase: 'auth_ldap.servers', ex: 'ldap.example.com'},
+        map: {
+            'auth_ldap.port':                                   {path: ['port'], type: 'int', ex: '636'},
+            'auth_ldap.use_ssl':                                {path: ['use_ssl'], type: 'bool', ex: 'true'},
+            'auth_ldap.use_starttls':                           {path: ['use_starttls'], type: 'bool', ex: 'false'},
+            'auth_ldap.dn_lookup_bind.user_dn':                 {path: ['user_dn'], type: 'string', ex: 'cn=admin,dc=example,dc=com'},
+            'auth_ldap.dn_lookup_base':                         {path: ['dn_lookup_base'], type: 'string', ex: 'dc=example,dc=com'},
+            'auth_ldap.dn_lookup_attribute':                    {path: ['dn_lookup_attribute'], type: 'string', ex: 'sAMAccountName'},
+            'auth_ldap.ssl_options.verify':                     {path: ['ssl_options', 'verify'], type: 'string', ex: 'verify_peer'},
+            'auth_ldap.ssl_options.sni':                        {path: ['ssl_options', 'sni'], type: 'string', ex: 'ldap.example.com'},
+            'aws.arns.auth_ldap.dn_lookup_bind.password':       {path: ['password_arn'], type: 'string', ex: 'arn:aws:secretsmanager:us-west-2:111122223333:secret:RabbitMqDnLookupUserPassword'},
+            'aws.arns.auth_ldap.ssl_options.cacertfile':        {path: ['ssl_options', 'cacertfile_arn'], type: 'string', ex: 'arn:aws:s3:::my-bucket/ca-cert.pem'},
+            'aws.arns.auth_ldap.ssl_options.certfile':          {path: ['ssl_options', 'certfile_arn'], type: 'string', ex: 'arn:aws:s3:::my-bucket/client-cert.pem'},
+            'aws.arns.auth_ldap.ssl_options.keyfile':           {path: ['ssl_options', 'keyfile_arn'], type: 'string', ex: 'arn:aws:secretsmanager:us-west-2:111122223333:secret:RabbitMqClientKey'}
+        },
+        formOnly: []
+    },
+    http: {
+        backend: 'http',
+        map: {
+            'auth_http.user_path':                              {path: ['user_path'], type: 'string', ex: 'https://auth.example.com/auth/user'},
+            'auth_http.vhost_path':                             {path: ['vhost_path'], type: 'string', ex: 'https://auth.example.com/auth/vhost'},
+            'auth_http.resource_path':                          {path: ['resource_path'], type: 'string', ex: 'https://auth.example.com/auth/resource'},
+            'auth_http.topic_path':                             {path: ['topic_path'], type: 'string', ex: 'https://auth.example.com/auth/topic'},
+            'auth_http.http_method':                            {path: ['http_method'], type: 'string', ex: 'post'},
+            'auth_http.ssl_options.verify':                     {path: ['ssl_options', 'verify'], type: 'string', ex: 'verify_peer'},
+            'auth_http.ssl_options.sni':                        {path: ['ssl_options', 'sni'], type: 'string', ex: 'auth.example.com'},
+            'aws.arns.auth_http.ssl_options.cacertfile':        {path: ['ssl_options', 'cacertfile_arn'], type: 'string', ex: 'arn:aws:s3:::my-bucket/ca-cert.pem'},
+            'aws.arns.auth_http.ssl_options.certfile':          {path: ['ssl_options', 'certfile_arn'], type: 'string', ex: 'arn:aws:s3:::my-bucket/client-cert.pem'},
+            'aws.arns.auth_http.ssl_options.keyfile':           {path: ['ssl_options', 'keyfile_arn'], type: 'string', ex: 'arn:aws:secretsmanager:us-west-2:111122223333:secret:RabbitMqClientKey'}
+        },
+        formOnly: []
+    },
+    oauth: {
+        backend: 'oauth2',
+        map: {
+            'auth_oauth2.jwks_uri':                             {path: ['jwks_uri'], type: 'string', ex: 'https://idp.example.com/.well-known/jwks.json'},
+            'auth_oauth2.issuer':                               {path: ['issuer'], type: 'string', ex: 'https://idp.example.com/'},
+            'auth_oauth2.resource_server_id':                   {path: ['resource_server_id'], type: 'string', ex: 'rabbitmq'},
+            'auth_oauth2.ssl_options.verify':                   {path: ['ssl_options', 'verify'], type: 'string', ex: 'verify_peer'},
+            'auth_oauth2.ssl_options.sni':                      {path: ['ssl_options', 'sni'], type: 'string', ex: 'idp.example.com'},
+            'aws.arns.auth_oauth2.ssl_options.cacertfile':      {path: ['ssl_options', 'cacertfile_arn'], type: 'string', ex: 'arn:aws:s3:::my-bucket/ca-cert.pem'},
+            'aws.arns.auth_oauth2.ssl_options.certfile':        {path: ['ssl_options', 'certfile_arn'], type: 'string', ex: 'arn:aws:s3:::my-bucket/client-cert.pem'},
+            'aws.arns.auth_oauth2.ssl_options.keyfile':         {path: ['ssl_options', 'keyfile_arn'], type: 'string', ex: 'arn:aws:secretsmanager:us-west-2:111122223333:secret:RabbitMqClientKey'}
+        },
+        // access_token is a runtime bearer token, never part of rabbitmq.conf.
+        formOnly: ['access_token'],
+        notes: ['# access_token: paste it into the "Access token" form field above (a runtime token, not a rabbitmq.conf key).']
+    },
+    tls: {
+        // TLS validation targets a broker listener; the mTLS/SSL tutorials
+        // configure ssl_options at the top level (no auth_<backend> prefix).
+        backend: null,
+        map: {
+            'ssl_options.verify':                               {path: ['ssl_options', 'verify'], type: 'string', ex: 'verify_peer'},
+            'ssl_options.sni':                                  {path: ['ssl_options', 'sni'], type: 'string', ex: 'listener.example.com'},
+            'aws.arns.ssl_options.cacertfile':                  {path: ['ssl_options', 'cacertfile_arn'], type: 'string', ex: 'arn:aws:s3:::my-bucket/ca-cert.pem'},
+            'aws.arns.ssl_options.certfile':                    {path: ['ssl_options', 'certfile_arn'], type: 'string', ex: 'arn:aws:s3:::my-bucket/client-cert.pem'},
+            'aws.arns.ssl_options.keyfile':                     {path: ['ssl_options', 'keyfile_arn'], type: 'string', ex: 'arn:aws:secretsmanager:us-west-2:111122223333:secret:RabbitMqClientKey'}
+        },
+        // `target` names the listener under test; it is a validation concept,
+        // not a rabbitmq.conf key.
+        formOnly: ['target'],
+        notes: ['# target: enter the listener name in the "Target" form field above (a validation concept, not a rabbitmq.conf key).']
+    }
+};
+
+// aws.arns.assume_role_arn is read from BROKER config, never from the request
+// body: accepting a request-supplied role would let one call swap the broker's
+// AWS credentials (confused-deputy). We recognize the key so we can tell the
+// operator we skipped it, and never place it in the request body.
+var AWS_AUTH_VALIDATE_ASSUME_ROLE_KEY = 'aws.arns.assume_role_arn';
+
+// Set a nested value at obj[path[0]][path[1]]..., creating objects as needed.
+function aws_auth_validate_set_path(obj, path, val) {
+    var cur = obj;
+    for (var i = 0; i < path.length - 1; i++) {
+        if (typeof cur[path[i]] !== 'object' || cur[path[i]] === null) {
+            cur[path[i]] = {};
+        }
+        cur = cur[path[i]];
+    }
+    cur[path[path.length - 1]] = val;
+}
+
+// Read a nested value; returns undefined if any segment is missing.
+function aws_auth_validate_get_path(obj, path) {
+    var cur = obj;
+    for (var i = 0; i < path.length; i++) {
+        if (cur === null || typeof cur !== 'object' ||
+            !Object.prototype.hasOwnProperty.call(cur, path[i])) {
+            return undefined;
+        }
+        cur = cur[path[i]];
+    }
+    return cur;
+}
+
+// Coerce a raw conf value string to the descriptor's type. Only the value is
+// treated case-sensitively (ARNs, DNs); the KEY is lower-cased by the caller.
+function aws_auth_validate_coerce(type, raw) {
+    if (type === 'int') {
+        var n = parseInt(raw, 10);
+        return isNaN(n) ? undefined : n;
+    }
+    if (type === 'bool') {
+        var l = raw.toLowerCase();
+        if (l === 'true') { return true; }
+        if (l === 'false') { return false; }
+        return undefined;
+    }
+    return raw;
+}
+
+// Parse rabbitmq.conf dotted-key text into a request body for `method`.
+// Returns {body, servers, skippedAssumeRole, unknown} where `unknown` counts
+// recognized-but-not-applicable lines (e.g. keys for a different method).
+// Comment (#) and blank lines are ignored. auth_backends.* lines are ignored
+// (the endpoint takes the method from the URL). Unknown keys are counted, not
+// rejected -- the operator may paste a fuller config than one method uses.
+function aws_auth_validate_conf_to_body(method, text) {
+    var spec = AWS_AUTH_VALIDATE_CONF[method];
+    var body = {};
+    var servers = {};
+    var skippedAssumeRole = false;
+    var unknown = 0;
+    var lines = ('' + text).split(/\r?\n/);
+    for (var i = 0; i < lines.length; i++) {
+        var line = lines[i].trim();
+        if (line.length === 0 || line.charAt(0) === '#') { continue; }
+        var eq = line.indexOf('=');
+        if (eq === -1) { unknown++; continue; }
+        var key = line.substring(0, eq).trim().toLowerCase();
+        var val = line.substring(eq + 1).trim();
+        if (key === AWS_AUTH_VALIDATE_ASSUME_ROLE_KEY) { skippedAssumeRole = true; continue; }
+        if (key.indexOf('auth_backends.') === 0 || key === 'auth_backends') { continue; }
+        if (spec.list && spec.list.re.test(key)) {
+            var m = key.match(spec.list.idxRe);
+            var idx = m ? parseInt(m[1], 10) : (Object.keys(servers).length + 1);
+            servers[idx] = val;
+            continue;
+        }
+        var desc = spec.map[key];
+        if (!desc) { unknown++; continue; }
+        var coerced = aws_auth_validate_coerce(desc.type, val);
+        if (coerced !== undefined) { aws_auth_validate_set_path(body, desc.path, coerced); }
+    }
+    // Assemble the indexed server list in numeric order.
+    var idxs = Object.keys(servers).map(Number).sort(function(a, b) { return a - b; });
+    if (idxs.length > 0) {
+        body.servers = idxs.map(function(k) { return servers[k]; })
+                           .filter(function(s) { return ('' + s).length > 0; });
+    }
+    return {body: body, skippedAssumeRole: skippedAssumeRole, unknown: unknown};
+}
+
+// Render a request body back into rabbitmq.conf dotted-key text for `method`.
+// Emits an auth_backends header (except tls, which has no auth backend), then
+// each mapped key that is present in the body, in table order. Booleans render
+// true/false; the server list expands to auth_ldap.servers.N lines.
+function aws_auth_validate_body_to_conf(method, body) {
+    var spec = AWS_AUTH_VALIDATE_CONF[method];
+    var out = [];
+    if (spec.backend) { out.push('auth_backends.1 = ' + spec.backend); }
+    // Server list first (mirrors the tutorial ordering).
+    if (spec.list && $.isArray(body.servers)) {
+        for (var s = 0; s < body.servers.length; s++) {
+            out.push(spec.list.keyBase + '.' + (s + 1) + ' = ' + body.servers[s]);
+        }
+    }
+    for (var key in spec.map) {
+        if (!Object.prototype.hasOwnProperty.call(spec.map, key)) { continue; }
+        var desc = spec.map[key];
+        var v = aws_auth_validate_get_path(body, desc.path);
+        if (v === undefined || v === null || ('' + v).length === 0) { continue; }
+        if (desc.type === 'bool') { v = v ? 'true' : 'false'; }
+        out.push(key + ' = ' + v);
+    }
+    return out.join('\n');
+}
+
+// Merge form values into EXISTING rabbitmq.conf text, touching only the keys
+// this method's form manages and preserving everything else verbatim (comments,
+// blank lines, non-auth config, aws.arns.assume_role_arn, and keys belonging to
+// other methods). This is what "Update config from fields" uses so it does not
+// wipe unrelated lines.
+//
+// Rules:
+//  - A managed scalar key with a non-empty form value updates the existing line
+//    in place (keeping its original indentation and key text), or is appended if
+//    absent.
+//  - A managed key the form left empty is NOT removed -- the existing line, if
+//    any, is preserved untouched.
+//  - The server list (auth_ldap.servers.N) is treated as one managed block: when
+//    the form has servers, the run of existing server lines is replaced in place
+//    with the form's set; when the form has none, existing server lines are kept.
+//  - An auth_backends header is added only if the method has a backend and no
+//    auth_backends line exists at all (never rewrites an operator's header).
+function aws_auth_validate_merge_conf(method, existingText, body) {
+    var spec = AWS_AUTH_VALIDATE_CONF[method];
+
+    // Desired scalar key -> rendered value, for managed keys the form supplies.
+    var desired = {};
+    for (var key in spec.map) {
+        if (!Object.prototype.hasOwnProperty.call(spec.map, key)) { continue; }
+        var desc = spec.map[key];
+        var v = aws_auth_validate_get_path(body, desc.path);
+        if (v === undefined || v === null || ('' + v).length === 0) { continue; }
+        if (desc.type === 'bool') { v = v ? 'true' : 'false'; }
+        desired[key.toLowerCase()] = {canonical: key, value: '' + v};
+    }
+
+    // Desired server lines (only when the form actually has servers).
+    var hasServers = spec.list && $.isArray(body.servers) && body.servers.length > 0;
+    var serverLines = [];
+    if (hasServers) {
+        for (var s = 0; s < body.servers.length; s++) {
+            serverLines.push(spec.list.keyBase + '.' + (s + 1) + ' = ' + body.servers[s]);
+        }
+    }
+
+    var lines = ('' + existingText).split(/\r?\n/);
+    var out = [];
+    var seen = {};
+    var serverBlockEmitted = false;
+    var sawAuthBackends = false;
+
+    for (var i = 0; i < lines.length; i++) {
+        var line = lines[i];
+        var trimmed = line.trim();
+        // Preserve comments, blank lines, and anything without '=' verbatim.
+        if (trimmed.length === 0 || trimmed.charAt(0) === '#') { out.push(line); continue; }
+        var eq = trimmed.indexOf('=');
+        if (eq === -1) { out.push(line); continue; }
+        var k = trimmed.substring(0, eq).trim().toLowerCase();
+
+        if (k.indexOf('auth_backends.') === 0 || k === 'auth_backends') {
+            sawAuthBackends = true;
+            out.push(line);
+            continue;
+        }
+
+        // Server-list line: replace the whole run once with the form's servers.
+        if (spec.list && spec.list.re.test(k)) {
+            if (hasServers) {
+                if (!serverBlockEmitted) {
+                    for (var j = 0; j < serverLines.length; j++) { out.push(serverLines[j]); }
+                    serverBlockEmitted = true;
+                }
+                // Drop the original server line (replaced by the block above).
+            } else {
+                out.push(line); // form has no servers -- leave existing untouched
+            }
+            continue;
+        }
+
+        // Managed scalar key the form supplies: update value in place, keeping
+        // the operator's original indentation and key spelling.
+        if (Object.prototype.hasOwnProperty.call(desired, k) && !seen[k]) {
+            var leadingWs = line.match(/^\s*/)[0];
+            var origKey = trimmed.substring(0, eq).trim();
+            out.push(leadingWs + origKey + ' = ' + desired[k].value);
+            seen[k] = true;
+            continue;
+        }
+
+        // Any other line (unrelated config, another method's keys, a managed key
+        // the form left empty, assume_role) is preserved verbatim.
+        out.push(line);
+    }
+
+    // Append managed keys the form supplied that were not already present, in
+    // table order. Prepend an auth_backends header if none existed.
+    var appended = [];
+    if (spec.backend && !sawAuthBackends) {
+        appended.push('auth_backends.1 = ' + spec.backend);
+    }
+    if (hasServers && !serverBlockEmitted) {
+        for (var a = 0; a < serverLines.length; a++) { appended.push(serverLines[a]); }
+    }
+    for (var mkey in spec.map) {
+        if (!Object.prototype.hasOwnProperty.call(spec.map, mkey)) { continue; }
+        var lk = mkey.toLowerCase();
+        if (Object.prototype.hasOwnProperty.call(desired, lk) && !seen[lk]) {
+            appended.push(mkey + ' = ' + desired[lk].value);
+            seen[lk] = true;
+        }
+    }
+
+    if (appended.length > 0) {
+        // Separate appended keys from preserved content with a blank line, unless
+        // the existing text is empty or already ends blank.
+        while (out.length > 0 && out[out.length - 1].trim().length === 0) { out.pop(); }
+        if (out.length > 0) { out.push(''); }
+        out = out.concat(appended);
+    }
+
+    return out.join('\n');
+}
+
+// Overlay form-only fields (those with no rabbitmq.conf key -- oauth access_token,
+// tls target) onto a body parsed from conf text, so a value typed into the form
+// is not lost when the textarea drives the request.
+function aws_auth_validate_overlay_form_only(method, body) {
+    var spec = AWS_AUTH_VALIDATE_CONF[method];
+    var fields = spec.formOnly || [];
+    for (var i = 0; i < fields.length; i++) {
+        var key = fields[i];
+        if (Object.prototype.hasOwnProperty.call(body, key)) { continue; }
+        var el = $('#aws-av-fields-' + method).find('[data-av-field="' + key + '"]');
+        if (el.length === 0) { continue; }
+        var val = el.is(':checkbox') ? el.is(':checked') : el.val();
+        if (el.is(':checkbox')) {
+            if (val) { body[key] = true; }
+        } else if (val !== null && val !== undefined && ('' + val).length > 0) {
+            body[key] = val;
+        }
+    }
+}
+
+// Build an editable rabbitmq.conf template listing EVERY possible key for a
+// method, each pre-filled with a placeholder example value (the descriptor `ex`).
+// Shown in the preview so an operator sees the full shape for the selected
+// method and can edit values in place. This is a starting point, not a validated
+// config -- values are examples the operator replaces.
+function aws_auth_validate_template(method) {
+    var spec = AWS_AUTH_VALIDATE_CONF[method];
+    var out = [];
+    if (spec.backend) { out.push('auth_backends.1 = ' + spec.backend); }
+    if (spec.list) {
+        out.push(spec.list.keyBase + '.1 = ' + spec.list.ex);
+    }
+    for (var key in spec.map) {
+        if (!Object.prototype.hasOwnProperty.call(spec.map, key)) { continue; }
+        out.push(key + ' = ' + spec.map[key].ex);
+    }
+    if (spec.notes && spec.notes.length > 0) {
+        out.push('');
+        for (var i = 0; i < spec.notes.length; i++) { out.push(spec.notes[i]); }
+    }
+    return out.join('\n');
+}
+
+// Show the method's full template as the textarea PLACEHOLDER (the greyed-out
+// hint shown only while the box is empty). This never becomes content: the
+// moment the operator types, their text replaces the hint, and switching methods
+// just updates the hint. So there is nothing to clobber and no guard state.
+function aws_auth_validate_show_template(method) {
+    $('#aws-auth-validate-config').attr('placeholder', aws_auth_validate_template(method));
+}
+
+// Put rabbitmq.conf text into the config textarea.
+function aws_auth_validate_set_config_text(text) {
+    $('#aws-auth-validate-config').val(text);
+}
+
+// Set the small status line next to the copy/parse buttons.
+function aws_auth_validate_config_status(text, cls) {
+    $('#aws-auth-validate-copy-status')
+        .text(text ? (' ' + text) : '')
+        .attr('class', 'argument' + (cls ? ' ' + cls : ''));
+}
+
+// Submit the current method. The rabbitmq.conf textarea is authoritative when it
+// holds content (an operator may have pasted or hand-edited config lines), so we
+// parse and send that; otherwise we build the body from the visible form and
+// reflect it back into the textarea as conf so what was validated is always
+// visible. Form-only fields (oauth access_token, tls target) have no conf key,
+// so they are always overlaid from the form. Bound as a delegated click so it
+// survives re-renders. Never a GET/route param -- the body may carry an ARN.
 $(document).on('click', '#aws-auth-validate-submit', function() {
     var method = $('#aws-auth-validate-method').val();
-    var body = aws_auth_validate_build_body(method);
-    aws_auth_validate_req(method, body);
+    var raw = ('' + $('#aws-auth-validate-config').val()).trim();
+    var body;
+    if (raw.length > 0) {
+        var parsed = aws_auth_validate_conf_to_body(method, raw);
+        body = parsed.body;
+        // Form-only fields never appear in conf; take them from the form.
+        aws_auth_validate_overlay_form_only(method, body);
+    } else {
+        body = aws_auth_validate_build_body(method);
+        aws_auth_validate_set_config_text(aws_auth_validate_body_to_conf(method, body));
+    }
+    // Remember the exact conf text on screen so a 204 can mark it validated and
+    // the copy button can flag later edits. If the operator pasted conf we keep
+    // their text verbatim (comments and all); otherwise it is the generated conf.
+    var confText = '' + $('#aws-auth-validate-config').val();
+    aws_auth_validate_req(method, body, confText);
     return false;
 });
+
+// Parse the textarea rabbitmq.conf into the form fields. Lines that do not apply
+// to the selected method are ignored; aws.arns.assume_role_arn is skipped (read
+// from broker config, never the request).
+$(document).on('click', '#aws-auth-validate-parse', function() {
+    var raw = ('' + $('#aws-auth-validate-config').val()).trim();
+    if (raw.length === 0) {
+        aws_auth_validate_config_status('Nothing to parse: the config box is empty.', 'status-yellow');
+        return false;
+    }
+    var method = $('#aws-auth-validate-method').val();
+    var parsed = aws_auth_validate_conf_to_body(method, raw);
+    aws_auth_validate_populate_form(method, parsed.body);
+    var msg = 'Parsed into the ' + method + ' fields.';
+    if (parsed.skippedAssumeRole) {
+        msg += ' Skipped aws.arns.assume_role_arn (read from broker config).';
+    }
+    if (parsed.unknown > 0) {
+        msg += ' ' + parsed.unknown + ' line(s) did not apply to ' + method + '.';
+    }
+    aws_auth_validate_config_status(msg,
+        (parsed.skippedAssumeRole || parsed.unknown > 0) ? 'status-yellow' : 'status-green');
+    return false;
+});
+
+// Rebuild the textarea rabbitmq.conf from the current form fields.
+$(document).on('click', '#aws-auth-validate-build', function() {
+    var method = $('#aws-auth-validate-method').val();
+    var body = aws_auth_validate_build_body(method);
+    var existing = '' + $('#aws-auth-validate-config').val();
+    // Merge into whatever is already in the box: update/add only this method's
+    // managed keys, preserve every other line (comments, blank lines, unrelated
+    // config, assume_role, other methods' keys).
+    aws_auth_validate_set_config_text(aws_auth_validate_merge_conf(method, existing, body));
+    aws_auth_validate_config_status('Merged the form fields into the config (other lines preserved).', 'status-green');
+    return false;
+});
+
+// Copy the current config text to the clipboard. Warns if the text has been
+// edited since the last successful (204) validation, so an operator does not
+// accidentally save a config that never passed.
+$(document).on('click', '#aws-auth-validate-copy', function() {
+    var text = '' + $('#aws-auth-validate-config').val();
+    if (text.trim().length === 0) {
+        aws_auth_validate_config_status('Nothing to copy: the config box is empty.', 'status-yellow');
+        return false;
+    }
+    var edited = (AWS_AUTH_VALIDATE_LAST_VALID === null) ||
+        (text !== AWS_AUTH_VALIDATE_LAST_VALID);
+    var note = edited
+        ? 'Copied (note: this differs from the last validated config).'
+        : 'Copied the validated config.';
+    var noteCls = edited ? 'status-yellow' : 'status-green';
+    aws_auth_validate_copy_text(text, function(ok) {
+        if (ok) {
+            aws_auth_validate_config_status(note, noteCls);
+        } else {
+            aws_auth_validate_config_status('Could not access the clipboard; select the text and copy manually.', 'status-red');
+        }
+    });
+    return false;
+});
+
+// Clipboard copy with a graceful fallback for older WebViews without the async
+// Clipboard API. Invokes cb(true|false).
+function aws_auth_validate_copy_text(text, cb) {
+    if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+        navigator.clipboard.writeText(text).then(function() { cb(true); },
+                                                  function() { cb(false); });
+        return;
+    }
+    try {
+        var ta = document.createElement('textarea');
+        ta.value = text;
+        ta.style.position = 'fixed';
+        ta.style.left = '-9999px';
+        document.body.appendChild(ta);
+        ta.select();
+        var ok = document.execCommand('copy');
+        document.body.removeChild(ta);
+        cb(ok);
+    } catch (e) {
+        cb(false);
+    }
+}
 
 // Show/hide the per-method field groups when the method selector changes.
 $(document).on('change', '#aws-auth-validate-method', function() {
@@ -117,13 +677,20 @@ $(document).on('change', '#aws-auth-validate-method', function() {
     $('.aws-av-method-fields').hide();
     $('#aws-av-fields-' + method).show();
     $('#aws-auth-validate-result').empty();
+    // A prior 204 was for the previous method's body; it no longer applies.
+    AWS_AUTH_VALIDATE_LAST_VALID = null;
+    aws_auth_validate_config_status('', '');
+    // Update the preview placeholder to the newly-selected method's template.
+    // This only changes the greyed-out hint, so any content the operator typed
+    // is untouched.
+    aws_auth_validate_show_template(method);
 });
 
 // Issue the PUT and render the fixed category. Modeled on the reference plugin's
 // rqm_with_req: a hand-rolled request so we can inspect the status code and the
 // {error, message} body directly, rather than routing it through the management
 // plugin's CRUD helpers (which would surface a generic proxy error).
-function aws_auth_validate_req(method, body) {
+function aws_auth_validate_req(method, body, confText) {
     if (typeof has_auth_credentials === 'function' && !has_auth_credentials()) {
         location.reload();
         return;
@@ -135,19 +702,29 @@ function aws_auth_validate_req(method, body) {
         req.setRequestHeader('authorization', header);
     }
     req.setRequestHeader('content-type', 'application/json');
+    // The conf text on screen; on 204 this becomes the "last validated config"
+    // so the copy button can flag later edits. The wire body stays JSON (the
+    // endpoint's contract) -- only the textarea and clipboard use conf.
     req.onreadystatechange = function() {
         if (req.readyState !== 4) return;
-        aws_auth_validate_render_result(req);
+        aws_auth_validate_render_result(req, confText);
     };
     req.send(JSON.stringify(body));
 }
 
-function aws_auth_validate_render_result(req) {
+function aws_auth_validate_render_result(req, confText) {
     var category, message;
     if (req.status === 0) {
         category = 'transport_error';
     } else if (req.status === 204) {
         category = 'success';
+        // Record the exact conf text that passed so the copy button knows
+        // whether later edits diverged from it. The textarea already holds this
+        // text (we do not overwrite the operator's pasted comments/formatting).
+        if (typeof confText === 'string') {
+            AWS_AUTH_VALIDATE_LAST_VALID = confText;
+            aws_auth_validate_config_status('This config validated -- use Copy config to save it.', 'status-green');
+        }
     } else {
         try {
             var data = JSON.parse(req.responseText);

--- a/priv/www/js/aws_auth_validate.js
+++ b/priv/www/js/aws_auth_validate.js
@@ -1,0 +1,181 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// vim:ft=javascript:
+// -*- mode: javascript; -*-
+
+// Management-console UI for the AWS auth-validation endpoint
+//   PUT /api/aws/auth/validate/:method
+//
+// The endpoint returns a fixed, category-only result (never raw backend detail,
+// per the endpoint's R4 invariant): 204 success, or 4xx/5xx with a JSON body
+// {error: <category>, message: <fixed text>}. This UI submits a per-method form
+// as a JSON body and renders that category as a friendly banner. It never puts
+// secrets (password_arn, client_secret, ARNs) in the URL/hash or localStorage.
+
+dispatcher_add(function(sammy) {
+    sammy.get('#/auth-validate', function() {
+        render({}, 'aws_auth_validate', '#/auth-validate');
+    });
+});
+
+// Admin-gated tab. The tag matches the endpoint's default required_user_tag
+// (administrator). This is a client-side visibility hint only; the endpoint's
+// is_authorized/2 remains the authoritative gate, and an operator who lowers
+// aws.auth_validation.required_user_tag does not change this hint.
+NAVIGATION['Admin'][0]['Auth Validation'] = ['#/auth-validate', "administrator"];
+
+// The four methods and the request-body fields each accepts. Field names mirror
+// the backend allowed_fields/0 exactly; the registry filters the body to these,
+// so an unknown field is silently dropped rather than rejected.
+var AWS_AUTH_VALIDATE_METHODS = ['ldap', 'http', 'oauth', 'tls'];
+
+// Human-readable copy for each fixed response category the endpoint can return.
+// Keyed by the `error` value in the JSON body (plus synthetic keys for the
+// success and transport cases). Kept in one place so the .ejs and the banner
+// stay in sync.
+var AWS_AUTH_VALIDATE_CATEGORY = {
+    success:            {cls: 'status-green',  text: 'Validation succeeded (204).'},
+    input_invalid:      {cls: 'status-red',    text: 'Input invalid: the request failed pure validation before any connection.'},
+    connection_failed:  {cls: 'status-red',    text: 'Connection failed: the target could not be reached.'},
+    tls_failed:         {cls: 'status-red',    text: 'TLS failed: handshake or certificate verification did not succeed.'},
+    query_invalid:      {cls: 'status-red',    text: 'Query invalid: an authorization query could not be parsed.'},
+    auth_failed:        {cls: 'status-yellow', text: 'Auth failed: the server was reached but did not authenticate/respond as expected.'},
+    config_conflict:    {cls: 'status-yellow', text: 'Config conflict: the supplied options are mutually inconsistent (for example an ARN is referenced with no assume_role configured).'},
+    authz_unverified:   {cls: 'status-yellow', text: 'Authorization unverified: a configured authorization check could not be confirmed.'},
+    method_disabled:    {cls: 'status-yellow', text: 'Method disabled: enable it with aws.auth_validation.enabled_methods.<method> = true (every method is opt-in).'},
+    unknown_method:     {cls: 'status-red',    text: 'Unknown method.'},
+    insufficient_user_tag: {cls: 'status-red', text: 'Your user lacks the tag required to call this endpoint.'},
+    capacity_exhausted: {cls: 'status-yellow', text: 'Service at capacity or not ready. Try again shortly.'},
+    internal_error:     {cls: 'status-red',    text: 'Internal error during validation.'},
+    transport_error:    {cls: 'status-red',    text: 'Could not reach the management API.'}
+};
+
+// Read the visible method form into a JSON request body. Only non-empty fields
+// are included so an omitted optional field keeps the backend default. ssl_options
+// is collected from a small fixed set of sub-fields; ARN fields nest under it to
+// match the backend shape (ssl_options.cacertfile_arn etc.).
+function aws_auth_validate_build_body(method) {
+    var body = {};
+    var $form = $('#aws-auth-validate-form');
+
+    // Flat top-level fields per method. A checkbox contributes a boolean true
+    // only when checked (an unchecked box is omitted so the backend keeps its
+    // default); every other input contributes its non-empty value.
+    $form.find('[data-av-field]').each(function() {
+        var el = $(this);
+        var key = el.attr('data-av-field');
+        if (el.is(':checkbox')) {
+            if (el.is(':checked')) { body[key] = true; }
+        } else {
+            var val = el.val();
+            if (val !== null && val !== undefined && ('' + val).length > 0) {
+                body[key] = val;
+            }
+        }
+    });
+
+    // servers is a space-separated list for the ldap method.
+    if (method === 'ldap' && typeof body.servers === 'string') {
+        body.servers = body.servers.split(/\s+/).filter(function(s) { return s.length > 0; });
+    }
+    // port is an integer.
+    if (typeof body.port === 'string' && body.port.length > 0) {
+        var p = parseInt(body.port, 10);
+        if (!isNaN(p)) { body.port = p; } else { delete body.port; }
+    }
+
+    // ssl_options sub-object (shared shape across methods that support TLS).
+    var ssl = {};
+    $form.find('[data-av-ssl]').each(function() {
+        var key = $(this).attr('data-av-ssl');
+        var el = $(this);
+        var val = el.is(':checkbox') ? el.is(':checked') : el.val();
+        if (el.is(':checkbox')) {
+            if (val) { ssl[key] = true; }
+        } else if (val !== null && val !== undefined && ('' + val).length > 0) {
+            ssl[key] = val;
+        }
+    });
+    if (Object.keys(ssl).length > 0) {
+        body.ssl_options = ssl;
+    }
+    return body;
+}
+
+// Submit the current method form. Bound as a delegated click so it survives
+// re-renders. Never a GET/route param -- the body may carry an ARN.
+$(document).on('click', '#aws-auth-validate-submit', function() {
+    var method = $('#aws-auth-validate-method').val();
+    var body = aws_auth_validate_build_body(method);
+    aws_auth_validate_req(method, body);
+    return false;
+});
+
+// Show/hide the per-method field groups when the method selector changes.
+$(document).on('change', '#aws-auth-validate-method', function() {
+    var method = $(this).val();
+    $('.aws-av-method-fields').hide();
+    $('#aws-av-fields-' + method).show();
+    $('#aws-auth-validate-result').empty();
+});
+
+// Issue the PUT and render the fixed category. Modeled on the reference plugin's
+// rqm_with_req: a hand-rolled request so we can inspect the status code and the
+// {error, message} body directly, rather than routing it through the management
+// plugin's CRUD helpers (which would surface a generic proxy error).
+function aws_auth_validate_req(method, body) {
+    if (typeof has_auth_credentials === 'function' && !has_auth_credentials()) {
+        location.reload();
+        return;
+    }
+    var req = xmlHttpRequest();
+    req.open('PUT', 'api/aws/auth/validate/' + encodeURIComponent(method), true);
+    var header = authorization_header();
+    if (header !== null) {
+        req.setRequestHeader('authorization', header);
+    }
+    req.setRequestHeader('content-type', 'application/json');
+    req.onreadystatechange = function() {
+        if (req.readyState !== 4) return;
+        aws_auth_validate_render_result(req);
+    };
+    req.send(JSON.stringify(body));
+}
+
+function aws_auth_validate_render_result(req) {
+    var category, message;
+    if (req.status === 0) {
+        category = 'transport_error';
+    } else if (req.status === 204) {
+        category = 'success';
+    } else {
+        try {
+            var data = JSON.parse(req.responseText);
+            category = data && data.error ? data.error : 'internal_error';
+            message = data && data.message ? data.message : undefined;
+        } catch (e) {
+            category = 'internal_error';
+        }
+    }
+    var info = AWS_AUTH_VALIDATE_CATEGORY[category] ||
+        {cls: 'status-red', text: 'Unexpected response (' + req.status + ').'};
+    var html = '<div class="' + info.cls + '" style="padding:8px;">' +
+        '<strong>' + fmt_escape_html(category) + '</strong> &mdash; ' +
+        fmt_escape_html(info.text);
+    // The backend message is a fixed, non-secret string; safe to show, still escaped.
+    if (message) {
+        html += '<br/><span class="argument">' + fmt_escape_html(message) + '</span>';
+    }
+    html += ' <span class="argument">(HTTP ' + (req.status || 'n/a') + ')</span></div>';
+    $('#aws-auth-validate-result').html(html);
+}
+
+// Minimal HTML escaper (the console bundles fmt_escape_html in newer releases;
+// fall back to a local one so this works across broker versions).
+function fmt_escape_html(s) {
+    if (typeof window.fmt_escape_html === 'function' && window.fmt_escape_html !== fmt_escape_html) {
+        return window.fmt_escape_html(s);
+    }
+    return ('' + s).replace(/&/g, '&amp;').replace(/</g, '&lt;')
+                   .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}

--- a/priv/www/js/tmpl/aws_auth_validate.ejs
+++ b/priv/www/js/tmpl/aws_auth_validate.ejs
@@ -1,0 +1,131 @@
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<h1>Auth Validation</h1>
+<p class="description">
+  Validate an authentication-backend configuration (LDAP, HTTP, OAuth2, or TLS)
+  without a broker restart. The result is a fixed category; no target host,
+  certificate, or backend error detail is returned.
+</p>
+
+<div class="section">
+  <h2>Request</h2>
+  <table class="form">
+    <tr>
+      <th><label for="aws-auth-validate-method">Method:</label></th>
+      <td>
+        <select id="aws-auth-validate-method" name="method">
+          <option value="ldap">ldap</option>
+          <option value="http">http</option>
+          <option value="oauth">oauth</option>
+          <option value="tls">tls</option>
+        </select>
+        <p class="argument">
+          Each method must be enabled server-side
+          (<code>aws.auth_validation.enabled = true</code> plus
+          <code>aws.auth_validation.enabled_methods.&lt;method&gt; = true</code>);
+          a disabled method returns <code>method_disabled</code> below.
+        </p>
+      </td>
+    </tr>
+  </table>
+
+  <form id="aws-auth-validate-form">
+
+    <!-- ldap -->
+    <div id="aws-av-fields-ldap" class="aws-av-method-fields">
+      <table class="form">
+        <tr><th><label>Servers:</label></th>
+          <td><input type="text" data-av-field="servers" placeholder="ldap1.example.com ldap2.example.com" />
+            <span class="argument">space-separated hostnames</span></td></tr>
+        <tr><th><label>Port:</label></th>
+          <td><input type="number" data-av-field="port" min="1" max="65535" placeholder="389" /></td></tr>
+        <tr><th><label>User DN:</label></th>
+          <td><input type="text" data-av-field="user_dn" placeholder="cn=admin,dc=example,dc=com" /></td></tr>
+        <tr><th><label>Password ARN:</label></th>
+          <td><input type="text" data-av-field="password_arn" placeholder="arn:aws:secretsmanager:..." /></td></tr>
+        <tr><th><label>Use SSL (LDAPS):</label></th>
+          <td><input type="checkbox" data-av-field="use_ssl" /></td></tr>
+        <tr><th><label>Use StartTLS:</label></th>
+          <td><input type="checkbox" data-av-field="use_starttls" /></td></tr>
+      </table>
+    </div>
+
+    <!-- http -->
+    <div id="aws-av-fields-http" class="aws-av-method-fields" style="display:none;">
+      <table class="form">
+        <tr><th><label>User path:</label></th>
+          <td><input type="text" data-av-field="user_path" placeholder="https://auth.example.com/user" />
+            <span class="argument">required</span></td></tr>
+        <tr><th><label>Vhost path:</label></th>
+          <td><input type="text" data-av-field="vhost_path" placeholder="https://auth.example.com/vhost" /></td></tr>
+        <tr><th><label>Resource path:</label></th>
+          <td><input type="text" data-av-field="resource_path" placeholder="https://auth.example.com/resource" /></td></tr>
+        <tr><th><label>Topic path:</label></th>
+          <td><input type="text" data-av-field="topic_path" placeholder="https://auth.example.com/topic" /></td></tr>
+        <tr><th><label>HTTP method:</label></th>
+          <td><select data-av-field="http_method"><option value="">(default)</option>
+            <option value="get">get</option><option value="post">post</option></select></td></tr>
+      </table>
+    </div>
+
+    <!-- oauth -->
+    <div id="aws-av-fields-oauth" class="aws-av-method-fields" style="display:none;">
+      <table class="form">
+        <tr><th><label>JWKS URI:</label></th>
+          <td><input type="text" data-av-field="jwks_uri" placeholder="https://idp.example.com/.well-known/jwks.json" /></td></tr>
+        <tr><th><label>Issuer:</label></th>
+          <td><input type="text" data-av-field="issuer" placeholder="https://idp.example.com/" /></td></tr>
+        <tr><th><label>Resource server id:</label></th>
+          <td><input type="text" data-av-field="resource_server_id" placeholder="rabbitmq" /></td></tr>
+        <tr><th><label>Access token:</label></th>
+          <td><input type="text" data-av-field="access_token" placeholder="(optional) enables signature/exp/aud checks" /></td></tr>
+      </table>
+    </div>
+
+    <!-- tls -->
+    <div id="aws-av-fields-tls" class="aws-av-method-fields" style="display:none;">
+      <table class="form">
+        <tr><th><label>Target:</label></th>
+          <td><input type="text" data-av-field="target" placeholder="listener" /></td></tr>
+      </table>
+    </div>
+
+    <!-- shared ssl_options (applies to ldap/http/oauth/tls that support TLS) -->
+    <div class="section-hidden">
+      <h3>ssl_options</h3>
+      <table class="form">
+        <tr><th><label>CA cert ARN:</label></th>
+          <td><input type="text" data-av-ssl="cacertfile_arn" placeholder="arn:aws:s3:::.../ca.pem" /></td></tr>
+        <tr><th><label>Client cert ARN:</label></th>
+          <td><input type="text" data-av-ssl="certfile_arn" placeholder="(mTLS) arn:aws:s3:::.../cert.pem" /></td></tr>
+        <tr><th><label>Client key ARN:</label></th>
+          <td><input type="text" data-av-ssl="keyfile_arn" placeholder="(mTLS) arn:aws:secretsmanager:.../key" /></td></tr>
+        <tr><th><label>Verify:</label></th>
+          <td><select data-av-ssl="verify"><option value="">(default)</option>
+            <option value="verify_peer">verify_peer</option>
+            <option value="verify_none">verify_none</option></select></td></tr>
+        <tr><th><label>SNI:</label></th>
+          <td><input type="text" data-av-ssl="sni" placeholder="auth.example.com" /></td></tr>
+      </table>
+      <p class="argument">
+        ARN fields are resolved server-side under the configured
+        <code>aws.arns.assume_role_arn</code> and are never echoed back. Do not
+        expect resolved secret material to appear in any result.
+      </p>
+    </div>
+
+    <div style="margin-top:10px;">
+      <input type="submit" id="aws-auth-validate-submit" value="Validate" />
+    </div>
+  </form>
+</div>
+
+<div class="section">
+  <h2>Result</h2>
+  <div id="aws-auth-validate-result">
+    <p class="argument">Submit a request to see the categorized result here.</p>
+  </div>
+</div>

--- a/priv/www/js/tmpl/aws_auth_validate.ejs
+++ b/priv/www/js/tmpl/aws_auth_validate.ejs
@@ -9,10 +9,15 @@ SPDX-License-Identifier: Apache-2.0
    view's field containers so the rest of the console is unaffected. Checkboxes
    and the number input keep their natural size. */
 #aws-av-fields-ldap input[type=text],
+#aws-av-fields-ldap input[type=password],
 #aws-av-fields-http input[type=text],
+#aws-av-fields-http input[type=password],
 #aws-av-fields-oauth input[type=text],
+#aws-av-fields-oauth input[type=password],
 #aws-av-fields-tls input[type=text],
-#aws-auth-validate-form div.section-hidden input[type=text] {
+#aws-av-fields-tls input[type=password],
+#aws-auth-validate-form div.section-hidden input[type=text],
+#aws-auth-validate-form div.section-hidden input[type=password] {
   width: 320px;
   max-width: 100%;
   box-sizing: border-box;
@@ -75,6 +80,19 @@ SPDX-License-Identifier: Apache-2.0
 
   <div style="flex:1 1 360px; min-width:300px;">
 
+    <!-- Per-method ssl_options key sets differ by backend (each backend HARD-
+         REJECTS an unknown ssl_options key as input_invalid), so the ssl fields
+         live INSIDE each method group rather than in one shared block:
+           * ldap: cacertfile_arn, verify, server_name_indication
+                   (note: the key is server_name_indication, NOT sni; ldap has
+                    no client-cert/mTLS support -- no certfile_arn/keyfile_arn).
+           * http/oauth: cacertfile_arn, certfile_arn, keyfile_arn, verify, sni.
+           * tls: cacertfile_arn, verify (no sni, no client cert/key).
+         Because every field a method sends now lives under its own
+         #aws-av-fields-<method> container, aws_auth_validate_build_body scopes
+         its scan to that container and can never pick up another method's
+         (hidden) fields. -->
+
     <!-- ldap -->
     <div id="aws-av-fields-ldap" class="aws-av-method-fields">
       <table class="form">
@@ -96,6 +114,77 @@ SPDX-License-Identifier: Apache-2.0
         <tr><th><label>Use StartTLS:</label></th>
           <td><input type="checkbox" data-av-field="use_starttls" /></td></tr>
       </table>
+
+      <!-- Optional authorization layer. `username` is an IDENTIFIER, not a
+           credential: no principal password is ever accepted. When supplied
+           (and a DN lookup is configured), the service connection resolves it
+           to a user DN and the queries' ${username}/${user_dn} placeholders are
+           filled so membership is actually evaluated. Left blank, the queries
+           run in literal-DN reachability mode (any placeholder-free DN they
+           reference is checked for existence only). The four query names mirror
+           the broker's auth_ldap.queries.* keys; each value is a query-DSL
+           string parsed with the broker-compatible grammar (a parse failure
+           returns query_invalid; a referenced object that cannot be verified
+           returns authz_unverified). These are runtime validation inputs with
+           no single rabbitmq.conf line, so they are entered here rather than in
+           the rabbitmq.conf box. -->
+      <div class="section-hidden" style="margin-top:10px;">
+        <h3>Authorization checks (optional)</h3>
+        <p class="argument">
+          Supply a <strong>Username</strong> to evaluate the queries for a real
+          principal; leave it blank to only reachability-check any literal DNs
+          the queries reference. The username is an identifier, never a
+          password.
+        </p>
+        <table class="form">
+          <tr><th><label>Username:</label></th>
+            <td><input type="text" data-av-field="username" placeholder="(optional) e.g. alice" />
+              <span class="argument">identifier only -- no password</span></td></tr>
+          <tr><th valign="top"><label>Tags query:</label></th>
+            <td><textarea data-av-query="tags" rows="2" spellcheck="false" autocomplete="off"
+                          style="width:320px; max-width:100%; font-family:monospace; box-sizing:border-box;"
+                          placeholder="{in_group,&quot;cn=admin,ou=groups,dc=example,dc=com&quot;}"></textarea></td></tr>
+          <tr><th valign="top"><label>Vhost access query:</label></th>
+            <td><textarea data-av-query="vhost_access" rows="2" spellcheck="false" autocomplete="off"
+                          style="width:320px; max-width:100%; font-family:monospace; box-sizing:border-box;"
+                          placeholder="{exists,&quot;ou=${vhost},dc=example,dc=com&quot;}"></textarea></td></tr>
+          <tr><th valign="top"><label>Resource access query:</label></th>
+            <td><textarea data-av-query="resource_access" rows="2" spellcheck="false" autocomplete="off"
+                          style="width:320px; max-width:100%; font-family:monospace; box-sizing:border-box;"
+                          placeholder="{constant,true}"></textarea></td></tr>
+          <tr><th valign="top"><label>Topic access query:</label></th>
+            <td><textarea data-av-query="topic_access" rows="2" spellcheck="false" autocomplete="off"
+                          style="width:320px; max-width:100%; font-family:monospace; box-sizing:border-box;"
+                          placeholder="{constant,true}"></textarea></td></tr>
+        </table>
+        <p class="argument">
+          One query-DSL expression per box (same grammar as
+          <code>auth_ldap.queries.&lt;name&gt;</code>). <code>${username}</code>
+          and <code>${user_dn}</code> are filled from the Username above; other
+          placeholders (<code>${vhost}</code>, <code>${resource}</code>) are
+          grammar-checked only.
+        </p>
+      </div>
+
+      <!-- ldap ssl_options: cacertfile_arn, verify, server_name_indication.
+           LDAP does NOT accept sni, certfile_arn, or keyfile_arn. -->
+      <div class="section-hidden">
+        <h3>ssl_options</h3>
+        <table class="form">
+          <tr><th><label>CA cert ARN:</label></th>
+            <td><input type="text" data-av-ssl="cacertfile_arn" placeholder="arn:aws:s3:::.../ca.pem" /></td></tr>
+          <tr><th><label>Verify:</label></th>
+            <td><select data-av-ssl="verify"><option value="">(default)</option>
+              <option value="verify_peer">verify_peer</option>
+              <option value="verify_none">verify_none</option></select></td></tr>
+          <tr><th><label>Server name indication:</label></th>
+            <td><input type="text" data-av-ssl="server_name_indication" placeholder="ldap.example.com" /></td></tr>
+        </table>
+        <p class="argument">
+          ARN fields are resolved server-side under the configured
+          <code>aws.arns.assume_role_arn</code> and are never echoed back.
+        </p>
+      </div>
     </div>
 
     <!-- http -->
@@ -114,6 +203,29 @@ SPDX-License-Identifier: Apache-2.0
           <td><select data-av-field="http_method"><option value="">(default)</option>
             <option value="get">get</option><option value="post">post</option></select></td></tr>
       </table>
+
+      <!-- http ssl_options: cacertfile_arn, certfile_arn, keyfile_arn, verify, sni. -->
+      <div class="section-hidden">
+        <h3>ssl_options</h3>
+        <table class="form">
+          <tr><th><label>CA cert ARN:</label></th>
+            <td><input type="text" data-av-ssl="cacertfile_arn" placeholder="arn:aws:s3:::.../ca.pem" /></td></tr>
+          <tr><th><label>Client cert ARN:</label></th>
+            <td><input type="text" data-av-ssl="certfile_arn" placeholder="(mTLS) arn:aws:s3:::.../cert.pem" /></td></tr>
+          <tr><th><label>Client key ARN:</label></th>
+            <td><input type="text" data-av-ssl="keyfile_arn" placeholder="(mTLS) arn:aws:secretsmanager:.../key" /></td></tr>
+          <tr><th><label>Verify:</label></th>
+            <td><select data-av-ssl="verify"><option value="">(default)</option>
+              <option value="verify_peer">verify_peer</option>
+              <option value="verify_none">verify_none</option></select></td></tr>
+          <tr><th><label>SNI:</label></th>
+            <td><input type="text" data-av-ssl="sni" placeholder="auth.example.com" /></td></tr>
+        </table>
+        <p class="argument">
+          ARN fields are resolved server-side under the configured
+          <code>aws.arns.assume_role_arn</code> and are never echoed back.
+        </p>
+      </div>
     </div>
 
     <!-- oauth -->
@@ -126,40 +238,111 @@ SPDX-License-Identifier: Apache-2.0
         <tr><th><label>Resource server id:</label></th>
           <td><input type="text" data-av-field="resource_server_id" placeholder="rabbitmq" /></td></tr>
         <tr><th><label>Access token:</label></th>
-          <td><input type="text" data-av-field="access_token" placeholder="(optional) enables signature/exp/aud checks" /></td></tr>
+          <td><input type="password" data-av-field="access_token" autocomplete="off"
+                     placeholder="(optional) enables signature/exp/aud checks" /></td></tr>
       </table>
+
+      <!-- Optional authorization-evaluation layer. Reachability + JWKS
+           well-formedness need none of this; supplying an access_token adds
+           signature/exp/aud checks; supplying an authz_check goes one step
+           further and asks "would the broker GRANT this token <permission> on
+           <vhost>/<resource>?" using the broker's own scope-decision code. The
+           scope-config fields below shape that decision the same way the
+           customer's rabbitmq.conf would. Left entirely empty, none of this
+           runs -- the OAuth check stays a pure reachability probe. -->
+      <div class="section-hidden" style="margin-top:10px;">
+        <h3>Authorization check (optional)</h3>
+        <p class="argument">
+          Evaluates the supplied <strong>Access token</strong> against the
+          broker's own OAuth scope logic. Requires both an
+          <strong>Access token</strong> and a <strong>Resource server id</strong>
+          above; leave the permission blank to skip authorization entirely.
+          <code>scope_aliases</code> is entered here (one alias per line) rather
+          than in the rabbitmq.conf box.
+        </p>
+        <table class="form">
+          <tr><th><label>Permission:</label></th>
+            <td><select data-av-authz="permission">
+                  <option value="">(skip authz check)</option>
+                  <option value="configure">configure</option>
+                  <option value="write">write</option>
+                  <option value="read">read</option>
+                </select></td></tr>
+          <tr><th><label>Resource:</label></th>
+            <td><input type="text" data-av-authz="resource" placeholder="my-queue" /></td></tr>
+          <tr><th><label>Vhost:</label></th>
+            <td><input type="text" data-av-authz="vhost" placeholder="/ (default)" /></td></tr>
+          <tr><th><label>Scope prefix:</label></th>
+            <td><input type="text" data-av-field="scope_prefix" placeholder="rabbitmq.(default)" /></td></tr>
+          <tr><th><label>Additional scopes key:</label></th>
+            <td><input type="text" data-av-field="additional_scopes_key" placeholder="(optional) e.g. roles" /></td></tr>
+          <tr><th><label>Scope pattern syntax:</label></th>
+            <td><select data-av-field="scope_pattern_syntax">
+                  <option value="">(default: wildcard)</option>
+                  <option value="wildcard">wildcard</option>
+                  <option value="regex">regex</option>
+                </select></td></tr>
+          <tr><th valign="top"><label>Scope aliases:</label></th>
+            <td><textarea data-av-field="scope_aliases" rows="3"
+                          spellcheck="false" autocomplete="off"
+                          style="width:320px; max-width:100%; font-family:monospace; box-sizing:border-box;"
+                          placeholder="admin = rabbitmq.tag:administrator rabbitmq.configure:*/*&#10;monitor = rabbitmq.tag:monitoring"></textarea>
+              <span class="argument">one <code>alias = scope1 scope2 ...</code> per line</span></td></tr>
+        </table>
+      </div>
+
+      <!-- oauth ssl_options: cacertfile_arn, certfile_arn, keyfile_arn, verify, sni. -->
+      <div class="section-hidden">
+        <h3>ssl_options</h3>
+        <table class="form">
+          <tr><th><label>CA cert ARN:</label></th>
+            <td><input type="text" data-av-ssl="cacertfile_arn" placeholder="arn:aws:s3:::.../ca.pem" /></td></tr>
+          <tr><th><label>Client cert ARN:</label></th>
+            <td><input type="text" data-av-ssl="certfile_arn" placeholder="(mTLS) arn:aws:s3:::.../cert.pem" /></td></tr>
+          <tr><th><label>Client key ARN:</label></th>
+            <td><input type="text" data-av-ssl="keyfile_arn" placeholder="(mTLS) arn:aws:secretsmanager:.../key" /></td></tr>
+          <tr><th><label>Verify:</label></th>
+            <td><select data-av-ssl="verify"><option value="">(default)</option>
+              <option value="verify_peer">verify_peer</option>
+              <option value="verify_none">verify_none</option></select></td></tr>
+          <tr><th><label>SNI:</label></th>
+            <td><input type="text" data-av-ssl="sni" placeholder="idp.example.com" /></td></tr>
+        </table>
+        <p class="argument">
+          ARN fields are resolved server-side under the configured
+          <code>aws.arns.assume_role_arn</code> and are never echoed back.
+        </p>
+      </div>
     </div>
 
     <!-- tls -->
     <div id="aws-av-fields-tls" class="aws-av-method-fields" style="display:none;">
       <table class="form">
         <tr><th><label>Target:</label></th>
-          <td><input type="text" data-av-field="target" placeholder="listener" /></td></tr>
+          <td><select data-av-field="target"><option value="listener">listener</option>
+            <option value="management">management</option></select></td></tr>
       </table>
-    </div>
 
-    <!-- shared ssl_options (applies to ldap/http/oauth/tls that support TLS) -->
-    <div class="section-hidden">
-      <h3>ssl_options</h3>
-      <table class="form">
-        <tr><th><label>CA cert ARN:</label></th>
-          <td><input type="text" data-av-ssl="cacertfile_arn" placeholder="arn:aws:s3:::.../ca.pem" /></td></tr>
-        <tr><th><label>Client cert ARN:</label></th>
-          <td><input type="text" data-av-ssl="certfile_arn" placeholder="(mTLS) arn:aws:s3:::.../cert.pem" /></td></tr>
-        <tr><th><label>Client key ARN:</label></th>
-          <td><input type="text" data-av-ssl="keyfile_arn" placeholder="(mTLS) arn:aws:secretsmanager:.../key" /></td></tr>
-        <tr><th><label>Verify:</label></th>
-          <td><select data-av-ssl="verify"><option value="">(default)</option>
-            <option value="verify_peer">verify_peer</option>
-            <option value="verify_none">verify_none</option></select></td></tr>
-        <tr><th><label>SNI:</label></th>
-          <td><input type="text" data-av-ssl="sni" placeholder="auth.example.com" /></td></tr>
-      </table>
-      <p class="argument">
-        ARN fields are resolved server-side under the configured
-        <code>aws.arns.assume_role_arn</code> and are never echoed back. Do not
-        expect resolved secret material to appear in any result.
-      </p>
+      <!-- tls ssl_options: cacertfile_arn, verify, fail_if_no_peer_cert.
+           TLS validates inbound-listener material only: no sni, no client
+           cert/key. cacertfile_arn is required for this method. -->
+      <div class="section-hidden">
+        <h3>ssl_options</h3>
+        <table class="form">
+          <tr><th><label>CA cert ARN:</label></th>
+            <td><input type="text" data-av-ssl="cacertfile_arn" placeholder="(required) arn:aws:s3:::.../ca.pem" /></td></tr>
+          <tr><th><label>Verify:</label></th>
+            <td><select data-av-ssl="verify"><option value="">(default)</option>
+              <option value="verify_peer">verify_peer</option>
+              <option value="verify_none">verify_none</option></select></td></tr>
+          <tr><th><label>Fail if no peer cert:</label></th>
+            <td><input type="checkbox" data-av-ssl="fail_if_no_peer_cert" /></td></tr>
+        </table>
+        <p class="argument">
+          ARN fields are resolved server-side under the configured
+          <code>aws.arns.assume_role_arn</code> and are never echoed back.
+        </p>
+      </div>
     </div>
 
   </div><!-- /left column (individual fields) -->

--- a/priv/www/js/tmpl/aws_auth_validate.ejs
+++ b/priv/www/js/tmpl/aws_auth_validate.ejs
@@ -20,6 +20,22 @@ SPDX-License-Identifier: Apache-2.0
 /* Keep the field-title column on a single line (don't let the wider inputs
    squeeze the labels into wrapping). */
 #aws-auth-validate-form table.form th { white-space: nowrap; }
+
+/* Loading indicator shown while a validation request is in flight. A slow
+   failure can take several seconds; the spinner replaces any prior result so a
+   stale success banner is never shown mid-run. */
+#aws-auth-validate-result .aws-av-spinner {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+  vertical-align: middle;
+  border: 2px solid #ccc;
+  border-top-color: #555;
+  border-radius: 50%;
+  animation: aws-av-spin 0.7s linear infinite;
+}
+@keyframes aws-av-spin { to { transform: rotate(360deg); } }
 </style>
 
 <h1>Auth Validation</h1>
@@ -158,7 +174,7 @@ SPDX-License-Identifier: Apache-2.0
               spellcheck="false" autocomplete="off" autocapitalize="off"
               style="width:100%; font-family:monospace; box-sizing:border-box;"
               placeholder="auth_backends.1 = ldap&#10;auth_ldap.servers.1 = ldap.example.com&#10;auth_ldap.port = 636&#10;auth_ldap.use_ssl = true&#10;auth_ldap.dn_lookup_bind.user_dn = cn=admin,dc=example,dc=com&#10;auth_ldap.ssl_options.verify = verify_peer&#10;aws.arns.auth_ldap.dn_lookup_bind.password = arn:aws:secretsmanager:..."></textarea>
-    <div style="margin-top:6px;">
+    <div style="margin-top:6px; display:flex; flex-wrap:wrap; align-items:center; gap:10px;">
       <button type="button" id="aws-auth-validate-parse">Parse into fields</button>
       <button type="button" id="aws-auth-validate-build">Update config from fields</button>
       <button type="button" id="aws-auth-validate-copy">Copy config</button>

--- a/priv/www/js/tmpl/aws_auth_validate.ejs
+++ b/priv/www/js/tmpl/aws_auth_validate.ejs
@@ -3,6 +3,25 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
 
+<style type="text/css">
+/* Widen the text inputs in the left-hand field boxes so long placeholder
+   examples and values (DNs, ARNs, URLs) are not truncated. Scoped to this
+   view's field containers so the rest of the console is unaffected. Checkboxes
+   and the number input keep their natural size. */
+#aws-av-fields-ldap input[type=text],
+#aws-av-fields-http input[type=text],
+#aws-av-fields-oauth input[type=text],
+#aws-av-fields-tls input[type=text],
+#aws-auth-validate-form div.section-hidden input[type=text] {
+  width: 320px;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+/* Keep the field-title column on a single line (don't let the wider inputs
+   squeeze the labels into wrapping). */
+#aws-auth-validate-form table.form th { white-space: nowrap; }
+</style>
+
 <h1>Auth Validation</h1>
 <p class="description">
   Validate an authentication-backend configuration (LDAP, HTTP, OAuth2, or TLS)
@@ -34,6 +53,12 @@ SPDX-License-Identifier: Apache-2.0
 
   <form id="aws-auth-validate-form">
 
+  <!-- Two columns: individual field boxes on the left, the equivalent
+       rabbitmq.conf on the right. Wraps to stacked on narrow viewports. -->
+  <div style="display:flex; gap:20px; align-items:flex-start; flex-wrap:wrap;">
+
+  <div style="flex:1 1 360px; min-width:300px;">
+
     <!-- ldap -->
     <div id="aws-av-fields-ldap" class="aws-av-method-fields">
       <table class="form">
@@ -46,6 +71,10 @@ SPDX-License-Identifier: Apache-2.0
           <td><input type="text" data-av-field="user_dn" placeholder="cn=admin,dc=example,dc=com" /></td></tr>
         <tr><th><label>Password ARN:</label></th>
           <td><input type="text" data-av-field="password_arn" placeholder="arn:aws:secretsmanager:..." /></td></tr>
+        <tr><th><label>DN lookup base:</label></th>
+          <td><input type="text" data-av-field="dn_lookup_base" placeholder="dc=example,dc=com" /></td></tr>
+        <tr><th><label>DN lookup attribute:</label></th>
+          <td><input type="text" data-av-field="dn_lookup_attribute" placeholder="sAMAccountName" /></td></tr>
         <tr><th><label>Use SSL (LDAPS):</label></th>
           <td><input type="checkbox" data-av-field="use_ssl" /></td></tr>
         <tr><th><label>Use StartTLS:</label></th>
@@ -117,6 +146,28 @@ SPDX-License-Identifier: Apache-2.0
       </p>
     </div>
 
+  </div><!-- /left column (individual fields) -->
+
+  <!-- Right column: the equivalent rabbitmq.conf. -->
+  <div class="section-hidden" style="flex:1 1 360px; min-width:300px; margin-top:0;">
+    <h3>rabbitmq.conf</h3>
+    <p class="argument">
+      Paste your rabbitmq.conf here:
+    </p>
+    <textarea id="aws-auth-validate-config" rows="18"
+              spellcheck="false" autocomplete="off" autocapitalize="off"
+              style="width:100%; font-family:monospace; box-sizing:border-box;"
+              placeholder="auth_backends.1 = ldap&#10;auth_ldap.servers.1 = ldap.example.com&#10;auth_ldap.port = 636&#10;auth_ldap.use_ssl = true&#10;auth_ldap.dn_lookup_bind.user_dn = cn=admin,dc=example,dc=com&#10;auth_ldap.ssl_options.verify = verify_peer&#10;aws.arns.auth_ldap.dn_lookup_bind.password = arn:aws:secretsmanager:..."></textarea>
+    <div style="margin-top:6px;">
+      <button type="button" id="aws-auth-validate-parse">Parse into fields</button>
+      <button type="button" id="aws-auth-validate-build">Update config from fields</button>
+      <button type="button" id="aws-auth-validate-copy">Copy config</button>
+      <span id="aws-auth-validate-copy-status" class="argument"></span>
+    </div>
+  </div><!-- /right column (rabbitmq.conf) -->
+
+  </div><!-- /two-column row -->
+
     <div style="margin-top:10px;">
       <input type="submit" id="aws-auth-validate-submit" value="Validate" />
     </div>
@@ -129,3 +180,10 @@ SPDX-License-Identifier: Apache-2.0
     <p class="argument">Submit a request to see the categorized result here.</p>
   </div>
 </div>
+
+<script type="text/javascript">
+// Runs after the management console injects this template (jQuery .html()
+// executes inline scripts). Primes the preview with the full field template for
+// the initially-selected method. Defined in aws_auth_validate.js.
+if (typeof aws_auth_validate_on_render === 'function') { aws_auth_validate_on_render(); }
+</script>

--- a/src/aws_auth_validate_mgmt.erl
+++ b/src/aws_auth_validate_mgmt.erl
@@ -41,7 +41,11 @@
 
 dispatcher() -> [{"/aws/auth/validate/:method", ?MODULE, []}].
 
-web_ui() -> [].
+%% Register the management-console UI extension. The management plugin serves
+%% this plugin's priv/www/ automatically (see rabbit_mgmt_dispatcher), so the
+%% referenced file is loaded from priv/www/js/aws_auth_validate.js. The JS adds
+%% an admin-gated "Auth Validation" tab that drives PUT /aws/auth/validate/:method.
+web_ui() -> [{javascript, <<"aws_auth_validate.js">>}].
 
 %%--------------------------------------------------------------------
 %% cowboy_rest callbacks


### PR DESCRIPTION
*Issue #43*

Adds a management-console UI tab for the auth-validation endpoint
(`PUT /api/aws/auth/validate/:method`). Until now `web_ui/0` returned `[]`, so
the management plugin mounted no tab and the endpoint was API-only. This wires
up an admin-gated **Auth Validation** tab that drives the endpoint from the
browser, modeled on the `rabbitmq_queue_migration` management extension.

Scope is three files; no change to the endpoint's request pipeline (the one
`src/` edit is the `web_ui/0` return value).

### Changes

- **`src/aws_auth_validate_mgmt.erl`** -- `web_ui/0` now returns the JS asset,
  so the management plugin mounts the tab and serves this plugin's `priv/www`
  automatically (via `rabbit_mgmt_dispatcher`). No new routes needed.
- **`priv/www/js/aws_auth_validate.js`** (new) -- registers the Admin tab
  (`administrator` tag, matching the endpoint's default `required_user_tag`), a
  method selector (`ldap`/`http`/`oauth`/`tls`) with per-method field groups,
  and a hand-rolled request that maps the endpoint's fixed response categories
  (`input_invalid`, `connection_failed`, `tls_failed`, `auth_failed`,
  `config_conflict`, `authz_unverified`, `method_disabled`,
  `capacity_exhausted`, ...) to color-coded banners -- rather than routing
  through the console's CRUD helpers, which would surface a generic proxy error.
- **`priv/www/js/tmpl/aws_auth_validate.ejs`** (new) -- the form; field names
  mirror each backend's `allowed_fields/0` so the registry's `maps:with` filter
  keeps them.

### Security

Follows the endpoint's R6 invariant end to end:
- Secret-bearing fields (`password_arn`, `client_secret`, the mTLS cert/key
  ARNs, `access_token`) are sent in the JSON request body -- never in the
  URL/hash or Sammy route params (which land in browser history).
- Nothing is persisted to `localStorage` (the reference plugin persists form
  state; that was deliberately dropped so ARNs are never cached).
- Rendered text is HTML-escaped; only the backend's fixed, non-secret `message`
  is shown -- no target host, cert, or raw backend error is ever displayed.

The tab tag is a client-side visibility hint only; `is_authorized/2` remains the
authoritative gate.

### Testing

- Builds clean in the umbrella (`gmake`); assets confirmed served over HTTP on a
  running broker (`/api/extensions` lists the JS; the JS and EJS return 200).
- The endpoint itself was exercised end to end against the CDK LDAP test stack
  (a real simple-bind returns 204).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.