### PR TITLE
Auth Validation Endpoint SSRF/LDAP/audit hardening 

### DIFF
--- a/src/aws_auth_validate_ldap.erl
+++ b/src/aws_auth_validate_ldap.erl
@@ -559,17 +559,22 @@ is_private_ip(_) -> false.
 %%   fc00::/7       unique local addresses (ULA). Includes the IPv6 IMDS
 %%                  address fd00:ec2::254 -- the whole point of this block.
 %%   fe80::/10      link-local (spans fe80..febf, NOT just fe80)
-%% IPv4-mapped (::ffff:a.b.c.d), IPv4-compatible (::a.b.c.d), and NAT64
-%% (64:ff9b::a.b.c.d) addresses embed a v4 address in the low 32 bits; re-check
-%% those against the v4 ranges so e.g. ::ffff:169.254.169.254 (and the NAT64
-%% form 64:ff9b::169.254.169.254, which a host with a NAT64/DNS64 resolver would
-%% translate to IMDS) cannot reach IMDS.
+%% IPv4-mapped (::ffff:a.b.c.d), IPv4-compatible (::a.b.c.d), NAT64
+%% (64:ff9b::a.b.c.d), and 6to4 (2002:a.b.c.d::/16) addresses embed a v4 address;
+%% re-check those against the v4 ranges so e.g. ::ffff:169.254.169.254 (and the
+%% NAT64 form 64:ff9b::169.254.169.254, which a host with a NAT64/DNS64 resolver
+%% would translate to IMDS, or the 6to4 form 2002:a9fe:a9fe:: on a host with a
+%% 6to4 route) cannot reach IMDS. Mirrors the embedded-v4 unwrapping in the
+%% shared aws_auth_validate_net:classify_ip/2 so the two SSRF classifiers stay in
+%% step.
 is_private_ip6({0, 0, 0, 0, 0, 0, 0, 1}) -> true;
 is_private_ip6({0, 0, 0, 0, 0, 0, 0, 0}) -> true;
 is_private_ip6({W1, _, _, _, _, _, _, _}) when W1 >= 16#fc00, W1 =< 16#fdff -> true;
 is_private_ip6({W1, _, _, _, _, _, _, _}) when W1 >= 16#fe80, W1 =< 16#febf -> true;
 is_private_ip6({0, 0, 0, 0, 0, 16#ffff, W7, W8}) -> is_private_ip(v6_words_to_v4(W7, W8));
 is_private_ip6({16#0064, 16#ff9b, 0, 0, 0, 0, W7, W8}) -> is_private_ip(v6_words_to_v4(W7, W8));
+%% 6to4 2002::/16: the embedded v4 lives in the 2nd and 3rd 16-bit words.
+is_private_ip6({16#2002, W2, W3, _, _, _, _, _}) -> is_private_ip(v6_words_to_v4(W2, W3));
 is_private_ip6({0, 0, 0, 0, 0, 0, W7, W8}) -> is_private_ip(v6_words_to_v4(W7, W8));
 is_private_ip6(_) -> false.
 
@@ -753,7 +758,8 @@ resolve_principal_dn(Handle, #{
         eldap:search(Handle, [
             {base, Base},
             {filter, eldap:equalityMatch(Attr, Username)},
-            {attributes, ["distinguishedName"]}
+            {attributes, ["distinguishedName"]},
+            {timeout, search_time_limit_seconds()}
         ])
     of
         {ok, #eldap_search_result{entries = [#eldap_entry{object_name = Dn}]}} ->
@@ -948,7 +954,8 @@ member_exists(Handle, GroupDn, Desc, UserDn) ->
             {base, GroupDn},
             {filter, eldap:equalityMatch(Desc, UserDn)},
             {attributes, ["objectClass"]},
-            {scope, eldap:baseObject()}
+            {scope, eldap:baseObject()},
+            {timeout, search_time_limit_seconds()}
         ])
     of
         {ok, #eldap_search_result{entries = Entries}} ->
@@ -972,7 +979,8 @@ object_exists(Handle, DN) ->
             {base, DN},
             {filter, eldap:present("objectClass")},
             {attributes, ["objectClass"]},
-            {scope, eldap:baseObject()}
+            {scope, eldap:baseObject()},
+            {timeout, search_time_limit_seconds()}
         ])
     of
         {ok, #eldap_search_result{entries = Entries}} ->
@@ -1075,3 +1083,14 @@ resolve_arn(Arn, State) when is_binary(Arn) ->
 
 connection_timeout_ms() ->
     aws_auth_validate_ssl:connection_timeout_ms(#{default => ?DEFAULT_TIMEOUT_MS, max => 60_000}).
+
+%% Server-side LDAP search time limit, in whole seconds, for the post-bind
+%% probes (dn_lookup, principal resolution, membership/existence). eldap's
+%% open/2 timeout already bounds each socket recv on the client side; this adds
+%% the protocol-level timeLimit so a server that accepts the bind and then
+%% dribbles a search response cannot keep a probe -- and thus a semaphore slot --
+%% busy for the full connection timeout on every one of a request's several
+%% sequential searches. Derived from the same request-timeout config (ms -> s,
+%% rounded up, floored at 1s) so it tracks the operator's configured budget.
+search_time_limit_seconds() ->
+    max(1, (connection_timeout_ms() + 999) div 1000).

--- a/src/aws_auth_validate_mgmt.erl
+++ b/src/aws_auth_validate_mgmt.erl
@@ -94,32 +94,33 @@ accept_content(Req0, Context) ->
         true ->
             T0 = erlang:monotonic_time(millisecond),
             SourceIP = peer_ip(Req0),
+            User = username(Context),
             Method = cowboy_req:binding(method, Req0),
-            with_body(T0, SourceIP, Method, Req0, Context)
+            with_body(T0, SourceIP, User, Method, Req0, Context)
     end.
 
-with_body(T0, SourceIP, Method, Req0, Context) ->
+with_body(T0, SourceIP, User, Method, Req0, Context) ->
     MaxBytes = max_body_size(),
     case read_body(Req0, MaxBytes) of
         {error, body_too_large, Req1} ->
-            audit(Method, SourceIP, input_invalid, T0),
+            audit(Method, SourceIP, User, body_too_large, T0),
             reply_error(400, body_too_large, <<"Request body too large">>, Req1, Context);
         {ok, RawBody, Req1} ->
             case decode_json(RawBody) of
                 {error, _} ->
-                    audit(Method, SourceIP, input_invalid, T0),
+                    audit(Method, SourceIP, User, input_invalid, T0),
                     reply_error(400, input_invalid, <<"Invalid JSON body">>, Req1, Context);
                 {ok, BodyMap} when is_map(BodyMap) ->
-                    with_semaphore(T0, SourceIP, Method, BodyMap, Req1, Context);
+                    with_semaphore(T0, SourceIP, User, Method, BodyMap, Req1, Context);
                 {ok, _NotMap} ->
-                    audit(Method, SourceIP, input_invalid, T0),
+                    audit(Method, SourceIP, User, input_invalid, T0),
                     reply_error(
                         400, input_invalid, <<"JSON body must be an object">>, Req1, Context
                     )
             end
     end.
 
-with_semaphore(T0, SourceIP, Method, BodyMap, Req, Context) ->
+with_semaphore(T0, SourceIP, User, Method, BodyMap, Req, Context) ->
     %% acquire/0 is a gen_server:call to the semaphore worker. The worker is
     %% started by aws_sup only at boot when the feature is enabled; if the env
     %% was flipped to true at runtime (no restart) or the supervisor gave up on
@@ -129,7 +130,7 @@ with_semaphore(T0, SourceIP, Method, BodyMap, Req, Context) ->
     %% semaphore. Any other exit propagates (it is a genuine fault).
     case try_acquire() of
         not_ready ->
-            audit(Method, SourceIP, capacity_exhausted, T0),
+            audit(Method, SourceIP, User, capacity_exhausted, T0),
             reply_error(
                 503,
                 capacity_exhausted,
@@ -138,7 +139,7 @@ with_semaphore(T0, SourceIP, Method, BodyMap, Req, Context) ->
                 Context
             );
         {error, full} ->
-            audit(Method, SourceIP, capacity_exhausted, T0),
+            audit(Method, SourceIP, User, capacity_exhausted, T0),
             reply_error(503, capacity_exhausted, <<"Service at capacity">>, Req, Context);
         {ok, Ref} ->
             try
@@ -155,11 +156,11 @@ with_semaphore(T0, SourceIP, Method, BodyMap, Req, Context) ->
                 %% rather than a 400 connection_failed, which would wrongly tell
                 %% the caller their LDAP server is unreachable.
                 Result = aws_auth_validate_registry:dispatch(Method, BodyMap),
-                audit(Method, SourceIP, result_category(Result), T0),
+                audit(Method, SourceIP, User, result_category(Result), T0),
                 respond(Result, Req, Context)
             catch
                 _Class:_Reason:_Stack ->
-                    audit(Method, SourceIP, internal_error, T0),
+                    audit(Method, SourceIP, User, internal_error, T0),
                     reply_error(
                         500,
                         internal_error,
@@ -287,12 +288,26 @@ decode_json(<<>>) ->
 decode_json(Raw) ->
     rabbit_json:try_decode(Raw).
 
-audit(Method, SourceIP, ResultCategory, T0) ->
+audit(Method, SourceIP, User, ResultCategory, T0) ->
     Duration = erlang:monotonic_time(millisecond) - T0,
     ?AWS_LOG_INFO(
-        "auth_validate: method=~ts source_ip=~ts result=~ts duration_ms=~B",
-        [Method, format_ip(SourceIP), ResultCategory, Duration]
+        "auth_validate: method=~ts user=~ts source_ip=~ts result=~ts duration_ms=~B",
+        [Method, User, format_ip(SourceIP), ResultCategory, Duration]
     ).
+
+%% The authenticated management user's name, for the audit trail. This endpoint
+%% is admin-gated and makes outbound connections to caller-chosen targets (an
+%% SSRF surface), so the acting principal -- not just the TCP peer IP, which
+%% behind the management load balancer is often the LB -- must be attributable.
+%% is_authorized/2 populates Context#context.user before accept_content/2 runs;
+%% an OPTIONS preflight is let through unauthenticated (user=undefined), but the
+%% feature toggle short-circuits OPTIONS before any audit, so a `<<"unknown">>'
+%% here only ever reflects an unexpected shape, never a real unaudited PUT. Only
+%% the username is logged -- never tags, target host, URL, or DN (R4/R6).
+username(#context{user = #user{username = Name}}) when is_binary(Name) ->
+    Name;
+username(_) ->
+    <<"unknown">>.
 
 format_ip(IP) when is_tuple(IP) ->
     case inet:ntoa(IP) of

--- a/src/aws_auth_validate_mgmt.erl
+++ b/src/aws_auth_validate_mgmt.erl
@@ -292,8 +292,27 @@ audit(Method, SourceIP, User, ResultCategory, T0) ->
     Duration = erlang:monotonic_time(millisecond) - T0,
     ?AWS_LOG_INFO(
         "auth_validate: method=~ts user=~ts source_ip=~ts result=~ts duration_ms=~B",
-        [Method, User, format_ip(SourceIP), ResultCategory, Duration]
+        [sanitize_log(Method), sanitize_log(User), format_ip(SourceIP), ResultCategory, Duration]
     ).
+
+%% Strip control characters (CR, LF, TAB, any other byte < 0x20, and DEL) from a
+%% value before it is interpolated into the single-line audit record. Method
+%% comes from the URL path binding and User from the stored username -- both are
+%% caller-influenceable, so an embedded CR/LF could otherwise forge or split an
+%% audit line (log injection), defeating the attribution this record exists to
+%% provide. Each offending byte is replaced with the Unicode replacement
+%% character (U+FFFD) so the record stays on one line and the tampering is
+%% visible rather than silently dropped. UTF-8 multi-byte sequences are
+%% preserved untouched (every one of their bytes is >= 0x80).
+sanitize_log(Bin) when is_binary(Bin) ->
+    <<<<(sanitize_byte(B))/binary>> || <<B>> <= Bin>>;
+sanitize_log(Other) ->
+    Other.
+
+sanitize_byte(B) when B < 16#20; B =:= 16#7F ->
+    <<"\x{fffd}"/utf8>>;
+sanitize_byte(B) ->
+    <<B>>.
 
 %% The authenticated management user's name, for the audit trail. This endpoint
 %% is admin-gated and makes outbound connections to caller-chosen targets (an

--- a/test/aws_auth_validate_tests.erl
+++ b/test/aws_auth_validate_tests.erl
@@ -267,6 +267,17 @@ server_blocks_nat64_imds_test() ->
 server_allows_nat64_public_test() ->
     ?assertEqual(true, aws_auth_validate_ldap:is_allowed_server("64:ff9b::8.8.8.8")).
 
+%% 6to4 (2002::/16) embeds a v4 address in the 2nd/3rd words; on a host with a
+%% 6to4 route, 2002:a9fe:a9fe:: routes to IMDS 169.254.169.254, so it must be
+%% blocked just like the NAT64/v4-mapped forms.
+server_blocks_6to4_imds_test() ->
+    ?assertEqual(false, aws_auth_validate_ldap:is_allowed_server("2002:a9fe:a9fe::")).
+
+%% 6to4 wrapping a public v4 stays allowed: the embedded address, not the 2002
+%% prefix, decides.
+server_allows_6to4_public_test() ->
+    ?assertEqual(true, aws_auth_validate_ldap:is_allowed_server("2002:808:808::")).
+
 %% 240.0.0.0/4 (reserved/Class E) and the 255.255.255.255 limited broadcast.
 server_blocks_reserved_and_broadcast_test() ->
     ?assertEqual(false, aws_auth_validate_ldap:is_allowed_server("240.0.0.1")),
@@ -319,6 +330,16 @@ peer_allowed_rebound_to_nat64_imds_blocked_test() ->
         blocked,
         aws_auth_validate_ldap:peer_allowed(
             {ok, {{16#0064, 16#ff9b, 0, 0, 0, 0, 16#a9fe, 16#a9fe}, 389}}
+        )
+    ).
+
+%% A peer that rebound to 6to4-wrapped IMDS (2002:a9fe:a9fe::) must be caught on
+%% the live socket, matching the pre-connect is_allowed_server/1 check.
+peer_allowed_rebound_to_6to4_imds_blocked_test() ->
+    ?assertEqual(
+        blocked,
+        aws_auth_validate_ldap:peer_allowed(
+            {ok, {{16#2002, 16#a9fe, 16#a9fe, 0, 0, 0, 0, 0}, 389}}
         )
     ).
 


### PR DESCRIPTION
## Summary

Three focused hardening fixes to the auth-config validation endpoint, closing gaps found in review. No behavioral change to the happy path; each change tightens a security or observability edge.

## Changes

**1. SSRF: unwrap 6to4 (`2002::/16`) embedded IPv4 (`aws_auth_validate_ldap`)**

`is_private_ip6/1` already re-checked IPv4-mapped (`::ffff:a.b.c.d`), IPv4-compatible (`::a.b.c.d`), and NAT64 (`64:ff9b::a.b.c.d`) forms against the v4 private/infra ranges, but not 6to4. A 6to4-wrapped address such as `2002:a9fe:a9fe::` decodes to `169.254.169.254` and, on a host with a 6to4 route, would reach IMDS -- bypassing the LDAP SSRF classifier. This adds the 6to4 clause (embedded v4 lives in the 2nd/3rd 16-bit words), bringing the LDAP classifier back in step with the shared `aws_auth_validate_net:classify_ip/2`, which already handled 6to4.

**2. LDAP: server-side `timeLimit` on every post-bind search (`aws_auth_validate_ldap`)**

`eldap:open/2`'s timeout bounds each socket recv on the client side, but there was no protocol-level `timeLimit`. A server that accepts the bind and then dribbles a search response could hold a semaphore slot busy for the full connection timeout on each of a request's several sequential post-bind searches (dn_lookup, principal resolution, membership/existence). This passes a `{timeout, Seconds}` to each of those searches, derived from the configured connection timeout (ms -> s, rounded up, floored at 1s) so it tracks the operator's budget.

**3. Audit: log the authenticated management username (`aws_auth_validate_mgmt`)**

The endpoint is admin-gated and makes outbound connections to caller-chosen targets (an SSRF surface), so the acting principal must be attributable. Behind the management load balancer, source IP alone is often just the LB. Every audit path now includes the authenticated username. Only the username is logged -- never tags, target host, URL, or DN (preserves R4/R6). Also: an oversized body is now audited under its own `body_too_large` category instead of `input_invalid`, so the audit trail matches the returned status.

## Tests

Added to `aws_auth_validate_tests.erl`:
- `server_blocks_6to4_imds_test` / `server_allows_6to4_public_test` -- pre-connect `is_allowed_server/1` classifies 6to4-wrapped IMDS as blocked, 6to4-wrapped public as allowed (the embedded address decides, not the `2002` prefix).
- `peer_allowed_rebound_to_6to4_imds_blocked_test` -- the live-socket `peer_allowed/1` check catches a peer that rebound to 6to4-wrapped IMDS, matching the pre-connect check (defeats DNS rebinding on this form).

## Security invariants preserved
- No credential/DN/host leakage in logs -- only the username was added.
- SSRF guard remains resolve-and-pin; this only closes an embedded-v4 decode gap.
- No change to endpoint contract (methods, fields, error categories/statuses).
