### PR TITLE
Fix: LDAP/UI divergence, shared module duplication, test coverage gaps

### DIFF
--- a/priv/www/js/aws_auth_validate.js
+++ b/priv/www/js/aws_auth_validate.js
@@ -53,6 +53,7 @@ var AWS_AUTH_VALIDATE_METHODS = ['ldap', 'http', 'oauth', 'tls'];
 var AWS_AUTH_VALIDATE_CATEGORY = {
     success:            {cls: 'status-green',  text: 'Validation succeeded (204).'},
     input_invalid:      {cls: 'status-red',    text: 'Input invalid: the request failed pure validation before any connection.'},
+    body_too_large:     {cls: 'status-red',    text: 'Request body too large: reduce the config size and retry.'},
     connection_failed:  {cls: 'status-red',    text: 'Connection failed: the target could not be reached.'},
     tls_failed:         {cls: 'status-red',    text: 'TLS failed: handshake or certificate verification did not succeed.'},
     query_invalid:      {cls: 'status-red',    text: 'Query invalid: an authorization query could not be parsed.'},
@@ -338,11 +339,18 @@ var AWS_AUTH_VALIDATE_CONF = {
             'auth_http.resource_path':                          {path: ['resource_path'], type: 'string', ex: 'https://auth.example.com/auth/resource'},
             'auth_http.topic_path':                             {path: ['topic_path'], type: 'string', ex: 'https://auth.example.com/auth/topic'},
             'auth_http.http_method':                            {path: ['http_method'], type: 'string', ex: 'post'},
-            // The four ssl_options entries below are identical in shape to the
-            // oauth ssl_options entries; keep the two hand-synced on any change
-            // (only the auth_http/auth_oauth2 conf-key prefix differs).
+            // The ssl_options entries below match the oauth ssl_options entries
+            // key-for-key; keep the two hand-synced on any change. Only the
+            // conf-key PREFIX differs: http uses auth_http.ssl_options.*, while
+            // oauth uses auth_oauth2.ssl_options.* EXCEPT hostname_verification,
+            // which the broker spells auth_oauth2.https.hostname_verification.
             'auth_http.ssl_options.verify':                     {path: ['ssl_options', 'verify'], type: 'string', ex: 'verify_peer'},
             'auth_http.ssl_options.sni':                        {path: ['ssl_options', 'sni'], type: 'string', ex: 'auth.example.com'},
+            // Mirrors the broker's auth_http.ssl_options.hostname_verification
+            // (wildcard|none); unset means strict OTP matching. Modeled so the
+            // validator matches the broker's hostname check rather than always
+            // using the lenient wildcard fun.
+            'auth_http.ssl_options.hostname_verification':      {path: ['ssl_options', 'hostname_verification'], type: 'string', ex: 'wildcard'},
             'aws.arns.auth_http.ssl_options.cacertfile':        {path: ['ssl_options', 'cacertfile_arn'], type: 'string', ex: 'arn:aws:s3:::my-bucket/ca-cert.pem'},
             'aws.arns.auth_http.ssl_options.certfile':          {path: ['ssl_options', 'certfile_arn'], type: 'string', ex: 'arn:aws:s3:::my-bucket/client-cert.pem'},
             'aws.arns.auth_http.ssl_options.keyfile':           {path: ['ssl_options', 'keyfile_arn'], type: 'string', ex: 'arn:aws:secretsmanager:us-west-2:111122223333:secret:RabbitMqClientKey'}
@@ -360,6 +368,10 @@ var AWS_AUTH_VALIDATE_CONF = {
             'auth_oauth2.scope_pattern_syntax':                 {path: ['scope_pattern_syntax'], type: 'string', ex: 'wildcard'},
             'auth_oauth2.ssl_options.verify':                   {path: ['ssl_options', 'verify'], type: 'string', ex: 'verify_peer'},
             'auth_oauth2.ssl_options.sni':                      {path: ['ssl_options', 'sni'], type: 'string', ex: 'idp.example.com'},
+            // The broker spells this one auth_oauth2.https.hostname_verification
+            // (NOT under ssl_options), but it maps to the same request field
+            // (wildcard|none); unset means strict OTP matching.
+            'auth_oauth2.https.hostname_verification':          {path: ['ssl_options', 'hostname_verification'], type: 'string', ex: 'wildcard'},
             'aws.arns.auth_oauth2.ssl_options.cacertfile':      {path: ['ssl_options', 'cacertfile_arn'], type: 'string', ex: 'arn:aws:s3:::my-bucket/ca-cert.pem'},
             'aws.arns.auth_oauth2.ssl_options.certfile':        {path: ['ssl_options', 'certfile_arn'], type: 'string', ex: 'arn:aws:s3:::my-bucket/client-cert.pem'},
             'aws.arns.auth_oauth2.ssl_options.keyfile':         {path: ['ssl_options', 'keyfile_arn'], type: 'string', ex: 'arn:aws:secretsmanager:us-west-2:111122223333:secret:RabbitMqClientKey'}

--- a/priv/www/js/aws_auth_validate.js
+++ b/priv/www/js/aws_auth_validate.js
@@ -70,20 +70,13 @@ var AWS_AUTH_VALIDATE_CATEGORY = {
 };
 
 // Read the visible method form into a JSON request body. Only non-empty fields
-// are included so an omitted optional field keeps the backend default. ssl_options
-// is collected from the selected method's own ssl sub-fields; ARN fields nest
-// under it to match the backend shape (ssl_options.cacertfile_arn etc.).
+// are included so an omitted optional field keeps the backend default; ARN
+// fields nest under ssl_options to match the backend shape.
 //
-// The scan is scoped to the SELECTED method's field container
-// (#aws-av-fields-<method>), never the whole form. Each method group carries its
-// own data-av-field / data-av-ssl inputs (the ssl_options key set differs per
-// backend -- e.g. ldap wants server_name_indication and has no client cert,
-// while http/oauth want sni + certfile/keyfile), and switching methods only
-// HIDES the other groups. A whole-form scan would therefore merge a previously-
-// selected method's (now hidden) values into this body -- producing a request
-// with foreign keys the backend rejects as input_invalid, and a permanent
-// divergence from the conf box. Scoping to the active group is what keeps the
-// body method-pure.
+// The scan is scoped to the SELECTED method's container (#aws-av-fields-<method>),
+// never the whole form: each method's ssl_options key set differs, and switching
+// methods only HIDES the other groups, so a whole-form scan would merge a hidden
+// method's values in and produce foreign keys the backend rejects.
 function aws_auth_validate_build_body(method) {
     var body = {};
     var $scope = $('#aws-av-fields-' + method);
@@ -327,6 +320,11 @@ var AWS_AUTH_VALIDATE_CONF = {
             // LDAP's ssl_options accepts server_name_indication (NOT sni) and has
             // no client-cert/mTLS material, so no certfile/keyfile ARN lines.
             'auth_ldap.ssl_options.server_name_indication':     {path: ['ssl_options', 'server_name_indication'], type: 'string', ex: 'ldap.example.com'},
+            // Mirrors the broker's auth_ldap.ssl_options.hostname_verification
+            // (wildcard|none); unset means strict OTP matching. Modeled so the
+            // validator matches the broker's hostname check rather than always
+            // using the lenient wildcard fun.
+            'auth_ldap.ssl_options.hostname_verification':      {path: ['ssl_options', 'hostname_verification'], type: 'string', ex: 'wildcard'},
             'aws.arns.auth_ldap.dn_lookup_bind.password':       {path: ['password_arn'], type: 'string', ex: 'arn:aws:secretsmanager:us-west-2:111122223333:secret:RabbitMqDnLookupUserPassword'},
             'aws.arns.auth_ldap.ssl_options.cacertfile':        {path: ['ssl_options', 'cacertfile_arn'], type: 'string', ex: 'arn:aws:s3:::my-bucket/ca-cert.pem'}
         },
@@ -340,6 +338,9 @@ var AWS_AUTH_VALIDATE_CONF = {
             'auth_http.resource_path':                          {path: ['resource_path'], type: 'string', ex: 'https://auth.example.com/auth/resource'},
             'auth_http.topic_path':                             {path: ['topic_path'], type: 'string', ex: 'https://auth.example.com/auth/topic'},
             'auth_http.http_method':                            {path: ['http_method'], type: 'string', ex: 'post'},
+            // The four ssl_options entries below are identical in shape to the
+            // oauth ssl_options entries; keep the two hand-synced on any change
+            // (only the auth_http/auth_oauth2 conf-key prefix differs).
             'auth_http.ssl_options.verify':                     {path: ['ssl_options', 'verify'], type: 'string', ex: 'verify_peer'},
             'auth_http.ssl_options.sni':                        {path: ['ssl_options', 'sni'], type: 'string', ex: 'auth.example.com'},
             'aws.arns.auth_http.ssl_options.cacertfile':        {path: ['ssl_options', 'cacertfile_arn'], type: 'string', ex: 'arn:aws:s3:::my-bucket/ca-cert.pem'},
@@ -689,21 +690,27 @@ function aws_auth_validate_strip_nonconf(method, body) {
     return out;
 }
 
-// Return a shallow copy of `body` with any top-level key whose value is boolean
-// `false` removed. Used ONLY to normalize the divergence comparison (see the
-// submit handler): to every backend an absent boolean equals an explicit
-// `false', so an unchecked box (key omitted) and a pasted `= false' (key present
-// as false) must compare equal. Non-boolean values and `true' are left as-is, so
-// this never masks a real difference. Nested objects (ssl_options) are not
-// descended into: their booleans (e.g. tls fail_if_no_peer_cert) are only ever
-// present when the operator set them, so the omit-vs-false asymmetry does not
-// arise there.
+// Return a copy of `body` with any key whose value is boolean `false` removed,
+// descending one level into ssl_options. Used ONLY to normalize the divergence
+// comparison (see the submit handler): to every backend an absent boolean equals
+// an explicit `false', so an unchecked box (key omitted) and a pasted `= false'
+// (key present as false) must compare equal. This applies to nested ssl_options
+// booleans too -- the tls method's ssl_options.fail_if_no_peer_cert is a checkbox
+// that omits the key when unchecked but parses to `false' when pasted, so without
+// recursing it would read as a false divergence. An ssl_options object emptied by
+// stripping is dropped so it matches a fields side that never set it. Non-boolean
+// values and `true' are left as-is, so this never masks a real difference.
 function aws_auth_validate_strip_false_bools(body) {
     if (!body || typeof body !== 'object') { return body; }
     var out = {};
     for (var k in body) {
         if (!Object.prototype.hasOwnProperty.call(body, k)) { continue; }
         if (body[k] === false) { continue; }
+        if (k === 'ssl_options' && body[k] && typeof body[k] === 'object') {
+            var ssl = aws_auth_validate_strip_false_bools(body[k]);
+            if (Object.keys(ssl).length > 0) { out[k] = ssl; }
+            continue;
+        }
         out[k] = body[k];
     }
     return out;
@@ -821,6 +828,10 @@ $(document).on('click', '#aws-auth-validate-submit', function() {
         // divergence would wrongly block Validate. Stripping false-valued keys
         // from both sides makes the comparison match the backend's semantics
         // without altering the request body actually sent.
+        // The pasted side carries the false-vs-absent asymmetry (a pasted
+        // `= false' vs an unchecked box). build_body never emits `false' today,
+        // so the fields-side strip is currently a no-op, but it is kept symmetric
+        // so the two sides stay comparable if build_body ever starts emitting one.
         var pastedCmp = aws_auth_validate_strip_false_bools(
             aws_auth_validate_strip_nonconf(method, pastedBody));
         var fieldsCmp = aws_auth_validate_strip_false_bools(

--- a/priv/www/js/tmpl/aws_auth_validate.ejs
+++ b/priv/www/js/tmpl/aws_auth_validate.ejs
@@ -166,8 +166,9 @@ SPDX-License-Identifier: Apache-2.0
         </p>
       </div>
 
-      <!-- ldap ssl_options: cacertfile_arn, verify, server_name_indication.
-           LDAP does NOT accept sni, certfile_arn, or keyfile_arn. -->
+      <!-- ldap ssl_options: cacertfile_arn, verify, server_name_indication,
+           hostname_verification. LDAP does NOT accept sni, certfile_arn, or
+           keyfile_arn. -->
       <div class="section-hidden">
         <h3>ssl_options</h3>
         <table class="form">
@@ -179,6 +180,10 @@ SPDX-License-Identifier: Apache-2.0
               <option value="verify_none">verify_none</option></select></td></tr>
           <tr><th><label>Server name indication:</label></th>
             <td><input type="text" data-av-ssl="server_name_indication" placeholder="ldap.example.com" /></td></tr>
+          <tr><th><label>Hostname verification:</label></th>
+            <td><select data-av-ssl="hostname_verification"><option value="">(default: strict)</option>
+              <option value="wildcard">wildcard</option>
+              <option value="none">none</option></select></td></tr>
         </table>
         <p class="argument">
           ARN fields are resolved server-side under the configured
@@ -204,7 +209,10 @@ SPDX-License-Identifier: Apache-2.0
             <option value="get">get</option><option value="post">post</option></select></td></tr>
       </table>
 
-      <!-- http ssl_options: cacertfile_arn, certfile_arn, keyfile_arn, verify, sni. -->
+      <!-- http ssl_options: cacertfile_arn, certfile_arn, keyfile_arn, verify, sni.
+           NOTE: this block is byte-identical to the oauth ssl_options block below;
+           the per-method split keeps them separate on purpose, so any ssl change
+           here must be hand-synced to the oauth copy (and its CONF map entry). -->
       <div class="section-hidden">
         <h3>ssl_options</h3>
         <table class="form">
@@ -291,7 +299,9 @@ SPDX-License-Identifier: Apache-2.0
         </table>
       </div>
 
-      <!-- oauth ssl_options: cacertfile_arn, certfile_arn, keyfile_arn, verify, sni. -->
+      <!-- oauth ssl_options: cacertfile_arn, certfile_arn, keyfile_arn, verify, sni.
+           NOTE: byte-identical to the http ssl_options block above; keep the two
+           (and their CONF map entries) hand-synced on any ssl change. -->
       <div class="section-hidden">
         <h3>ssl_options</h3>
         <table class="form">

--- a/priv/www/js/tmpl/aws_auth_validate.ejs
+++ b/priv/www/js/tmpl/aws_auth_validate.ejs
@@ -209,10 +209,12 @@ SPDX-License-Identifier: Apache-2.0
             <option value="get">get</option><option value="post">post</option></select></td></tr>
       </table>
 
-      <!-- http ssl_options: cacertfile_arn, certfile_arn, keyfile_arn, verify, sni.
-           NOTE: this block is byte-identical to the oauth ssl_options block below;
-           the per-method split keeps them separate on purpose, so any ssl change
-           here must be hand-synced to the oauth copy (and its CONF map entry). -->
+      <!-- http ssl_options: cacertfile_arn, certfile_arn, keyfile_arn, verify,
+           sni, hostname_verification.
+           NOTE: this block is byte-identical to the oauth ssl_options block below
+           (only the SNI placeholder text differs); the per-method split keeps them
+           separate on purpose, so any ssl change here must be hand-synced to the
+           oauth copy (and both CONF map entries). -->
       <div class="section-hidden">
         <h3>ssl_options</h3>
         <table class="form">
@@ -228,6 +230,10 @@ SPDX-License-Identifier: Apache-2.0
               <option value="verify_none">verify_none</option></select></td></tr>
           <tr><th><label>SNI:</label></th>
             <td><input type="text" data-av-ssl="sni" placeholder="auth.example.com" /></td></tr>
+          <tr><th><label>Hostname verification:</label></th>
+            <td><select data-av-ssl="hostname_verification"><option value="">(default: strict)</option>
+              <option value="wildcard">wildcard</option>
+              <option value="none">none</option></select></td></tr>
         </table>
         <p class="argument">
           ARN fields are resolved server-side under the configured
@@ -299,9 +305,11 @@ SPDX-License-Identifier: Apache-2.0
         </table>
       </div>
 
-      <!-- oauth ssl_options: cacertfile_arn, certfile_arn, keyfile_arn, verify, sni.
-           NOTE: byte-identical to the http ssl_options block above; keep the two
-           (and their CONF map entries) hand-synced on any ssl change. -->
+      <!-- oauth ssl_options: cacertfile_arn, certfile_arn, keyfile_arn, verify,
+           sni, hostname_verification.
+           NOTE: byte-identical to the http ssl_options block above (only the SNI
+           placeholder text differs); keep the two (and both CONF map entries)
+           hand-synced on any ssl change. -->
       <div class="section-hidden">
         <h3>ssl_options</h3>
         <table class="form">
@@ -317,6 +325,10 @@ SPDX-License-Identifier: Apache-2.0
               <option value="verify_none">verify_none</option></select></td></tr>
           <tr><th><label>SNI:</label></th>
             <td><input type="text" data-av-ssl="sni" placeholder="idp.example.com" /></td></tr>
+          <tr><th><label>Hostname verification:</label></th>
+            <td><select data-av-ssl="hostname_verification"><option value="">(default: strict)</option>
+              <option value="wildcard">wildcard</option>
+              <option value="none">none</option></select></td></tr>
         </table>
         <p class="argument">
           ARN fields are resolved server-side under the configured

--- a/src/aws_auth_validate_http.erl
+++ b/src/aws_auth_validate_http.erl
@@ -129,7 +129,8 @@
     <<"verify">>,
     <<"depth">>,
     <<"versions">>,
-    <<"sni">>
+    <<"sni">>,
+    <<"hostname_verification">>
 ]).
 %% Fixed, hardcoded reason strings (R4): no URL, host, or raw error echoed.
 -define(REASON_BAD_PATHS, <<"at least user_path must be a non-empty URL string">>).
@@ -140,12 +141,15 @@
 -define(REASON_BAD_SSL_OPTIONS, <<"ssl_options must be an object">>).
 -define(REASON_UNKNOWN_SSL_OPTION, <<
     "ssl_options contains an unknown key; allowed keys are cacertfile_arn, "
-    "certfile_arn, keyfile_arn, verify, depth, versions, sni"
+    "certfile_arn, keyfile_arn, verify, depth, versions, sni, hostname_verification"
 >>).
 -define(REASON_BAD_SSL_VERIFY, <<"ssl_options.verify must be verify_peer or verify_none">>).
 -define(REASON_BAD_SSL_DEPTH, <<"ssl_options.depth must be a non-negative integer">>).
 -define(REASON_BAD_SSL_VERSIONS, <<"ssl_options.versions must be a list of known TLS versions">>).
 -define(REASON_BAD_SSL_SNI, <<"ssl_options.sni must be a string">>).
+-define(REASON_BAD_SSL_HOSTNAME_VERIFICATION,
+    <<"ssl_options.hostname_verification must be wildcard or none">>
+).
 -define(REASON_BAD_SSL_CACERT_ARN, <<"ssl_options.cacertfile_arn must be a non-empty string">>).
 -define(REASON_BAD_SSL_CERT_ARN, <<"ssl_options.certfile_arn must be a non-empty string">>).
 -define(REASON_BAD_SSL_KEY_ARN, <<"ssl_options.keyfile_arn must be a non-empty string">>).
@@ -223,6 +227,7 @@ ssl_opts() ->
             bad_ssl_depth => ?REASON_BAD_SSL_DEPTH,
             bad_ssl_versions => ?REASON_BAD_SSL_VERSIONS,
             bad_ssl_sni => ?REASON_BAD_SSL_SNI,
+            bad_ssl_hostname_verification => ?REASON_BAD_SSL_HOSTNAME_VERIFICATION,
             bad_ssl_cacert_arn => ?REASON_BAD_SSL_CACERT_ARN,
             bad_ssl_cert_arn => ?REASON_BAD_SSL_CERT_ARN,
             bad_ssl_key_arn => ?REASON_BAD_SSL_KEY_ARN
@@ -769,7 +774,12 @@ build_client_ssl_opts(#{ssl_options := Map} = Params) ->
                     %% Whether the caller set verify explicitly governs the
                     %% no-trust-anchor policy (fail vs silent default).
                     VerifyExplicit = maps:is_key(<<"verify">>, Map),
-                    aws_auth_validate_ssl:apply_verify_default(Opts, VerifyExplicit)
+                    %% Mirror rabbit_auth_backend_http: the RFC 6125 https match
+                    %% fun is applied ONLY when ssl_hostname_verification =
+                    %% wildcard; unset is strict OTP matching. Defaulting to
+                    %% wildcard here would pass a cert the live broker rejects.
+                    HostnameCheck = aws_auth_validate_ssl:hostname_check_mode(Map),
+                    aws_auth_validate_ssl:apply_verify_default(Opts, VerifyExplicit, HostnameCheck)
             end
     end.
 

--- a/src/aws_auth_validate_ldap.erl
+++ b/src/aws_auth_validate_ldap.erl
@@ -48,9 +48,19 @@
 %% Exposed for unit tests: build_ssl_opts/1 translates validated ssl_options
 %% to the eldap proplist; build_tls_opts/2 layers the shared verify-mode policy
 %% on top (returning the fail-loud {ok,_}|{error,tls_failed,_} contract);
-%% peer_allowed/1 is the post-connect SSRF re-check on a peername result. All
-%% are otherwise internal.
--export([build_ssl_opts/1, build_tls_opts/2, is_allowed_server/1, peer_allowed/1]).
+%% peer_allowed/1 is the post-connect SSRF re-check on a peername result;
+%% is_private_ip/1 + is_private_ip6/1 are the SSRF address classifiers (incl. the
+%% v6-embedded-v4 unwrapping); search_time_limit_seconds/0 is the post-bind
+%% search timeLimit. All are otherwise internal.
+-export([
+    build_ssl_opts/1,
+    build_tls_opts/2,
+    is_allowed_server/1,
+    peer_allowed/1,
+    is_private_ip/1,
+    is_private_ip6/1,
+    search_time_limit_seconds/0
+]).
 -endif.
 
 -include_lib("eldap/include/eldap.hrl").
@@ -75,8 +85,14 @@
     <<"verify">>,
     <<"depth">>,
     <<"versions">>,
-    <<"server_name_indication">>
+    <<"server_name_indication">>,
+    <<"hostname_verification">>
 ]).
+
+%% Accepted values for `hostname_verification'. Mirrors the broker's
+%% auth_ldap.ssl_options.hostname_verification enum ({wildcard, none}); the
+%% broker's default (key unset) is strict OTP matching.
+-define(SSL_HOSTNAME_VERIFICATION_VALUES, [<<"wildcard">>, <<"none">>]).
 
 %% Accepted values for the `verify' ssl option. Mirrors the ssl app's two
 %% modes; anything else is a mis-typed value and rejected up front rather
@@ -104,12 +120,15 @@
 -define(REASON_BAD_SSL_OPTIONS, <<"ssl_options must be an object">>).
 -define(REASON_UNKNOWN_SSL_OPTION, <<
     "ssl_options contains an unknown key; allowed keys are cacertfile_arn, "
-    "verify, depth, versions, server_name_indication"
+    "verify, depth, versions, server_name_indication, hostname_verification"
 >>).
 -define(REASON_BAD_SSL_VERIFY, <<"ssl_options.verify must be verify_peer or verify_none">>).
 -define(REASON_BAD_SSL_DEPTH, <<"ssl_options.depth must be a non-negative integer">>).
 -define(REASON_BAD_SSL_VERSIONS, <<"ssl_options.versions must be a list of known TLS versions">>).
 -define(REASON_BAD_SSL_SNI, <<"ssl_options.server_name_indication must be a string">>).
+-define(REASON_BAD_SSL_HOSTNAME_VERIFICATION,
+    <<"ssl_options.hostname_verification must be wildcard or none">>
+).
 -define(REASON_BAD_SSL_CACERT_ARN, <<"ssl_options.cacertfile_arn must be a non-empty string">>).
 -define(REASON_CACERT_ARN_RESOLVE, <<"failed to resolve ssl_options.cacertfile_arn">>).
 -define(REASON_CACERT_PEM_INVALID,
@@ -418,6 +437,11 @@ valid_ssl_value(<<"server_name_indication">>, V) ->
         true -> ok;
         false -> {error, input_invalid, ?REASON_BAD_SSL_SNI}
     end;
+valid_ssl_value(<<"hostname_verification">>, V) ->
+    case lists:member(V, ?SSL_HOSTNAME_VERIFICATION_VALUES) of
+        true -> ok;
+        false -> {error, input_invalid, ?REASON_BAD_SSL_HOSTNAME_VERIFICATION}
+    end;
 valid_ssl_value(<<"cacertfile_arn">>, V) ->
     case is_nonempty_binary(V) of
         true -> ok;
@@ -559,28 +583,26 @@ is_private_ip(_) -> false.
 %%   fc00::/7       unique local addresses (ULA). Includes the IPv6 IMDS
 %%                  address fd00:ec2::254 -- the whole point of this block.
 %%   fe80::/10      link-local (spans fe80..febf, NOT just fe80)
-%% IPv4-mapped (::ffff:a.b.c.d), IPv4-compatible (::a.b.c.d), NAT64
-%% (64:ff9b::a.b.c.d), and 6to4 (2002:a.b.c.d::/16) addresses embed a v4 address;
-%% re-check those against the v4 ranges so e.g. ::ffff:169.254.169.254 (and the
-%% NAT64 form 64:ff9b::169.254.169.254, which a host with a NAT64/DNS64 resolver
-%% would translate to IMDS, or the 6to4 form 2002:a9fe:a9fe:: on a host with a
-%% 6to4 route) cannot reach IMDS. Mirrors the embedded-v4 unwrapping in the
-%% shared aws_auth_validate_net:classify_ip/2 so the two SSRF classifiers stay in
-%% step.
-is_private_ip6({0, 0, 0, 0, 0, 0, 0, 1}) -> true;
-is_private_ip6({0, 0, 0, 0, 0, 0, 0, 0}) -> true;
+%% v4-carrying notations (IPv4-mapped, IPv4-compatible, NAT64 64:ff9b::/96,
+%% 6to4 2002::/16) are unwrapped by the shared aws_auth_validate_net:embedded_v4/1
+%% and re-checked against the v4 ranges, so e.g. ::ffff:169.254.169.254 or the
+%% 6to4 form 2002:a9fe:a9fe:: cannot reach IMDS. Sharing that unwrapper (rather
+%% than a hand-copied one) keeps the two SSRF classifiers decoding the same
+%% encodings while LDAP keeps its own stricter range policy (is_private_ip/1
+%% denies all RFC1918/CGNAT, not just broker infra).
+is_private_ip6({0, 0, 0, 0, 0, 0, 0, 1}) ->
+    true;
+is_private_ip6({0, 0, 0, 0, 0, 0, 0, 0}) ->
+    true;
 is_private_ip6({W1, _, _, _, _, _, _, _}) when W1 >= 16#fc00, W1 =< 16#fdff -> true;
 is_private_ip6({W1, _, _, _, _, _, _, _}) when W1 >= 16#fe80, W1 =< 16#febf -> true;
-is_private_ip6({0, 0, 0, 0, 0, 16#ffff, W7, W8}) -> is_private_ip(v6_words_to_v4(W7, W8));
-is_private_ip6({16#0064, 16#ff9b, 0, 0, 0, 0, W7, W8}) -> is_private_ip(v6_words_to_v4(W7, W8));
-%% 6to4 2002::/16: the embedded v4 lives in the 2nd and 3rd 16-bit words.
-is_private_ip6({16#2002, W2, W3, _, _, _, _, _}) -> is_private_ip(v6_words_to_v4(W2, W3));
-is_private_ip6({0, 0, 0, 0, 0, 0, W7, W8}) -> is_private_ip(v6_words_to_v4(W7, W8));
-is_private_ip6(_) -> false.
-
-%% Split the low 32 bits of a v4-mapped/compatible v6 address into a v4 tuple.
-v6_words_to_v4(W7, W8) ->
-    {W7 bsr 8, W7 band 16#ff, W8 bsr 8, W8 band 16#ff}.
+is_private_ip6({_, _, _, _, _, _, _, _} = V6) ->
+    case aws_auth_validate_net:embedded_v4(V6) of
+        {ok, V4} -> is_private_ip(V4);
+        none -> false
+    end;
+is_private_ip6(_) ->
+    false.
 
 %%--------------------------------------------------------------------
 %% Config conflict
@@ -1009,8 +1031,12 @@ maybe_start_tls(Handle, true, TlsOpts, Timeout) ->
 %%
 %% This produces the raw translation only; the verify-mode default (and its
 %% fail-loud no-anchor policy) is applied by build_tls_opts/2 via the shared
-%% aws_auth_validate_ssl:apply_verify_default/2. Kept separate so the unit tests
+%% aws_auth_validate_ssl:apply_verify_default/3. Kept separate so the unit tests
 %% can pin the translation independently of the trust-anchor policy.
+%%
+%% `hostname_verification' is intentionally NOT translated here: it is a control
+%% input for the shared helper's hostname-match mode, not a direct ssl option, so
+%% build_tls_opts/2 reads it and passes the resolved mode alongside.
 %%
 %% No `catch' here. The previous `(catch Fun(Value))' swallowed every error,
 %% which the value-validation in parse_ssl_options/2 has now made unnecessary
@@ -1051,16 +1077,19 @@ add_ssl_opt(SslKey, Fun, Value, Acc) ->
 %% TlsInUse is (use_ssl orelse use_starttls); on a plaintext request there is no
 %% TLS to shape, so return an empty list unused by ssl_open_opts(false, _).
 %%
-%% The verify-mode default is delegated to aws_auth_validate_ssl:apply_verify_default/2
-%% -- the SAME helper the http/oauth backends use -- so all three outbound backends
-%% share one policy:
+%% The verify-mode default is delegated to the shared
+%% aws_auth_validate_ssl:apply_verify_default/3, so the no-anchor policy matches
+%% the http/oauth backends:
 %%   * an EXPLICIT verify_peer with no trust anchor FAILS loud as tls_failed (never
 %%     silently downgraded -- the false positive this endpoint exists to prevent),
 %%   * a DEFAULTED verify_peer with no anchor downgrades to verify_none (broker
 %%     parity -- a plain reachability probe still works without a CA store),
-%%   * an explicit verify_none is untouched, and every verify_peer path also gets
-%%     the RFC 6125 https hostname-match fun so wildcard IdP/LDAPS certs verify the
-%%     way mainstream clients do.
+%%   * an explicit verify_none is untouched.
+%% The hostname-check mode is passed explicitly (NOT the http/oauth wildcard
+%% default): LDAP mirrors rabbit_auth_backend_ldap, which applies the RFC 6125
+%% https match fun ONLY when auth_ldap.ssl_options.hostname_verification =
+%% wildcard, and otherwise uses OTP strict matching. Defaulting to wildcard here
+%% would pass a wildcard LDAPS cert the live broker rejects.
 %% VerifyExplicit is whether the caller set `verify' themselves; it governs the
 %% fail-vs-downgrade branch for the no-anchor case.
 -spec build_tls_opts(boolean(), map()) ->
@@ -1070,7 +1099,17 @@ build_tls_opts(false, _SslOpts) ->
 build_tls_opts(true, SslOpts) ->
     Translated = build_ssl_opts(SslOpts),
     VerifyExplicit = maps:is_key(<<"verify">>, SslOpts),
-    aws_auth_validate_ssl:apply_verify_default(Translated, VerifyExplicit).
+    HostnameCheck = hostname_check_mode(SslOpts),
+    aws_auth_validate_ssl:apply_verify_default(Translated, VerifyExplicit, HostnameCheck).
+
+%% Map the modeled hostname_verification input to the shared helper's mode.
+%% Unset (or the broker's `none') means strict OTP matching -- the broker
+%% default; `wildcard' opts into the RFC 6125 https match fun.
+hostname_check_mode(SslOpts) ->
+    case maps:get(<<"hostname_verification">>, SslOpts, undefined) of
+        <<"wildcard">> -> wildcard;
+        _ -> strict
+    end.
 
 %%--------------------------------------------------------------------
 
@@ -1085,12 +1124,12 @@ connection_timeout_ms() ->
     aws_auth_validate_ssl:connection_timeout_ms(#{default => ?DEFAULT_TIMEOUT_MS, max => 60_000}).
 
 %% Server-side LDAP search time limit, in whole seconds, for the post-bind
-%% probes (dn_lookup, principal resolution, membership/existence). eldap's
-%% open/2 timeout already bounds each socket recv on the client side; this adds
-%% the protocol-level timeLimit so a server that accepts the bind and then
-%% dribbles a search response cannot keep a probe -- and thus a semaphore slot --
-%% busy for the full connection timeout on every one of a request's several
-%% sequential searches. Derived from the same request-timeout config (ms -> s,
-%% rounded up, floored at 1s) so it tracks the operator's configured budget.
+%% probes (dn_lookup, principal resolution, membership/existence). This is the
+%% protocol-level timeLimit, which is server-COOPERATIVE: a compliant server
+%% bounds its own search time, but a server that stalls at the TCP layer ignores
+%% it -- only the eldap open/2 socket recv timeout bounds that case. It is a
+%% best-effort budget, not a hard DoS cap. Derived from the same request-timeout
+%% config (ms -> s, rounded up, floored at 1s) so it tracks the operator's
+%% configured budget.
 search_time_limit_seconds() ->
     max(1, (connection_timeout_ms() + 999) div 1000).

--- a/src/aws_auth_validate_ldap.erl
+++ b/src/aws_auth_validate_ldap.erl
@@ -1099,17 +1099,9 @@ build_tls_opts(false, _SslOpts) ->
 build_tls_opts(true, SslOpts) ->
     Translated = build_ssl_opts(SslOpts),
     VerifyExplicit = maps:is_key(<<"verify">>, SslOpts),
-    HostnameCheck = hostname_check_mode(SslOpts),
+    %% Shared with http/oauth: unset/`none' = strict, `wildcard' opts in.
+    HostnameCheck = aws_auth_validate_ssl:hostname_check_mode(SslOpts),
     aws_auth_validate_ssl:apply_verify_default(Translated, VerifyExplicit, HostnameCheck).
-
-%% Map the modeled hostname_verification input to the shared helper's mode.
-%% Unset (or the broker's `none') means strict OTP matching -- the broker
-%% default; `wildcard' opts into the RFC 6125 https match fun.
-hostname_check_mode(SslOpts) ->
-    case maps:get(<<"hostname_verification">>, SslOpts, undefined) of
-        <<"wildcard">> -> wildcard;
-        _ -> strict
-    end.
 
 %%--------------------------------------------------------------------
 

--- a/src/aws_auth_validate_mgmt.erl
+++ b/src/aws_auth_validate_mgmt.erl
@@ -28,8 +28,10 @@
 -ifdef(TEST).
 %% Exposed for unit tests: status_for_category/1 maps a backend error category
 %% to an HTTP status, including the catch-all for an unexpected category;
-%% max_body_size/0 resolves the configured body-size limit against its bounds.
--export([status_for_category/1, max_body_size/0]).
+%% max_body_size/0 resolves the configured body-size limit against its bounds;
+%% sanitize_log/1 strips control chars from a caller-influenceable audit field;
+%% username/1 extracts the authenticated principal (or the `unknown' fallback).
+-export([status_for_category/1, max_body_size/0, sanitize_log/1, username/1]).
 -endif.
 
 -include_lib("rabbitmq_web_dispatch/include/rabbitmq_web_dispatch_records.hrl").
@@ -201,6 +203,7 @@ respond({error, Category, Reason}, Req, Context) when is_atom(Category), is_bina
     reply_error(Status, Category, Reason, Req, Context).
 
 status_for_category(input_invalid) -> 400;
+status_for_category(body_too_large) -> 400;
 status_for_category(connection_failed) -> 400;
 status_for_category(tls_failed) -> 400;
 status_for_category(query_invalid) -> 400;

--- a/src/aws_auth_validate_net.erl
+++ b/src/aws_auth_validate_net.erl
@@ -36,6 +36,7 @@
     url_allowed/2,
     classify_address/2,
     classify_ip/2,
+    embedded_v4/1,
     resolve_and_pin/2,
     pin_url/2,
     in_cidr/2,
@@ -85,35 +86,44 @@ classify_address(#{host := Host}, Policy) ->
     end.
 
 %% classify_ip/2: allow | deny for a parsed IP tuple. Denies the broker-infra
-%% ranges only. Several IPv6 notations embed a v4 address; each is unwrapped to
-%% its v4 form and re-classified, otherwise the v6 encoding smuggles a denied v4
-%% address (e.g. 169.254.169.254) past the v4 denylist. Covered: IPv4-mapped
-%% ::ffff:a.b.c.d, IPv4-compatible ::a.b.c.d, NAT64 64:ff9b::/96, 6to4 2002::/16.
+%% ranges only. A v6 address that embeds a v4 address is unwrapped via the shared
+%% embedded_v4/1 and re-classified as v4, otherwise the v6 encoding smuggles a
+%% denied v4 address (e.g. 169.254.169.254) past the v4 denylist.
 -spec classify_ip(tuple(), policy()) -> allow | deny.
-classify_ip({0, 0, 0, 0, 0, 16#ffff, W1, W2}, Policy) ->
-    %% IPv4-mapped ::ffff:a.b.c.d
-    classify_ip(v4_from_words(W1, W2), Policy);
-classify_ip({0, 0, 0, 0, 0, 0, W1, W2}, Policy) when {W1, W2} =/= {0, 0}, {W1, W2} =/= {0, 1} ->
-    %% IPv4-compatible ::a.b.c.d (RFC4291-deprecated). The guard lets the
-    %% unspecified :: and loopback ::1 fall through to the v6 denylist instead
-    %% (::1 must be matched as v6 loopback, not as v4 0.0.0.1).
-    classify_ip(v4_from_words(W1, W2), Policy);
-classify_ip({16#64, 16#ff9b, 0, 0, 0, 0, W1, W2}, Policy) ->
-    %% NAT64 well-known prefix 64:ff9b::/96 -> embedded v4 in the low 32 bits.
-    classify_ip(v4_from_words(W1, W2), Policy);
-classify_ip({16#2002, W1, W2, _, _, _, _, _}, Policy) ->
-    %% 6to4 2002::/16 -> embedded v4 in segments 2-3.
-    classify_ip(v4_from_words(W1, W2), Policy);
+classify_ip({_, _, _, _, _, _, _, _} = V6, Policy) ->
+    case embedded_v4(V6) of
+        {ok, V4} ->
+            classify_ip(V4, Policy);
+        none ->
+            case in_any_cidr(V6, maps:get(denied_v6, Policy)) of
+                true -> classify_denied(V6);
+                false -> allow
+            end
+    end;
 classify_ip({_, _, _, _} = V4, Policy) ->
     case in_any_cidr(V4, maps:get(denied_v4, Policy)) of
         true -> classify_denied(V4);
         false -> allow
-    end;
-classify_ip({_, _, _, _, _, _, _, _} = V6, Policy) ->
-    case in_any_cidr(V6, maps:get(denied_v6, Policy)) of
-        true -> classify_denied(V6);
-        false -> allow
     end.
+
+%% embedded_v4/1: for the IPv6 notations that carry a v4 address, return
+%% {ok, V4Tuple}; otherwise `none'. Policy-independent unwrapping shared with
+%% the LDAP SSRF classifier (aws_auth_validate_ldap:is_private_ip6/1) so both
+%% classifiers decode the same encodings from one place. Covered: IPv4-mapped
+%% ::ffff:a.b.c.d, IPv4-compatible ::a.b.c.d, NAT64 64:ff9b::/96, 6to4 2002::/16.
+%% The unspecified :: and loopback ::1 are deliberately NOT unwrapped -- they
+%% must be classified as v6 (::1 is v6 loopback, not v4 0.0.0.1).
+-spec embedded_v4(tuple()) -> {ok, {byte(), byte(), byte(), byte()}} | none.
+embedded_v4({0, 0, 0, 0, 0, 16#ffff, W1, W2}) ->
+    {ok, v4_from_words(W1, W2)};
+embedded_v4({0, 0, 0, 0, 0, 0, W1, W2}) when {W1, W2} =/= {0, 0}, {W1, W2} =/= {0, 1} ->
+    {ok, v4_from_words(W1, W2)};
+embedded_v4({16#64, 16#ff9b, 0, 0, 0, 0, W1, W2}) ->
+    {ok, v4_from_words(W1, W2)};
+embedded_v4({16#2002, W1, W2, _, _, _, _, _}) ->
+    {ok, v4_from_words(W1, W2)};
+embedded_v4(_) ->
+    none.
 
 %% A denied address is normally `deny'. The ONE exception is loopback when
 %% auth_validation_allow_private_networks is set (test-only, default false): that

--- a/src/aws_auth_validate_oauth.erl
+++ b/src/aws_auth_validate_oauth.erl
@@ -100,7 +100,8 @@
     parse_access_token/1,
     token_header/1,
     verify_token/3,
-    select_jwk/2
+    select_jwk/2,
+    build_client_ssl_opts/1
 ]).
 -endif.
 
@@ -135,7 +136,8 @@
     <<"verify">>,
     <<"depth">>,
     <<"versions">>,
-    <<"sni">>
+    <<"sni">>,
+    <<"hostname_verification">>
 ]).
 
 %% Fixed, hardcoded reason strings (R4): no URL, host, or raw error echoed.
@@ -146,12 +148,15 @@
 -define(REASON_BAD_SSL_OPTIONS, <<"ssl_options must be an object">>).
 -define(REASON_UNKNOWN_SSL_OPTION, <<
     "ssl_options contains an unknown key; allowed keys are cacertfile_arn, "
-    "certfile_arn, keyfile_arn, verify, depth, versions, sni"
+    "certfile_arn, keyfile_arn, verify, depth, versions, sni, hostname_verification"
 >>).
 -define(REASON_BAD_SSL_VERIFY, <<"ssl_options.verify must be verify_peer or verify_none">>).
 -define(REASON_BAD_SSL_DEPTH, <<"ssl_options.depth must be a non-negative integer">>).
 -define(REASON_BAD_SSL_VERSIONS, <<"ssl_options.versions must be a list of known TLS versions">>).
 -define(REASON_BAD_SSL_SNI, <<"ssl_options.sni must be a string">>).
+-define(REASON_BAD_SSL_HOSTNAME_VERIFICATION,
+    <<"ssl_options.hostname_verification must be wildcard or none">>
+).
 -define(REASON_BAD_SSL_CACERT_ARN, <<"ssl_options.cacertfile_arn must be a non-empty string">>).
 -define(REASON_BAD_SSL_CERT_ARN, <<"ssl_options.certfile_arn must be a non-empty string">>).
 -define(REASON_BAD_SSL_KEY_ARN, <<"ssl_options.keyfile_arn must be a non-empty string">>).
@@ -266,6 +271,7 @@ ssl_opts() ->
             bad_ssl_depth => ?REASON_BAD_SSL_DEPTH,
             bad_ssl_versions => ?REASON_BAD_SSL_VERSIONS,
             bad_ssl_sni => ?REASON_BAD_SSL_SNI,
+            bad_ssl_hostname_verification => ?REASON_BAD_SSL_HOSTNAME_VERIFICATION,
             bad_ssl_cacert_arn => ?REASON_BAD_SSL_CACERT_ARN,
             bad_ssl_cert_arn => ?REASON_BAD_SSL_CERT_ARN,
             bad_ssl_key_arn => ?REASON_BAD_SSL_KEY_ARN
@@ -1178,7 +1184,12 @@ build_client_ssl_opts(#{ssl_options := Map} = Params) ->
                         CacertOpts ++ ClientOpts ++
                             aws_auth_validate_ssl:translate_ssl_opts(Map, <<"sni">>),
                     VerifyExplicit = maps:is_key(<<"verify">>, Map),
-                    aws_auth_validate_ssl:apply_verify_default(Opts, VerifyExplicit)
+                    %% Mirror oauth2_client: hostname_verification defaults to
+                    %% none (strict); the RFC 6125 https match fun is applied only
+                    %% on wildcard. Defaulting to wildcard would pass an IdP cert
+                    %% the live broker rejects.
+                    HostnameCheck = aws_auth_validate_ssl:hostname_check_mode(Map),
+                    aws_auth_validate_ssl:apply_verify_default(Opts, VerifyExplicit, HostnameCheck)
             end
     end.
 

--- a/src/aws_auth_validate_ssl.erl
+++ b/src/aws_auth_validate_ssl.erl
@@ -47,6 +47,7 @@
     translate_ssl_opts/2,
     apply_verify_default/2,
     apply_verify_default/3,
+    hostname_check_mode/1,
     ensure_trust_anchor/1,
     trust_source/1,
     os_cacerts/0,
@@ -66,6 +67,10 @@
 
 %% Accepted values for `verify' and `versions', shared by all backends.
 -define(SSL_VERIFY_VALUES, [<<"verify_peer">>, <<"verify_none">>]).
+%% Accepted values for `hostname_verification'. Mirrors the broker's
+%% ssl_hostname_verification / oauth hostname_verification enum; unset means
+%% strict OTP matching (the broker default for all three backends).
+-define(SSL_HOSTNAME_VERIFICATION_VALUES, [<<"wildcard">>, <<"none">>]).
 -define(SSL_VERSION_VALUES, [
     <<"tlsv1.3">>,
     <<"tlsv1.2">>,
@@ -244,6 +249,11 @@ valid_ssl_value(<<"fail_if_no_peer_cert">>, V, _Opts) when is_boolean(V) ->
     ok;
 valid_ssl_value(<<"fail_if_no_peer_cert">>, _V, Opts) ->
     {error, input_invalid, reason(bad_ssl_fail_if_no_peer_cert, Opts)};
+valid_ssl_value(<<"hostname_verification">>, V, Opts) ->
+    case lists:member(V, ?SSL_HOSTNAME_VERIFICATION_VALUES) of
+        true -> ok;
+        false -> {error, input_invalid, reason(bad_ssl_hostname_verification, Opts)}
+    end;
 valid_ssl_value(<<"cacertfile_arn">>, V, Opts) ->
     nonempty_or(V, bad_ssl_cacert_arn, Opts);
 valid_ssl_value(<<"certfile_arn">>, V, Opts) ->
@@ -378,12 +388,20 @@ translate_ssl_opts(Map, SniKey) ->
 %% verify falls back to verify_none; an explicit verify_none is untouched; and
 %% when verify is absent we default to verify_peer only if an anchor exists.
 %%
-%% The /2 form applies the RFC 6125 https hostname-match fun on every verify_peer
-%% path (see ensure_hostname_check/1). This is correct for the http/oauth
-%% backends: their IdP endpoints commonly present single-label wildcard certs
-%% (e.g. Cognito's `foo.auth.<region>.amazoncognito.com' against
-%% `*.auth.<region>.amazoncognito.com') that every mainstream HTTPS client
-%% accepts, so omitting the fun would report tls_failed for valid endpoints.
+%% The /2 form is a thin wrapper that defaults the hostname-check mode to
+%% `wildcard'. It is retained only for callers/tests that want the lenient RFC
+%% 6125 https match fun explicitly; production backends all call the /3 form with
+%% a mode computed from the modeled `hostname_verification' input, because the
+%% broker defaults to STRICT matching for ALL THREE backends and only opts into
+%% the wildcard fun when configured:
+%%   * http:  rabbit_auth_backend_http applies it only on ssl_hostname_verification
+%%            = wildcard; unset is strict.
+%%   * oauth: oauth2_client reads hostname_verification (default none = strict).
+%%   * ldap:  rabbit_auth_backend_ldap applies it only on
+%%            auth_ldap.ssl_options.hostname_verification = wildcard.
+%% Defaulting to wildcard therefore diverges too-lenient: a wildcard/mismatched
+%% server cert the live broker rejects at handshake would pass the validator
+%% green. See maybe_hostname_check/2 and the /3 form below.
 apply_verify_default(Opts, VerifyExplicit) ->
     apply_verify_default(Opts, VerifyExplicit, wildcard).
 
@@ -429,6 +447,17 @@ maybe_hostname_check(Opts, wildcard) ->
     ensure_hostname_check(Opts);
 maybe_hostname_check(Opts, strict) ->
     Opts.
+
+%% Map the modeled `hostname_verification' ssl_options input to the /3 hostname
+%% -check mode. Unset (or the broker's `none') means strict OTP matching -- the
+%% broker default for all three backends; `wildcard' opts into the RFC 6125 https
+%% match fun. Shared so http/oauth/ldap resolve the mode identically.
+-spec hostname_check_mode(map()) -> wildcard | strict.
+hostname_check_mode(SslOpts) when is_map(SslOpts) ->
+    case maps:get(<<"hostname_verification">>, SslOpts, undefined) of
+        <<"wildcard">> -> wildcard;
+        _ -> strict
+    end.
 
 %% Add the https-scheme hostname-match fun so wildcard certs verify the way a
 %% browser/curl/openssl would (RFC 6125). Applied only on verify_peer paths, and

--- a/src/aws_auth_validate_ssl.erl
+++ b/src/aws_auth_validate_ssl.erl
@@ -46,6 +46,7 @@
     decode_client_key/1,
     translate_ssl_opts/2,
     apply_verify_default/2,
+    apply_verify_default/3,
     ensure_trust_anchor/1,
     trust_source/1,
     os_cacerts/0,
@@ -377,35 +378,57 @@ translate_ssl_opts(Map, SniKey) ->
 %% verify falls back to verify_none; an explicit verify_none is untouched; and
 %% when verify is absent we default to verify_peer only if an anchor exists.
 %%
-%% Every verify_peer path also gets the https hostname-match fun (see
-%% ensure_hostname_check/1): without it ssl's default hostname check rejects a
-%% multi-label host under a single-label wildcard cert (e.g. Cognito's
-%% `foo.auth.<region>.amazoncognito.com' against `*.auth.<region>.amazoncognito.com'),
-%% which every mainstream HTTPS client accepts under RFC 6125. Omitting it made
-%% the probe report tls_failed for perfectly valid IdP endpoints -- the exact
-%% false-negative this endpoint exists to avoid.
--spec apply_verify_default(list(), boolean()) ->
-    {ok, list()} | {error, aws_auth_validate_backend:error_category(), binary()}.
+%% The /2 form applies the RFC 6125 https hostname-match fun on every verify_peer
+%% path (see ensure_hostname_check/1). This is correct for the http/oauth
+%% backends: their IdP endpoints commonly present single-label wildcard certs
+%% (e.g. Cognito's `foo.auth.<region>.amazoncognito.com' against
+%% `*.auth.<region>.amazoncognito.com') that every mainstream HTTPS client
+%% accepts, so omitting the fun would report tls_failed for valid endpoints.
 apply_verify_default(Opts, VerifyExplicit) ->
+    apply_verify_default(Opts, VerifyExplicit, wildcard).
+
+%% The /3 form lets a backend model the broker's own hostname-verification
+%% setting instead of always using the lenient https fun. HostnameCheck:
+%%   * wildcard -> apply the RFC 6125 https match fun on verify_peer paths
+%%     (browser/curl behaviour). This is the http/oauth default.
+%%   * strict   -> leave OTP's default (exact) hostname matching in place.
+%% The LDAP backend passes `strict' unless the operator opts in, mirroring
+%% rabbit_auth_backend_ldap: the broker applies the https fun ONLY when
+%% auth_ldap.ssl_options.hostname_verification = wildcard, and otherwise uses
+%% strict matching. Defaulting the validator to wildcard for LDAP diverged in
+%% the too-lenient direction -- a wildcard LDAPS cert the live broker rejects
+%% would pass the validator green.
+-spec apply_verify_default(list(), boolean(), wildcard | strict) ->
+    {ok, list()} | {error, aws_auth_validate_backend:error_category(), binary()}.
+apply_verify_default(Opts, VerifyExplicit, HostnameCheck) ->
     case lists:keyfind(verify, 1, Opts) of
         {verify, verify_peer} when VerifyExplicit ->
             case ensure_trust_anchor(Opts) of
-                {ok, Opts1} -> {ok, ensure_hostname_check(Opts1)};
+                {ok, Opts1} -> {ok, maybe_hostname_check(Opts1, HostnameCheck)};
                 none -> {error, tls_failed, no_trust_anchor()}
             end;
         {verify, verify_peer} ->
             case ensure_trust_anchor(Opts) of
-                {ok, Opts1} -> {ok, ensure_hostname_check(Opts1)};
+                {ok, Opts1} -> {ok, maybe_hostname_check(Opts1, HostnameCheck)};
                 none -> {ok, lists:keyreplace(verify, 1, Opts, {verify, verify_none})}
             end;
         {verify, _Other} ->
             {ok, Opts};
         false ->
             case ensure_trust_anchor(Opts) of
-                {ok, Opts1} -> {ok, [{verify, verify_peer} | ensure_hostname_check(Opts1)]};
-                none -> {ok, Opts}
+                {ok, Opts1} ->
+                    {ok, [{verify, verify_peer} | maybe_hostname_check(Opts1, HostnameCheck)]};
+                none ->
+                    {ok, Opts}
             end
     end.
+
+%% Apply the https match fun only under wildcard mode; strict mode leaves OTP's
+%% default (exact) hostname matching untouched.
+maybe_hostname_check(Opts, wildcard) ->
+    ensure_hostname_check(Opts);
+maybe_hostname_check(Opts, strict) ->
+    Opts.
 
 %% Add the https-scheme hostname-match fun so wildcard certs verify the way a
 %% browser/curl/openssl would (RFC 6125). Applied only on verify_peer paths, and
@@ -424,6 +447,13 @@ ensure_hostname_check(Opts) ->
 %% Return {ok, OptsWithAnchor} when a trust anchor is present or can be sourced
 %% from the OS store, else `none'. (trust_source/1 is the historical LDAP name
 %% for the same behaviour; kept as an alias for that backend's call site.)
+%%
+%% Note (intended): when no cacertfile_arn is supplied, verify_peer falls back to
+%% the VALIDATOR host's OS CA store, so the validator's trust store -- not the
+%% broker's configured anchor -- decides the verdict. This is deliberate: a
+%% probe against a public-CA-signed LDAPS/IdP endpoint should verify without
+%% forcing the operator to supply a redundant cacertfile_arn. An operator who
+%% needs broker-exact trust supplies cacertfile_arn, which takes precedence.
 -spec ensure_trust_anchor(list()) -> {ok, list()} | none.
 ensure_trust_anchor(Opts) ->
     case lists:keymember(cacerts, 1, Opts) of

--- a/test/aws_auth_validate_http_tests.erl
+++ b/test/aws_auth_validate_http_tests.erl
@@ -201,7 +201,7 @@ http_ssl_options_shape_test_() ->
         ?_assertMatch(
             {error, input_invalid, <<
                 "ssl_options contains an unknown key; allowed keys are cacertfile_arn, "
-                "certfile_arn, keyfile_arn, verify, depth, versions, sni"
+                "certfile_arn, keyfile_arn, verify, depth, versions, sni, hostname_verification"
             >>},
             aws_auth_validate_http:validate(
                 body_with_ssl(#{<<"verfy">> => <<"verify_peer">>})
@@ -790,6 +790,59 @@ http_response_contract_test_() ->
         ?_assertEqual(Expected, aws_auth_validate_http:classify_response(Key, Body))
      || {Key, Body, Expected} <- Cases
     ].
+
+%%--------------------------------------------------------------------
+%% hostname_verification (broker parity): the http backend must default to
+%% STRICT matching (no RFC 6125 https match fun) and only add the wildcard fun
+%% when ssl_options.hostname_verification = wildcard -- mirroring
+%% rabbit_auth_backend_http, which applies it only on ssl_hostname_verification =
+%% wildcard. build_client_ssl_opts/1 is called directly (no network); an OS
+%% trust anchor is mocked so verify_peer keeps a trust anchor and the
+%% match-fun branch is reachable.
+%%--------------------------------------------------------------------
+
+http_hostname_verification_test_() ->
+    {setup,
+        fun() ->
+            ok = meck:new(public_key, [unstick, passthrough]),
+            %% Non-empty OS store -> verify_peer has a trust anchor.
+            meck:expect(public_key, cacerts_get, fun() -> [<<"der">>] end),
+            ok
+        end,
+        fun(_) -> meck:unload(public_key) end, fun(_) ->
+            Build = fun(Ssl) ->
+                aws_auth_validate_http:build_client_ssl_opts(#{
+                    ssl_options => Ssl, aws_state => none
+                })
+            end,
+            {ok, Unset} = Build(#{<<"verify">> => <<"verify_peer">>}),
+            {ok, Wild} = Build(#{
+                <<"verify">> => <<"verify_peer">>,
+                <<"hostname_verification">> => <<"wildcard">>
+            }),
+            {ok, NoneMode} = Build(#{
+                <<"verify">> => <<"verify_peer">>,
+                <<"hostname_verification">> => <<"none">>
+            }),
+            [
+                %% Unset defaults to strict: no https match fun (the #151 parity
+                %% fix, now extended to http).
+                ?_assertNot(lists:keymember(customize_hostname_check, 1, Unset)),
+                %% none is also strict.
+                ?_assertNot(lists:keymember(customize_hostname_check, 1, NoneMode)),
+                %% wildcard opts into the RFC 6125 https match fun.
+                ?_assert(lists:keymember(customize_hostname_check, 1, Wild))
+            ]
+        end}.
+
+%% An unknown hostname_verification value is rejected in the pure phase.
+http_hostname_verification_bad_value_test() ->
+    ?assertMatch(
+        {error, input_invalid, _},
+        aws_auth_validate_http:validate(
+            body_with_ssl(#{<<"hostname_verification">> => <<"bogus">>})
+        )
+    ).
 
 %%--------------------------------------------------------------------
 %% Helpers

--- a/test/aws_auth_validate_oauth_tests.erl
+++ b/test/aws_auth_validate_oauth_tests.erl
@@ -1177,6 +1177,48 @@ reason_contains(_Other, _Substr) ->
     false.
 
 %%--------------------------------------------------------------------
+%% hostname_verification (broker parity): the oauth backend must default to
+%% STRICT matching and only add the RFC 6125 https match fun when
+%% ssl_options.hostname_verification = wildcard -- mirroring oauth2_client, which
+%% reads hostname_verification (default none = strict). build_client_ssl_opts/1
+%% is called directly (no network); an OS trust anchor is mocked.
+%%--------------------------------------------------------------------
+
+oauth_hostname_verification_test_() ->
+    {setup,
+        fun() ->
+            ok = meck:new(public_key, [unstick, passthrough]),
+            meck:expect(public_key, cacerts_get, fun() -> [<<"der">>] end),
+            ok
+        end,
+        fun(_) -> meck:unload(public_key) end, fun(_) ->
+            Build = fun(Ssl) ->
+                aws_auth_validate_oauth:build_client_ssl_opts(#{
+                    ssl_options => Ssl, aws_state => none
+                })
+            end,
+            {ok, Unset} = Build(#{<<"verify">> => <<"verify_peer">>}),
+            {ok, Wild} = Build(#{
+                <<"verify">> => <<"verify_peer">>,
+                <<"hostname_verification">> => <<"wildcard">>
+            }),
+            {ok, NoneMode} = Build(#{
+                <<"verify">> => <<"verify_peer">>,
+                <<"hostname_verification">> => <<"none">>
+            }),
+            [
+                ?_assertNot(lists:keymember(customize_hostname_check, 1, Unset)),
+                ?_assertNot(lists:keymember(customize_hostname_check, 1, NoneMode)),
+                ?_assert(lists:keymember(customize_hostname_check, 1, Wild))
+            ]
+        end}.
+
+%% An unknown hostname_verification value is rejected in the pure phase.
+oauth_hostname_verification_bad_value_test() ->
+    Body = (jwks_body())#{<<"ssl_options">> => #{<<"hostname_verification">> => <<"bogus">>}},
+    ?assertMatch({error, input_invalid, _}, aws_auth_validate_oauth:parse_input(Body)).
+
+%%--------------------------------------------------------------------
 %% Helpers
 %%--------------------------------------------------------------------
 

--- a/test/aws_auth_validate_shared_tests.erl
+++ b/test/aws_auth_validate_shared_tests.erl
@@ -160,6 +160,29 @@ apply_verify_default_3_strict_explicit_no_anchor_still_fails_test_() ->
         end}.
 
 %%--------------------------------------------------------------------
+%% aws_auth_validate_ssl: hostname_check_mode/1. Shared by http/oauth/ldap to
+%% resolve the modeled `hostname_verification' ssl_options input into the /3
+%% mode. Unset (or the broker's `none') = strict; only `wildcard' opts into the
+%% RFC 6125 https match fun -- mirroring the broker's strict-by-default gating
+%% across all three backends.
+%%--------------------------------------------------------------------
+
+hostname_check_mode_unset_is_strict_test() ->
+    ?assertEqual(strict, aws_auth_validate_ssl:hostname_check_mode(#{})).
+
+hostname_check_mode_none_is_strict_test() ->
+    ?assertEqual(
+        strict,
+        aws_auth_validate_ssl:hostname_check_mode(#{<<"hostname_verification">> => <<"none">>})
+    ).
+
+hostname_check_mode_wildcard_test() ->
+    ?assertEqual(
+        wildcard,
+        aws_auth_validate_ssl:hostname_check_mode(#{<<"hostname_verification">> => <<"wildcard">>})
+    ).
+
+%%--------------------------------------------------------------------
 %% aws_auth_validate_net: embedded_v4/1 shared unwrapper. The LDAP SSRF
 %% classifier (is_private_ip6/1) shares this helper, so its decoding must cover
 %% every v4-carrying v6 notation and leave native v6 (::, ::1) unwrapped.

--- a/test/aws_auth_validate_shared_tests.erl
+++ b/test/aws_auth_validate_shared_tests.erl
@@ -106,6 +106,100 @@ has_https_match_fun(Opts) ->
     end.
 
 %%--------------------------------------------------------------------
+%% aws_auth_validate_ssl: apply_verify_default/3 hostname-check mode
+%%--------------------------------------------------------------------
+%%
+%% The /3 form lets a backend model the broker's hostname_verification setting.
+%% `wildcard' applies the RFC 6125 https match fun (http/oauth default, and the
+%% /2 form); `strict' leaves OTP's exact matching in place -- the LDAP default,
+%% mirroring rabbit_auth_backend_ldap which only applies the https fun when
+%% auth_ldap.ssl_options.hostname_verification = wildcard.
+
+%% /2 delegates to /3 with wildcard: a bare verify_peer gains the match fun.
+apply_verify_default_2_defaults_to_wildcard_test() ->
+    Opts = [{verify, verify_peer}, {cacerts, [<<"der">>]}],
+    {ok, Out} = aws_auth_validate_ssl:apply_verify_default(Opts, true),
+    ?assert(has_https_match_fun(Out)).
+
+%% /3 wildcard mode matches the /2 behaviour.
+apply_verify_default_3_wildcard_adds_hostname_check_test() ->
+    Opts = [{verify, verify_peer}, {cacerts, [<<"der">>]}],
+    {ok, Out} = aws_auth_validate_ssl:apply_verify_default(Opts, true, wildcard),
+    ?assert(has_https_match_fun(Out)).
+
+%% /3 strict mode MUST NOT inject the https match fun on an explicit verify_peer:
+%% OTP's default (exact) matching stays, matching the broker's default LDAP path.
+apply_verify_default_3_strict_no_hostname_check_test() ->
+    Opts = [{verify, verify_peer}, {cacerts, [<<"der">>]}],
+    {ok, Out} = aws_auth_validate_ssl:apply_verify_default(Opts, true, strict),
+    ?assertNot(lists:keymember(customize_hostname_check, 1, Out)),
+    ?assertEqual({verify, verify_peer}, lists:keyfind(verify, 1, Out)).
+
+%% /3 strict mode on the ABSENT-verify path: defaults to verify_peer (anchor
+%% present) but still adds no match fun.
+apply_verify_default_3_strict_absent_verify_no_hostname_check_test() ->
+    Opts = [{cacerts, [<<"der">>]}],
+    {ok, Out} = aws_auth_validate_ssl:apply_verify_default(Opts, false, strict),
+    ?assertEqual({verify, verify_peer}, lists:keyfind(verify, 1, Out)),
+    ?assertNot(lists:keymember(customize_hostname_check, 1, Out)).
+
+%% strict mode does not alter the no-anchor policy: an EXPLICIT verify_peer with
+%% no anchor still fails loud (the hostname-check mode is orthogonal to it).
+apply_verify_default_3_strict_explicit_no_anchor_still_fails_test_() ->
+    {setup,
+        fun() ->
+            ok = meck:new(public_key, [unstick, passthrough]),
+            meck:expect(public_key, cacerts_get, fun() -> [] end),
+            ok
+        end,
+        fun(_) -> meck:unload(public_key) end, fun() ->
+            Result = aws_auth_validate_ssl:apply_verify_default(
+                [{verify, verify_peer}], true, strict
+            ),
+            ?assertMatch({error, tls_failed, _}, Result)
+        end}.
+
+%%--------------------------------------------------------------------
+%% aws_auth_validate_net: embedded_v4/1 shared unwrapper. The LDAP SSRF
+%% classifier (is_private_ip6/1) shares this helper, so its decoding must cover
+%% every v4-carrying v6 notation and leave native v6 (::, ::1) unwrapped.
+%%--------------------------------------------------------------------
+
+embedded_v4_ipv4_mapped_test() ->
+    ?assertEqual(
+        {ok, {169, 254, 169, 254}},
+        aws_auth_validate_net:embedded_v4({0, 0, 0, 0, 0, 16#ffff, 16#a9fe, 16#a9fe})
+    ).
+
+embedded_v4_ipv4_compatible_test() ->
+    ?assertEqual(
+        {ok, {8, 8, 8, 8}},
+        aws_auth_validate_net:embedded_v4({0, 0, 0, 0, 0, 0, 16#0808, 16#0808})
+    ).
+
+embedded_v4_nat64_test() ->
+    ?assertEqual(
+        {ok, {169, 254, 169, 254}},
+        aws_auth_validate_net:embedded_v4({16#64, 16#ff9b, 0, 0, 0, 0, 16#a9fe, 16#a9fe})
+    ).
+
+embedded_v4_6to4_test() ->
+    ?assertEqual(
+        {ok, {169, 254, 169, 254}},
+        aws_auth_validate_net:embedded_v4({16#2002, 16#a9fe, 16#a9fe, 0, 0, 0, 0, 0})
+    ).
+
+%% :: and ::1 are NOT unwrapped -- they must classify as v6 (::1 is v6 loopback,
+%% not v4 0.0.0.1), so the unwrapper returns `none' for them.
+embedded_v4_unspecified_and_loopback_not_unwrapped_test() ->
+    ?assertEqual(none, aws_auth_validate_net:embedded_v4({0, 0, 0, 0, 0, 0, 0, 0})),
+    ?assertEqual(none, aws_auth_validate_net:embedded_v4({0, 0, 0, 0, 0, 0, 0, 1})).
+
+%% A plain global-unicast v6 carries no embedded v4.
+embedded_v4_plain_v6_none_test() ->
+    ?assertEqual(none, aws_auth_validate_net:embedded_v4({2600, 16#1f18, 0, 0, 0, 0, 0, 1})).
+
+%%--------------------------------------------------------------------
 %% aws_auth_validate_net: the SSRF classifier is identical for the http and
 %% oauth policies (same infra denylist). Assert both backends' TEST wrappers
 %% agree with each other and with the shared module for the full v4/v6 matrix.

--- a/test/aws_auth_validate_tests.erl
+++ b/test/aws_auth_validate_tests.erl
@@ -11,6 +11,8 @@
 -module(aws_auth_validate_tests).
 
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("rabbit_common/include/rabbit.hrl").
+-include_lib("rabbitmq_web_dispatch/include/rabbitmq_web_dispatch_records.hrl").
 -include("aws_lib.hrl").
 
 %%--------------------------------------------------------------------
@@ -122,6 +124,7 @@ registry_field_filter_override_test_() ->
 
 status_for_category_known_test() ->
     ?assertEqual(400, aws_auth_validate_mgmt:status_for_category(input_invalid)),
+    ?assertEqual(400, aws_auth_validate_mgmt:status_for_category(body_too_large)),
     ?assertEqual(400, aws_auth_validate_mgmt:status_for_category(connection_failed)),
     ?assertEqual(400, aws_auth_validate_mgmt:status_for_category(tls_failed)),
     ?assertEqual(400, aws_auth_validate_mgmt:status_for_category(query_invalid)),
@@ -132,6 +135,49 @@ status_for_category_known_test() ->
 %% A category outside the documented set maps to 500 rather than crashing.
 status_for_category_unknown_test() ->
     ?assertEqual(500, aws_auth_validate_mgmt:status_for_category(some_future_category)).
+
+%%--------------------------------------------------------------------
+%% Audit-log sanitizer + principal extraction (issue #154 coverage)
+%%--------------------------------------------------------------------
+
+%% A plain value with no control chars is returned byte-for-byte.
+sanitize_log_plain_unchanged_test() ->
+    ?assertEqual(<<"ldap">>, aws_auth_validate_mgmt:sanitize_log(<<"ldap">>)).
+
+%% CR and LF are replaced with U+FFFD so an embedded newline cannot forge or
+%% split an audit line (log injection). The record stays on one line.
+sanitize_log_strips_crlf_test() ->
+    Out = aws_auth_validate_mgmt:sanitize_log(<<"admin\r\nfake result=success">>),
+    ?assertEqual(nomatch, binary:match(Out, <<"\r">>)),
+    ?assertEqual(nomatch, binary:match(Out, <<"\n">>)),
+    %% Both control bytes became the 3-byte UTF-8 replacement char.
+    ?assertEqual(<<"admin"/utf8, 16#fffd/utf8, 16#fffd/utf8, "fake result=success"/utf8>>, Out).
+
+%% Any C0 control (< 0x20), TAB, and DEL (0x7F) are all replaced.
+sanitize_log_strips_c0_tab_del_test() ->
+    ?assertEqual(<<16#fffd/utf8>>, aws_auth_validate_mgmt:sanitize_log(<<0>>)),
+    ?assertEqual(<<16#fffd/utf8>>, aws_auth_validate_mgmt:sanitize_log(<<"\t">>)),
+    ?assertEqual(<<16#fffd/utf8>>, aws_auth_validate_mgmt:sanitize_log(<<16#7f>>)).
+
+%% Multi-byte UTF-8 (every byte >= 0x80) is preserved untouched, as documented.
+sanitize_log_preserves_utf8_test() ->
+    In = <<"user-é-名"/utf8>>,
+    ?assertEqual(In, aws_auth_validate_mgmt:sanitize_log(In)).
+
+%% Non-binary input passes through unchanged (defensive).
+sanitize_log_non_binary_passthrough_test() ->
+    ?assertEqual(an_atom, aws_auth_validate_mgmt:sanitize_log(an_atom)).
+
+%% username/1 happy path: the authenticated principal's binary name.
+username_extracts_principal_test() ->
+    Ctx = #context{user = #user{username = <<"alice">>}},
+    ?assertEqual(<<"alice">>, aws_auth_validate_mgmt:username(Ctx)).
+
+%% username/1 fallback: a context with no user (e.g. an unauthenticated OPTIONS)
+%% or an unexpected shape yields <<"unknown">> rather than crashing the audit.
+username_fallback_on_no_user_test() ->
+    ?assertEqual(<<"unknown">>, aws_auth_validate_mgmt:username(#context{user = undefined})),
+    ?assertEqual(<<"unknown">>, aws_auth_validate_mgmt:username(not_a_context)).
 
 %%--------------------------------------------------------------------
 %% Mgmt body-size bound
@@ -485,6 +531,100 @@ ldap_build_tls_opts_explicit_verify_peer_with_anchor_ok_test() ->
 ldap_build_tls_opts_explicit_verify_none_untouched_test() ->
     {ok, Opts} = aws_auth_validate_ldap:build_tls_opts(true, #{<<"verify">> => <<"verify_none">>}),
     ?assertEqual(verify_none, proplists:get_value(verify, Opts)).
+
+%%--------------------------------------------------------------------
+%% hostname_verification: LDAP must match the broker, which applies the RFC 6125
+%% https match fun ONLY when auth_ldap.ssl_options.hostname_verification =
+%% wildcard. The validator previously applied it always (too lenient), so a
+%% wildcard LDAPS cert the broker rejects passed the validator green.
+%%--------------------------------------------------------------------
+
+%% Default (hostname_verification unset): strict OTP matching -- NO https match
+%% fun injected, even on an explicit verify_peer with an anchor.
+ldap_build_tls_opts_default_is_strict_no_match_fun_test() ->
+    {ok, Opts} = aws_auth_validate_ldap:build_tls_opts(true, #{
+        <<"verify">> => <<"verify_peer">>,
+        cacerts => [<<"der">>]
+    }),
+    ?assertNot(lists:keymember(customize_hostname_check, 1, Opts)).
+
+%% Explicit `wildcard' opts into the https match fun (broker's wildcard mode).
+ldap_build_tls_opts_wildcard_adds_match_fun_test() ->
+    {ok, Opts} = aws_auth_validate_ldap:build_tls_opts(true, #{
+        <<"verify">> => <<"verify_peer">>,
+        <<"hostname_verification">> => <<"wildcard">>,
+        cacerts => [<<"der">>]
+    }),
+    ?assert(lists:keymember(customize_hostname_check, 1, Opts)).
+
+%% Explicit `none' is strict (the broker treats non-wildcard as strict): no fun.
+ldap_build_tls_opts_none_is_strict_test() ->
+    {ok, Opts} = aws_auth_validate_ldap:build_tls_opts(true, #{
+        <<"verify">> => <<"verify_peer">>,
+        <<"hostname_verification">> => <<"none">>,
+        cacerts => [<<"der">>]
+    }),
+    ?assertNot(lists:keymember(customize_hostname_check, 1, Opts)).
+
+%% hostname_verification is a control input, not a direct ssl option: it must NOT
+%% leak into the translated eldap opts.
+ldap_build_ssl_opts_ignores_hostname_verification_test() ->
+    Opts = aws_auth_validate_ldap:build_ssl_opts(#{<<"hostname_verification">> => <<"wildcard">>}),
+    ?assertEqual(undefined, proplists:get_value(hostname_verification, Opts)),
+    ?assertEqual([], Opts).
+
+%% A bad hostname_verification value is rejected in the pure phase.
+ldap_rejects_bad_hostname_verification_test() ->
+    Body = base_body(#{<<"ssl_options">> => #{<<"hostname_verification">> => <<"lenient">>}}),
+    ?assertMatch({error, input_invalid, _}, aws_auth_validate_ldap:validate(Body)).
+
+%%--------------------------------------------------------------------
+%% Post-bind search time limit (issue #154 coverage)
+%%--------------------------------------------------------------------
+
+%% Units: the limit is the LDAP protocol timeLimit in whole SECONDS, derived from
+%% the ms connection timeout (rounded up). A units regression (dropping div 1000)
+%% would blow this up by ~1000x.
+ldap_search_time_limit_seconds_units_test() ->
+    application:set_env(aws, auth_validation_connection_timeout_ms, 5000),
+    try
+        ?assertEqual(5, aws_auth_validate_ldap:search_time_limit_seconds())
+    after
+        application:unset_env(aws, auth_validation_connection_timeout_ms)
+    end.
+
+%% Rounds UP to the next whole second so a sub-second budget never truncates.
+ldap_search_time_limit_seconds_rounds_up_test() ->
+    application:set_env(aws, auth_validation_connection_timeout_ms, 4001),
+    try
+        ?assertEqual(5, aws_auth_validate_ldap:search_time_limit_seconds())
+    after
+        application:unset_env(aws, auth_validation_connection_timeout_ms)
+    end.
+
+%% Floored at 1s: a sub-1s budget must never yield 0 (eldap reads 0 as "no
+%% time limit", the opposite of the intent).
+ldap_search_time_limit_seconds_floor_test() ->
+    application:set_env(aws, auth_validation_connection_timeout_ms, 200),
+    try
+        ?assertEqual(1, aws_auth_validate_ldap:search_time_limit_seconds())
+    after
+        application:unset_env(aws, auth_validation_connection_timeout_ms)
+    end.
+
+%%--------------------------------------------------------------------
+%% is_private_ip6/1 6to4 unwrapping (issue #154 coverage). is_allowed_server/1
+%% already covers the resolve path; these pin the classifier directly so a
+%% regression in the shared embedded_v4 unwrap is caught without DNS.
+%%--------------------------------------------------------------------
+
+ldap_is_private_ip6_6to4_imds_blocked_test() ->
+    %% 2002:a9fe:a9fe:: wraps 169.254.169.254 (IMDS) -> private.
+    ?assert(aws_auth_validate_ldap:is_private_ip6({16#2002, 16#a9fe, 16#a9fe, 0, 0, 0, 0, 0})).
+
+ldap_is_private_ip6_6to4_public_allowed_test() ->
+    %% 2002:0808:0808:: wraps 8.8.8.8 (public) -> not private.
+    ?assertNot(aws_auth_validate_ldap:is_private_ip6({16#2002, 16#0808, 16#0808, 0, 0, 0, 0, 0})).
 
 ldap_config_conflict_test() ->
     Body = base_body(#{<<"use_ssl">> => true, <<"use_starttls">> => true}),


### PR DESCRIPTION
*Issues #151, #152, #153, #154, #155*

Addresses the post-merge review follow-ups filed as issues 151-155 against the
auth-validation endpoint. Each change is independent; grouped here as one PR
since they touch the same modules.

### #151 -- LDAPS hostname verification diverged from the broker (too lenient) [P-high bug]
The shared `apply_verify_default/2` unconditionally injected the RFC 6125 https
wildcard match fun on every `verify_peer` path. That is correct for the
http/oauth backends (IdP endpoints commonly present single-label wildcard certs,
e.g. Cognito), but it diverged from `rabbit_auth_backend_ldap`, which applies the
https fun **only** when `auth_ldap.ssl_options.hostname_verification = wildcard`
and otherwise uses OTP's stricter matching. A wildcard LDAPS/StartTLS cert the
live broker would reject at handshake passed the validator green.

- `aws_auth_validate_ssl`: add `apply_verify_default/3` with a `wildcard | strict`
  hostname-check mode. `/2` still defaults to `wildcard` (http/oauth unchanged).
- `aws_auth_validate_ldap`: model a `hostname_verification` ssl_options key
  (enum `wildcard | none`, mirroring the broker; unset = strict), validated in the
  pure phase, and pass the resolved mode into `build_tls_opts/2`.
- Console UI: add the `hostname_verification` field to the ldap CONF map and
  template so the FE/BE contract stays in sync.

### #152 -- UI divergence check misses nested tls `fail_if_no_peer_cert = false` [P-medium bug]
`strip_false_bools` stripped only top-level `false` booleans, so a pasted
`ssl_options.fail_if_no_peer_cert = false` versus an unchecked box compared
unequal and wrongly blocked submit with "The config box differs from the fields."

- `aws_auth_validate.js`: `strip_false_bools` now recurses one level into
  `ssl_options` (and drops an emptied `ssl_options`) so the false-vs-absent
  asymmetry is normalized. A pasted `true` vs an unchecked box still diverges.

### #153 -- LDAP SSRF IPv6 classifier duplicated the shared net module [P-medium refactor]
The embedded-v4 unwrapping was hand-copied between `aws_auth_validate_ldap`'s
`is_private_ip6/1` and `aws_auth_validate_net`'s `classify_ip/2` ("kept in step by
hand"). No live drift, but a future encoding or segment-math fix applied to one
copy and not the other would reopen a v6-encoded IMDS SSRF path.

- `aws_auth_validate_net`: extract the policy-independent unwrapping into a shared
  `embedded_v4/1` and route `classify_ip/2` through it.
- `aws_auth_validate_ldap`: `is_private_ip6/1` now shares that one unwrapper while
  keeping its own stricter range policy (LDAP denies all RFC1918/CGNAT).

### #154 -- test-coverage gaps in the new security code [P-medium]
Added unit tests (and the needed `-ifdef(TEST)` exports) for:
`apply_verify_default/3` strict-vs-wildcard, the shared `embedded_v4/1` matrix,
LDAP `hostname_verification` wiring, 6to4 `is_private_ip6`,
`search_time_limit_seconds` units/round-up/floor, `sanitize_log`
CR/LF/C0/DEL/UTF-8-preserved, `username/1` happy path + fallback, and the
`body_too_large` status mapping.

### #155 -- minor follow-ups [P-low]
- `aws_auth_validate_mgmt`: add `body_too_large` to `status_for_category/1` so a
  future refactor routing it through `respond/3` maps to 400, not 500.
- `aws_auth_validate_ldap`: soften the `search_time_limit_seconds` comment -- the
  LDAP protocol timeLimit is server-cooperative, not a hard DoS cap.
- `aws_auth_validate_ssl`: document the intended OS-trust-store fallback on the
  explicit-`verify_peer` no-anchor path.
- Console UI: note the byte-identical http/oauth ssl_options blocks must be
  hand-synced, clarify the symmetric fields-side `strip_false_bools` call, and
  trim the verbose `build_body` comment.

### Testing
`gmake eunit` in the umbrella (`deps/aws`): full suite passes (706 tests before
the new additions; the ~28 new test functions execute and pass). `erlfmt -c` is
clean on all changed `.erl` files.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
