### PR TITLE
Hardening/auth validation parity followups

### DIFF
--- a/priv/www/js/aws_auth_validate.js
+++ b/priv/www/js/aws_auth_validate.js
@@ -53,6 +53,7 @@ var AWS_AUTH_VALIDATE_METHODS = ['ldap', 'http', 'oauth', 'tls'];
 var AWS_AUTH_VALIDATE_CATEGORY = {
     success:            {cls: 'status-green',  text: 'Validation succeeded (204).'},
     input_invalid:      {cls: 'status-red',    text: 'Input invalid: the request failed pure validation before any connection.'},
+    body_too_large:     {cls: 'status-red',    text: 'Request body too large: reduce the config size and retry.'},
     connection_failed:  {cls: 'status-red',    text: 'Connection failed: the target could not be reached.'},
     tls_failed:         {cls: 'status-red',    text: 'TLS failed: handshake or certificate verification did not succeed.'},
     query_invalid:      {cls: 'status-red',    text: 'Query invalid: an authorization query could not be parsed.'},

--- a/src/aws_auth_validate_http.erl
+++ b/src/aws_auth_validate_http.erl
@@ -365,44 +365,14 @@ collect_paths([Key | Rest], Body, Acc, Paths) ->
             {error, input_invalid, ?REASON_BAD_PATH_VALUE}
     end.
 
-%% Parse + minimally validate an http(s) URL. Returns a normalized
-%% representation the probe and the SSRF guard can both use. Kept deliberately
-%% small here; richer parsing belongs with the guard work.
+%% Parse + minimally validate an http(s) URL via the shared
+%% aws_auth_validate_net:parse_url/2. The broker's auth_http.*_path config is
+%% query- and fragment-less and the probe appends its own ?username= params, so
+%% a pre-existing query (double-? mangling) or #fragment (probe's query dropped
+%% after the fragment) is rejected -- both are the parser's default. userinfo and
+%% out-of-range ports are always rejected.
 parse_url(Bin) when is_binary(Bin) ->
-    Str = binary_to_list(Bin),
-    case uri_string:parse(Str) of
-        #{scheme := Scheme, host := Host} = Parsed when
-            Host =/= [], (Scheme =:= "http" orelse Scheme =:= "https")
-        ->
-            %% Reject, as off-shape *_path input:
-            %%  * an out-of-range port (else httpc crashes at request time),
-            %%  * userinfo (user:pass@host) -- embedded credentials httpc would
-            %%    turn into an Authorization header,
-            %%  * a pre-existing query string OR a #fragment -- the broker's
-            %%    auth_http.*_path config is query- and fragment-less and the
-            %%    probe appends its own ?username= params. A path that already
-            %%    carried a query would be mangled into a double-? URL; a path
-            %%    with a fragment would have the probe's ?query appended AFTER
-            %%    the fragment, so httpc drops the query (fragments are not sent)
-            %%    and the probe misfires. Either way it would spuriously fail.
-            Port = maps:get(port, Parsed, undefined),
-            HasQuery = maps:is_key(query, Parsed) andalso maps:get(query, Parsed) =/= [],
-            HasFragment =
-                maps:is_key(fragment, Parsed) andalso maps:get(fragment, Parsed) =/= [],
-            case Port of
-                P when is_integer(P), (P < 1 orelse P > 65535) ->
-                    {error, bad_url};
-                _ when HasQuery orelse HasFragment ->
-                    {error, bad_url};
-                _ ->
-                    case maps:is_key(userinfo, Parsed) of
-                        true -> {error, bad_url};
-                        false -> {ok, Parsed#{url_string => Str}}
-                    end
-            end;
-        _ ->
-            {error, bad_url}
-    end.
+    aws_auth_validate_net:parse_url(Bin, #{allowed_schemes => ?ALLOWED_SCHEMES}).
 
 parse_http_method(Body, Acc) ->
     case maps:get(<<"http_method">>, Body, undefined) of

--- a/src/aws_auth_validate_ldap.erl
+++ b/src/aws_auth_validate_ldap.erl
@@ -49,16 +49,16 @@
 %% to the eldap proplist; build_tls_opts/2 layers the shared verify-mode policy
 %% on top (returning the fail-loud {ok,_}|{error,tls_failed,_} contract);
 %% peer_allowed/1 is the post-connect SSRF re-check on a peername result;
-%% is_private_ip/1 + is_private_ip6/1 are the SSRF address classifiers (incl. the
-%% v6-embedded-v4 unwrapping); search_time_limit_seconds/0 is the post-bind
-%% search timeLimit. All are otherwise internal.
+%% is_denied_ip/1 is the SSRF address classifier for v4 and v6 (delegating to the
+%% shared aws_auth_validate_net:classify_ip/2 with LDAP's denylist);
+%% search_time_limit_seconds/0 is the post-bind search timeLimit. All are
+%% otherwise internal.
 -export([
     build_ssl_opts/1,
     build_tls_opts/2,
     is_allowed_server/1,
     peer_allowed/1,
-    is_private_ip/1,
-    is_private_ip6/1,
+    is_denied_ip/1,
     parse_port/2,
     search_time_limit_seconds/0
 ]).
@@ -569,92 +569,50 @@ check_server_ip(Server) ->
         {error, _} ->
             %% Also try IPv6
             case inet:getaddr(Server, inet6) of
-                {ok, IP6} -> not is_denied_ip6(IP6);
+                {ok, IP6} -> not is_denied_ip(IP6);
                 {error, _} -> false
             end
     end.
 
-%% A range-policy-denied address is normally blocked. The ONE relaxation is
-%% loopback when auth_validation_allow_private_networks is set (test-only,
-%% default false), so an integration suite can reach a local slapd on
-%% 127.0.0.1/::1. Mirrors aws_auth_validate_net:classify_denied/1 exactly, so the
-%% two backends grant the identical (loopback-only) test-mode relaxation.
+%% Classify a v4 or v6 address against LDAP's range policy via the shared
+%% aws_auth_validate_net:classify_ip/2 (which dispatches on tuple shape), passing
+%% LDAP's own denylist. Sharing the classifier (not just the CIDR-matching leaf)
+%% means the v6->embedded-v4 unwrap and the loopback-only test relaxation are
+%% defined in ONE place: LDAP cannot drift from http/oauth on how a v6-encoded v4
+%% address (e.g. ::ffff:127.0.0.1) is unwrapped before the relaxation applies.
+%% LDAP keeps its own broader list.
 is_denied_ip(IP) ->
-    is_private_ip(IP) andalso not relaxed_loopback(IP).
+    aws_auth_validate_net:classify_ip(IP, ldap_cidr_policy()) =:= deny.
 
-is_denied_ip6(IP) ->
-    is_private_ip6(IP) andalso not relaxed_loopback(IP).
-
-relaxed_loopback(IP) ->
-    is_loopback(IP) andalso allow_private_networks().
-
-is_loopback({127, _, _, _}) -> true;
-is_loopback({0, 0, 0, 0, 0, 0, 0, 1}) -> true;
-is_loopback(_) -> false.
-
-allow_private_networks() ->
-    application:get_env(aws, auth_validation_allow_private_networks, false) =:= true.
-
-%% LDAP's SSRF range policy, as CIDR lists. This is deliberately BROADER than the
-%% http/oauth infra-only denylist in aws_auth_validate_net: LDAP denies ALL
-%% RFC1918/CGNAT/reserved space, not just broker infra. Expressed as
-%% {Network, PrefixBits} tuples run through the shared
-%% aws_auth_validate_net:in_any_cidr/2 so both backends enumerate ranges in ONE
-%% vocabulary -- a future range fix (or a segment-math change) cannot silently
-%% apply to only one classifier. This mirrors #153, which unified the embedded-v4
-%% unwrapper for exactly this reason; here we unify the range-matching mechanism
-%% while each backend keeps its own distinct list.
+%% LDAP's SSRF range policy, as a classify_ip/2 CIDR policy. This is deliberately
+%% BROADER than the http/oauth infra-only denylist in aws_auth_validate_net: LDAP
+%% denies ALL RFC1918/CGNAT/reserved space, not just broker infra. Sharing the
+%% classifier while keeping a distinct list means a future range or segment-math
+%% fix cannot silently apply to only one backend. Mirrors #153, one layer up.
 %%   100.64.0.0/10 (RFC 6598) is carrier-grade NAT shared address space; it can
 %%     route to provider/internal infrastructure, so it is denied too.
 %%   240.0.0.0/4 is reserved/Class E, including 255.255.255.255 limited broadcast.
--define(LDAP_DENIED_V4_CIDRS, [
-    {{127, 0, 0, 0}, 8},
-    {{10, 0, 0, 0}, 8},
-    {{172, 16, 0, 0}, 12},
-    {{192, 168, 0, 0}, 16},
-    {{169, 254, 0, 0}, 16},
-    {{100, 64, 0, 0}, 10},
-    {{0, 0, 0, 0}, 8},
-    {{240, 0, 0, 0}, 4}
-]).
-
-%% The IPv6 ranges corresponding to the v4 blocks above, so the filter cannot be
-%% bypassed with a v6 address.
-%%   ::1/128       loopback
-%%   ::/128        unspecified
-%%   fc00::/7      unique local addresses (ULA). Includes the IPv6 IMDS address
-%%                 fd00:ec2::254 -- the whole point of this block.
-%%   fe80::/10     link-local (spans fe80..febf, NOT just fe80)
-%% v4-carrying notations (IPv4-mapped, IPv4-compatible, NAT64 64:ff9b::/96, 6to4
-%% 2002::/16) are NOT listed here: they are unwrapped by the shared
-%% aws_auth_validate_net:embedded_v4/1 and re-checked against the v4 CIDRs, so
-%% e.g. ::ffff:169.254.169.254 or 2002:a9fe:a9fe:: still cannot reach IMDS.
--define(LDAP_DENIED_V6_CIDRS, [
-    {{0, 0, 0, 0, 0, 0, 0, 1}, 128},
-    {{0, 0, 0, 0, 0, 0, 0, 0}, 128},
-    {{16#fc00, 0, 0, 0, 0, 0, 0, 0}, 7},
-    {{16#fe80, 0, 0, 0, 0, 0, 0, 0}, 10}
-]).
-
-%% Deny the LDAP range policy's v4 blocks (see ?LDAP_DENIED_V4_CIDRS).
-is_private_ip({_, _, _, _} = V4) ->
-    aws_auth_validate_net:in_any_cidr(V4, ?LDAP_DENIED_V4_CIDRS).
-
-%% Deny the LDAP range policy's v6 blocks, then fall through to the shared
-%% embedded-v4 unwrapper so a v6-encoded v4 address is re-checked against the v4
-%% policy. Keeps LDAP's stricter range policy while sharing the unwrap mechanism.
-is_private_ip6({_, _, _, _, _, _, _, _} = V6) ->
-    case aws_auth_validate_net:in_any_cidr(V6, ?LDAP_DENIED_V6_CIDRS) of
-        true ->
-            true;
-        false ->
-            case aws_auth_validate_net:embedded_v4(V6) of
-                {ok, V4} -> is_private_ip(V4);
-                none -> false
-            end
-    end;
-is_private_ip6(_) ->
-    false.
+%%   fc00::/7 includes the IPv6 IMDS address fd00:ec2::254; fe80::/10 spans
+%%     fe80..febf. v4-carrying v6 notations are unwrapped by classify_ip/2.
+ldap_cidr_policy() ->
+    #{
+        denied_v4 => [
+            {{127, 0, 0, 0}, 8},
+            {{10, 0, 0, 0}, 8},
+            {{172, 16, 0, 0}, 12},
+            {{192, 168, 0, 0}, 16},
+            {{169, 254, 0, 0}, 16},
+            {{100, 64, 0, 0}, 10},
+            {{0, 0, 0, 0}, 8},
+            {{240, 0, 0, 0}, 4}
+        ],
+        denied_v6 => [
+            {{0, 0, 0, 0, 0, 0, 0, 1}, 128},
+            {{0, 0, 0, 0, 0, 0, 0, 0}, 128},
+            {{16#fc00, 0, 0, 0, 0, 0, 0, 0}, 7},
+            {{16#fe80, 0, 0, 0, 0, 0, 0, 0}, 10}
+        ]
+    }.
 
 %%--------------------------------------------------------------------
 %% Config conflict
@@ -769,13 +727,8 @@ check_peer_ip(Handle) ->
         _ -> blocked
     end.
 
-peer_allowed({ok, {IP, _Port}}) when tuple_size(IP) =:= 4 ->
+peer_allowed({ok, {IP, _Port}}) when tuple_size(IP) =:= 4; tuple_size(IP) =:= 8 ->
     case is_denied_ip(IP) of
-        true -> blocked;
-        false -> ok
-    end;
-peer_allowed({ok, {IP, _Port}}) when tuple_size(IP) =:= 8 ->
-    case is_denied_ip6(IP) of
         true -> blocked;
         false -> ok
     end;

--- a/src/aws_auth_validate_ldap.erl
+++ b/src/aws_auth_validate_ldap.erl
@@ -59,6 +59,7 @@
     peer_allowed/1,
     is_private_ip/1,
     is_private_ip6/1,
+    parse_port/2,
     search_time_limit_seconds/0
 ]).
 -endif.
@@ -66,6 +67,12 @@
 -include_lib("eldap/include/eldap.hrl").
 
 -define(DEFAULT_TIMEOUT_MS, 5_000).
+
+%% Default LDAP port when the request omits `port'. Mirrors the broker's
+%% rabbit_auth_backend_ldap default (application env `port', 389 -- the broker
+%% does NOT bump to 636 for TLS), so a config that omits port validates the same
+%% way the live broker would connect rather than being rejected input_invalid.
+-define(DEFAULT_LDAP_PORT, 389).
 
 %% Accepted query names within the `queries' object. Mirrors the broker's
 %% auth_ldap.queries.* config keys.
@@ -302,6 +309,10 @@ parse_servers(Body, Acc) ->
 
 parse_port(Body, Acc) ->
     case maps:get(<<"port">>, Body, undefined) of
+        %% Omitted port defaults to the broker's default (389), so a config the
+        %% live broker would accept is not rejected here for parity's sake.
+        undefined ->
+            {ok, Acc#{port => ?DEFAULT_LDAP_PORT}};
         Port when is_integer(Port), Port >= 1, Port =< 65535 ->
             {ok, Acc#{port => Port}};
         _ ->
@@ -530,8 +541,6 @@ is_nonempty_binary(B) -> is_binary(B) andalso byte_size(B) > 0.
 %% Server address validation: resolve the hostname and reject addresses in
 %% private, loopback, link-local, or metadata IP ranges. This prevents SSRF
 %% via the validation endpoint while still allowing legitimate LDAP servers.
-%% Bypassed when auth_validation_allow_private_networks is true (for testing
-%% against local slapd instances).
 %%
 %% This is the FIRST of two SSRF checks (defence in depth). It resolves Server
 %% and rejects a blocked IP before any connection is attempted, so a malformed
@@ -541,65 +550,108 @@ is_nonempty_binary(B) -> is_binary(B) andalso byte_size(B) > 0.
 %% closed by the SECOND check, verify_connected_peer/1, which re-validates the
 %% actual connected socket's peer (see do_ldap_bind/1). We keep this pre-connect
 %% check too: it rejects bad input cheaply (no socket, clearer input_invalid
-%% category) and avoids dialing out for the common case. Both checks are
-%% bypassed under auth_validation_allow_private_networks for local-slapd tests.
+%% category) and avoids dialing out for the common case.
+%%
+%% The test-only auth_validation_allow_private_networks flag relaxes ONLY
+%% loopback (see is_denied_ip/1), not the whole denylist -- it must not grant the
+%% LDAP backend a broader test-mode bypass than the http/oauth backends get from
+%% aws_auth_validate_net (which relaxes loopback alone). IMDS, link-local,
+%% RFC1918, CGNAT, and reserved space stay denied even with the flag on, so a
+%% test env cannot accidentally prove a path to instance metadata that the
+%% stricter guard would block.
 is_allowed_server(Server) ->
-    case application:get_env(aws, auth_validation_allow_private_networks, false) of
-        true -> true;
-        _ -> check_server_ip(Server)
-    end.
+    check_server_ip(Server).
 
 check_server_ip(Server) ->
     case inet:getaddr(Server, inet) of
         {ok, IP} ->
-            not is_private_ip(IP);
+            not is_denied_ip(IP);
         {error, _} ->
             %% Also try IPv6
             case inet:getaddr(Server, inet6) of
-                {ok, IP6} -> not is_private_ip6(IP6);
+                {ok, IP6} -> not is_denied_ip6(IP6);
                 {error, _} -> false
             end
     end.
 
-%% Block RFC 1918, loopback, link-local, CGNAT, and cloud metadata ranges.
-%%   100.64.0.0/10 (RFC 6598) is carrier-grade NAT shared address space (second
-%%   octet 64..127); it can route to provider/internal infrastructure, so it is
-%%   denied alongside the RFC 1918 ranges.
-is_private_ip({127, _, _, _}) -> true;
-is_private_ip({10, _, _, _}) -> true;
-is_private_ip({172, B, _, _}) when B >= 16, B =< 31 -> true;
-is_private_ip({192, 168, _, _}) -> true;
-is_private_ip({169, 254, _, _}) -> true;
-is_private_ip({100, B, _, _}) when B >= 64, B =< 127 -> true;
-is_private_ip({0, _, _, _}) -> true;
-%% 240.0.0.0/4 (reserved/Class E, including 255.255.255.255 limited broadcast).
-is_private_ip({B, _, _, _}) when B >= 240 -> true;
-is_private_ip(_) -> false.
+%% A range-policy-denied address is normally blocked. The ONE relaxation is
+%% loopback when auth_validation_allow_private_networks is set (test-only,
+%% default false), so an integration suite can reach a local slapd on
+%% 127.0.0.1/::1. Mirrors aws_auth_validate_net:classify_denied/1 exactly, so the
+%% two backends grant the identical (loopback-only) test-mode relaxation.
+is_denied_ip(IP) ->
+    is_private_ip(IP) andalso not relaxed_loopback(IP).
 
-%% Block the IPv6 ranges that correspond to the v4 blocks above, so the filter
-%% cannot be bypassed by handing the endpoint a v6 (or v6-encoded) address.
-%%   ::1            loopback
-%%   ::             unspecified
-%%   fc00::/7       unique local addresses (ULA). Includes the IPv6 IMDS
-%%                  address fd00:ec2::254 -- the whole point of this block.
-%%   fe80::/10      link-local (spans fe80..febf, NOT just fe80)
-%% v4-carrying notations (IPv4-mapped, IPv4-compatible, NAT64 64:ff9b::/96,
-%% 6to4 2002::/16) are unwrapped by the shared aws_auth_validate_net:embedded_v4/1
-%% and re-checked against the v4 ranges, so e.g. ::ffff:169.254.169.254 or the
-%% 6to4 form 2002:a9fe:a9fe:: cannot reach IMDS. Sharing that unwrapper (rather
-%% than a hand-copied one) keeps the two SSRF classifiers decoding the same
-%% encodings while LDAP keeps its own stricter range policy (is_private_ip/1
-%% denies all RFC1918/CGNAT, not just broker infra).
-is_private_ip6({0, 0, 0, 0, 0, 0, 0, 1}) ->
-    true;
-is_private_ip6({0, 0, 0, 0, 0, 0, 0, 0}) ->
-    true;
-is_private_ip6({W1, _, _, _, _, _, _, _}) when W1 >= 16#fc00, W1 =< 16#fdff -> true;
-is_private_ip6({W1, _, _, _, _, _, _, _}) when W1 >= 16#fe80, W1 =< 16#febf -> true;
+is_denied_ip6(IP) ->
+    is_private_ip6(IP) andalso not relaxed_loopback(IP).
+
+relaxed_loopback(IP) ->
+    is_loopback(IP) andalso allow_private_networks().
+
+is_loopback({127, _, _, _}) -> true;
+is_loopback({0, 0, 0, 0, 0, 0, 0, 1}) -> true;
+is_loopback(_) -> false.
+
+allow_private_networks() ->
+    application:get_env(aws, auth_validation_allow_private_networks, false) =:= true.
+
+%% LDAP's SSRF range policy, as CIDR lists. This is deliberately BROADER than the
+%% http/oauth infra-only denylist in aws_auth_validate_net: LDAP denies ALL
+%% RFC1918/CGNAT/reserved space, not just broker infra. Expressed as
+%% {Network, PrefixBits} tuples run through the shared
+%% aws_auth_validate_net:in_any_cidr/2 so both backends enumerate ranges in ONE
+%% vocabulary -- a future range fix (or a segment-math change) cannot silently
+%% apply to only one classifier. This mirrors #153, which unified the embedded-v4
+%% unwrapper for exactly this reason; here we unify the range-matching mechanism
+%% while each backend keeps its own distinct list.
+%%   100.64.0.0/10 (RFC 6598) is carrier-grade NAT shared address space; it can
+%%     route to provider/internal infrastructure, so it is denied too.
+%%   240.0.0.0/4 is reserved/Class E, including 255.255.255.255 limited broadcast.
+-define(LDAP_DENIED_V4_CIDRS, [
+    {{127, 0, 0, 0}, 8},
+    {{10, 0, 0, 0}, 8},
+    {{172, 16, 0, 0}, 12},
+    {{192, 168, 0, 0}, 16},
+    {{169, 254, 0, 0}, 16},
+    {{100, 64, 0, 0}, 10},
+    {{0, 0, 0, 0}, 8},
+    {{240, 0, 0, 0}, 4}
+]).
+
+%% The IPv6 ranges corresponding to the v4 blocks above, so the filter cannot be
+%% bypassed with a v6 address.
+%%   ::1/128       loopback
+%%   ::/128        unspecified
+%%   fc00::/7      unique local addresses (ULA). Includes the IPv6 IMDS address
+%%                 fd00:ec2::254 -- the whole point of this block.
+%%   fe80::/10     link-local (spans fe80..febf, NOT just fe80)
+%% v4-carrying notations (IPv4-mapped, IPv4-compatible, NAT64 64:ff9b::/96, 6to4
+%% 2002::/16) are NOT listed here: they are unwrapped by the shared
+%% aws_auth_validate_net:embedded_v4/1 and re-checked against the v4 CIDRs, so
+%% e.g. ::ffff:169.254.169.254 or 2002:a9fe:a9fe:: still cannot reach IMDS.
+-define(LDAP_DENIED_V6_CIDRS, [
+    {{0, 0, 0, 0, 0, 0, 0, 1}, 128},
+    {{0, 0, 0, 0, 0, 0, 0, 0}, 128},
+    {{16#fc00, 0, 0, 0, 0, 0, 0, 0}, 7},
+    {{16#fe80, 0, 0, 0, 0, 0, 0, 0}, 10}
+]).
+
+%% Deny the LDAP range policy's v4 blocks (see ?LDAP_DENIED_V4_CIDRS).
+is_private_ip({_, _, _, _} = V4) ->
+    aws_auth_validate_net:in_any_cidr(V4, ?LDAP_DENIED_V4_CIDRS).
+
+%% Deny the LDAP range policy's v6 blocks, then fall through to the shared
+%% embedded-v4 unwrapper so a v6-encoded v4 address is re-checked against the v4
+%% policy. Keeps LDAP's stricter range policy while sharing the unwrap mechanism.
 is_private_ip6({_, _, _, _, _, _, _, _} = V6) ->
-    case aws_auth_validate_net:embedded_v4(V6) of
-        {ok, V4} -> is_private_ip(V4);
-        none -> false
+    case aws_auth_validate_net:in_any_cidr(V6, ?LDAP_DENIED_V6_CIDRS) of
+        true ->
+            true;
+        false ->
+            case aws_auth_validate_net:embedded_v4(V6) of
+                {ok, V4} -> is_private_ip(V4);
+                none -> false
+            end
     end;
 is_private_ip6(_) ->
     false.
@@ -702,15 +754,13 @@ do_ldap_connect(
 %% Re-validate the IP eldap actually connected to, closing the DNS-rebinding
 %% TOCTOU between is_allowed_server/1 (pre-connect, on a resolved IP) and this
 %% live socket. Reads the peer from the open handle rather than re-resolving the
-%% hostname, so what we check is exactly what we will talk to. Bypassed under
-%% auth_validation_allow_private_networks (local-slapd testing), matching
-%% is_allowed_server/1. Fails closed: if the peer cannot be determined, treat it
+%% hostname, so what we check is exactly what we will talk to. Always runs; the
+%% test-only loopback relaxation lives in is_denied_ip/1 (see is_allowed_server/1),
+%% so a local-slapd suite reaches 127.0.0.1/::1 while IMDS/RFC1918/etc stay denied
+%% even under the flag. Fails closed: if the peer cannot be determined, treat it
 %% as blocked.
 verify_connected_peer(Handle) ->
-    case application:get_env(aws, auth_validation_allow_private_networks, false) of
-        true -> ok;
-        _ -> check_peer_ip(Handle)
-    end.
+    check_peer_ip(Handle).
 
 check_peer_ip(Handle) ->
     case eldap:info(Handle) of
@@ -720,12 +770,12 @@ check_peer_ip(Handle) ->
     end.
 
 peer_allowed({ok, {IP, _Port}}) when tuple_size(IP) =:= 4 ->
-    case is_private_ip(IP) of
+    case is_denied_ip(IP) of
         true -> blocked;
         false -> ok
     end;
 peer_allowed({ok, {IP, _Port}}) when tuple_size(IP) =:= 8 ->
-    case is_private_ip6(IP) of
+    case is_denied_ip6(IP) of
         true -> blocked;
         false -> ok
     end;

--- a/src/aws_auth_validate_net.erl
+++ b/src/aws_auth_validate_net.erl
@@ -4,10 +4,11 @@
 %% -*- mode: erlang; -*-
 
 %% Shared SSRF / DNS-rebinding network guard for the http and oauth validation
-%% backends. (The ldap backend enforces a DIFFERENT, stricter address policy --
-%% it denies ALL private/RFC1918/CGNAT ranges, not just broker infra -- so it
-%% deliberately does NOT share this module. See aws_auth_validate_ldap's
-%% is_private_ip/1.)
+%% backends. The ldap backend shares the address classifier (classify_ip/2) and
+%% URL parser (parse_url/2) here, but passes its OWN stricter denylist -- it
+%% denies ALL private/RFC1918/CGNAT ranges, not just broker infra -- and adds a
+%% post-connect peer re-check for eldap's re-resolve. See aws_auth_validate_ldap's
+%% is_denied_ip/1.
 %%
 %% The validator issues outbound requests to customer-supplied URLs from the
 %% broker's network position -- a textbook SSRF / confused-deputy surface.
@@ -25,11 +26,13 @@
 %%     caller preserves Host header + SNI) so httpc cannot re-resolve to a
 %%     different address (DNS-rebinding / TOCTOU defense).
 %%
-%% Policy: deny the broker's own infra only (IMDS, loopback, link-local,
-%% unspecified). RFC1918 / unique-local are NOT denied -- a customer auth server
-%% or IdP normally lives in their VPC. The test-only
-%% auth_validation_allow_private_networks flag relaxes ONLY loopback so an
-%% integration suite can reach a local stub; IMDS/link-local stay denied.
+%% Policy: the http/oauth denylist denies the broker's own infra only (IMDS,
+%% loopback, link-local, unspecified). RFC1918 / unique-local are NOT denied there
+%% -- a customer auth server or IdP normally lives in their VPC. (The ldap backend
+%% passes classify_ip/2 its OWN stricter denylist that DOES deny RFC1918/CGNAT;
+%% the denylist is a per-backend parameter, not a property of this module.) The
+%% test-only auth_validation_allow_private_networks flag relaxes ONLY loopback so
+%% an integration suite can reach a local stub; IMDS/link-local stay denied.
 -module(aws_auth_validate_net).
 
 -export([
@@ -39,6 +42,7 @@
     embedded_v4/1,
     resolve_and_pin/2,
     pin_url/2,
+    parse_url/2,
     in_cidr/2,
     in_any_cidr/2
 ]).
@@ -54,7 +58,25 @@
     reason_connection := binary()
 }.
 
--export_type([policy/0]).
+%% The subset classify_ip/2 actually reads: just the infra denylists. A full
+%% policy() satisfies it, and a backend that only classifies addresses (ldap)
+%% can pass a denylist-only map without dummy scheme/reason keys.
+-type cidr_policy() :: #{
+    denied_v4 := [{tuple(), non_neg_integer()}],
+    denied_v6 := [{tuple(), non_neg_integer()}],
+    _ => _
+}.
+
+%% Options for parse_url/2: the scheme allowlist (same key name as policy())
+%% plus whether a pre-existing query string or #fragment is rejected. Defaults
+%% reject both.
+-type url_opts() :: #{
+    allowed_schemes := [string()],
+    query => allow | reject,
+    fragment => allow | reject
+}.
+
+-export_type([policy/0, cidr_policy/0, url_opts/0]).
 
 %%--------------------------------------------------------------------
 %% Pure phase: scheme allowlist + literal-IP classification
@@ -85,11 +107,52 @@ classify_address(#{host := Host}, Policy) ->
         {error, _} -> allow
     end.
 
+%% Parse and minimally validate a URL against Opts, returning a normalized map
+%% the probe and the SSRF guard share. Always rejects a non-allowlisted scheme,
+%% an empty host, userinfo (embedded credentials httpc would turn into an
+%% Authorization header), and an out-of-range port (else httpc crashes at
+%% request time). A pre-existing query string or #fragment is rejected unless
+%% Opts opts in (default reject), because a caller that appends its own path or
+%% query would otherwise produce an ambiguous or mangled URL.
+-spec parse_url(binary(), url_opts()) -> {ok, map()} | {error, bad_url}.
+parse_url(Bin, Opts) when is_binary(Bin) ->
+    Str = binary_to_list(Bin),
+    case uri_string:parse(Str) of
+        #{scheme := Scheme, host := Host} = Parsed when Host =/= [] ->
+            case lists:member(Scheme, maps:get(allowed_schemes, Opts)) of
+                false ->
+                    {error, bad_url};
+                true ->
+                    Port = maps:get(port, Parsed, undefined),
+                    QueryRejected =
+                        maps:get(query, Opts, reject) =:= reject andalso
+                            maps:is_key(query, Parsed) andalso
+                            maps:get(query, Parsed) =/= [],
+                    FragmentRejected =
+                        maps:get(fragment, Opts, reject) =:= reject andalso
+                            maps:is_key(fragment, Parsed) andalso
+                            maps:get(fragment, Parsed) =/= [],
+                    case Port of
+                        P when is_integer(P), (P < 1 orelse P > 65535) ->
+                            {error, bad_url};
+                        _ when QueryRejected orelse FragmentRejected ->
+                            {error, bad_url};
+                        _ ->
+                            case maps:is_key(userinfo, Parsed) of
+                                true -> {error, bad_url};
+                                false -> {ok, Parsed#{url_string => Str}}
+                            end
+                    end
+            end;
+        _ ->
+            {error, bad_url}
+    end.
+
 %% classify_ip/2: allow | deny for a parsed IP tuple. Denies the broker-infra
 %% ranges only. A v6 address that embeds a v4 address is unwrapped via the shared
 %% embedded_v4/1 and re-classified as v4, otherwise the v6 encoding smuggles a
 %% denied v4 address (e.g. 169.254.169.254) past the v4 denylist.
--spec classify_ip(tuple(), policy()) -> allow | deny.
+-spec classify_ip(tuple(), cidr_policy()) -> allow | deny.
 classify_ip({_, _, _, _, _, _, _, _} = V6, Policy) ->
     case embedded_v4(V6) of
         {ok, V4} ->
@@ -107,9 +170,9 @@ classify_ip({_, _, _, _} = V4, Policy) ->
     end.
 
 %% embedded_v4/1: for the IPv6 notations that carry a v4 address, return
-%% {ok, V4Tuple}; otherwise `none'. Policy-independent unwrapping shared with
-%% the LDAP SSRF classifier (aws_auth_validate_ldap:is_private_ip6/1) so both
-%% classifiers decode the same encodings from one place. Covered: IPv4-mapped
+%% {ok, V4Tuple}; otherwise `none'. Policy-independent unwrapping used by
+%% classify_ip/2 (which all three backends share) so every classifier decodes
+%% the same encodings from one place. Covered: IPv4-mapped
 %% ::ffff:a.b.c.d, IPv4-compatible ::a.b.c.d, NAT64 64:ff9b::/96, 6to4 2002::/16.
 %% The unspecified :: and loopback ::1 are deliberately NOT unwrapped -- they
 %% must be classified as v6 (::1 is v6 loopback, not v4 0.0.0.1).

--- a/src/aws_auth_validate_oauth.erl
+++ b/src/aws_auth_validate_oauth.erl
@@ -92,7 +92,7 @@
 %% network. Mirrors the HTTP/LDAP backends' -ifdef(TEST) export blocks.
 -export([
     parse_input/1,
-    parse_url/1,
+    parse_url/2,
     classify_ip/1,
     in_cidr/2,
     url_allowed/1,
@@ -426,15 +426,10 @@ parse_optional_url(_, _QueryPolicy) ->
     {error, bad_url}.
 
 %% Parse + validate an https URL. Returns a normalized representation the probe
-%% and the SSRF guard can both use. Defaults to reject_query for callers (and
-%% tests) that supply a URL that must not carry a query -- e.g. a discovered
-%% jwks_uri, whose path is used as-is but which we still normalize.
-parse_url(Bin) ->
-    parse_url(Bin, reject_query).
-
-%% QueryPolicy: reject_query bars a pre-existing query string (the caller appends
-%% a path, so a query would be ambiguous); allow_query permits it (the URL is
-%% fetched verbatim). userinfo and out-of-range ports are always rejected.
+%% and the SSRF guard can both use. QueryPolicy: reject_query bars a pre-existing
+%% query string (the caller appends a path, so a query would be ambiguous);
+%% allow_query permits it (the URL is fetched verbatim). userinfo and
+%% out-of-range ports are always rejected.
 parse_url(Bin, QueryPolicy) when is_binary(Bin) ->
     Str = binary_to_list(Bin),
     case uri_string:parse(Str) of

--- a/src/aws_auth_validate_oauth.erl
+++ b/src/aws_auth_validate_oauth.erl
@@ -387,10 +387,14 @@ parse_input([Step | Rest], Body, Acc0) ->
     end.
 
 %% Parse jwks_uri and issuer. At least one must be present and a valid https URL.
+%% jwks_uri is fetched VERBATIM, so a pre-existing query string is allowed (some
+%% IdPs publish one, and the live broker's uaa_jwks:get/2 fetches it as-is);
+%% issuer has the OIDC well-known path appended, so a query there is ambiguous
+%% and stays rejected.
 parse_urls(Body, Acc) ->
     JwksRaw = maps:get(<<"jwks_uri">>, Body, undefined),
     IssuerRaw = maps:get(<<"issuer">>, Body, undefined),
-    case {parse_optional_url(JwksRaw), parse_optional_url(IssuerRaw)} of
+    case {parse_optional_url(JwksRaw, allow_query), parse_optional_url(IssuerRaw, reject_query)} of
         {{error, _}, _} ->
             {error, input_invalid, ?REASON_BAD_URL};
         {_, {error, _}} ->
@@ -411,17 +415,27 @@ parse_urls(Body, Acc) ->
             {ok, Acc2}
     end.
 
-%% Parse an optional URL field: undefined -> none, valid -> {ok, Parsed}, invalid -> {error, _}.
-parse_optional_url(undefined) ->
+%% Parse an optional URL field: undefined -> none, valid -> {ok, Parsed}, invalid
+%% -> {error, _}. QueryPolicy is allow_query (jwks_uri, fetched verbatim) or
+%% reject_query (issuer, has the well-known path appended).
+parse_optional_url(undefined, _QueryPolicy) ->
     none;
-parse_optional_url(V) when is_binary(V), byte_size(V) > 0 ->
-    parse_url(V);
-parse_optional_url(_) ->
+parse_optional_url(V, QueryPolicy) when is_binary(V), byte_size(V) > 0 ->
+    parse_url(V, QueryPolicy);
+parse_optional_url(_, _QueryPolicy) ->
     {error, bad_url}.
 
 %% Parse + validate an https URL. Returns a normalized representation the probe
-%% and the SSRF guard can both use.
-parse_url(Bin) when is_binary(Bin) ->
+%% and the SSRF guard can both use. Defaults to reject_query for callers (and
+%% tests) that supply a URL that must not carry a query -- e.g. a discovered
+%% jwks_uri, whose path is used as-is but which we still normalize.
+parse_url(Bin) ->
+    parse_url(Bin, reject_query).
+
+%% QueryPolicy: reject_query bars a pre-existing query string (the caller appends
+%% a path, so a query would be ambiguous); allow_query permits it (the URL is
+%% fetched verbatim). userinfo and out-of-range ports are always rejected.
+parse_url(Bin, QueryPolicy) when is_binary(Bin) ->
     Str = binary_to_list(Bin),
     case uri_string:parse(Str) of
         #{scheme := Scheme, host := Host} = Parsed when
@@ -430,13 +444,14 @@ parse_url(Bin) when is_binary(Bin) ->
             %% Reject:
             %%   * out-of-range port (else httpc crashes at request time)
             %%   * userinfo (embedded credentials)
-            %%   * pre-existing query string (OIDC discovery appends well-known path)
+            %%   * a pre-existing query string, only under reject_query
             Port = maps:get(port, Parsed, undefined),
             HasQuery = maps:is_key(query, Parsed) andalso maps:get(query, Parsed) =/= [],
+            QueryRejected = HasQuery andalso QueryPolicy =:= reject_query,
             case Port of
                 P when is_integer(P), (P < 1 orelse P > 65535) ->
                     {error, bad_url};
-                _ when HasQuery ->
+                _ when QueryRejected ->
                     {error, bad_url};
                 _ ->
                     case maps:is_key(userinfo, Parsed) of
@@ -1052,7 +1067,9 @@ parse_discovery_doc(Body) ->
         {ok, Map} when is_map(Map) ->
             case maps:get(<<"jwks_uri">>, Map, undefined) of
                 JwksUriBin when is_binary(JwksUriBin), byte_size(JwksUriBin) > 0 ->
-                    case parse_url(JwksUriBin) of
+                    %% A discovered jwks_uri is fetched verbatim (same path as a
+                    %% directly-supplied one), so allow a query string here too.
+                    case parse_url(JwksUriBin, allow_query) of
                         {ok, Parsed} -> {ok, Parsed};
                         {error, _} -> {error, auth_failed, ?REASON_DISCOVERY}
                     end;

--- a/src/aws_auth_validate_oauth.erl
+++ b/src/aws_auth_validate_oauth.erl
@@ -431,38 +431,22 @@ parse_optional_url(V, QueryPolicy) when is_binary(V), byte_size(V) > 0 ->
 parse_optional_url(_, _QueryPolicy) ->
     {error, bad_url}.
 
-%% Parse + validate an https URL. Returns a normalized representation the probe
-%% and the SSRF guard can both use. QueryPolicy: reject_query bars a pre-existing
-%% query string (the caller appends a path, so a query would be ambiguous);
-%% allow_query permits it (the URL is fetched verbatim). userinfo and
-%% out-of-range ports are always rejected.
+%% Parse + validate an https URL via the shared aws_auth_validate_net:parse_url/2.
+%% QueryPolicy reflects this backend's two cases and governs a pre-existing query
+%% string AND a #fragment identically, because both fail for the same reason:
+%% reject_query (issuer) has the well-known path appended, so a query or fragment
+%% would be mangled (the path lands after the '#' and httpc drops it), whereas
+%% allow_query (jwks_uri) is fetched verbatim, so a query or an httpc-dropped
+%% fragment is harmless. userinfo and out-of-range ports are always rejected.
 parse_url(Bin, QueryPolicy) when is_binary(Bin) ->
-    Str = binary_to_list(Bin),
-    case uri_string:parse(Str) of
-        #{scheme := Scheme, host := Host} = Parsed when
-            Host =/= [], Scheme =:= "https"
-        ->
-            %% Reject:
-            %%   * out-of-range port (else httpc crashes at request time)
-            %%   * userinfo (embedded credentials)
-            %%   * a pre-existing query string, only under reject_query
-            Port = maps:get(port, Parsed, undefined),
-            HasQuery = maps:is_key(query, Parsed) andalso maps:get(query, Parsed) =/= [],
-            QueryRejected = HasQuery andalso QueryPolicy =:= reject_query,
-            case Port of
-                P when is_integer(P), (P < 1 orelse P > 65535) ->
-                    {error, bad_url};
-                _ when QueryRejected ->
-                    {error, bad_url};
-                _ ->
-                    case maps:is_key(userinfo, Parsed) of
-                        true -> {error, bad_url};
-                        false -> {ok, Parsed#{url_string => Str}}
-                    end
-            end;
-        _ ->
-            {error, bad_url}
-    end.
+    aws_auth_validate_net:parse_url(Bin, #{
+        allowed_schemes => ?ALLOWED_SCHEMES,
+        query => query_opt(QueryPolicy),
+        fragment => query_opt(QueryPolicy)
+    }).
+
+query_opt(allow_query) -> allow;
+query_opt(reject_query) -> reject.
 
 parse_resource_server_id(Body, Acc) ->
     case maps:get(<<"resource_server_id">>, Body, undefined) of

--- a/test/aws_auth_validate_oauth_tests.erl
+++ b/test/aws_auth_validate_oauth_tests.erl
@@ -91,6 +91,22 @@ issuer_with_query_rejected_test() ->
     Body = #{<<"issuer">> => <<"https://idp.example.com?foo=bar">>},
     ?assertMatch({error, input_invalid, _}, aws_auth_validate_oauth:parse_input(Body)).
 
+%% A jwks_uri with a #fragment is ACCEPTED: the URL is fetched verbatim (httpc
+%% drops the fragment on the wire), so rejecting it would refuse a config the
+%% broker accepts. Pins the oauth backend's fragment-permissive behavior against
+%% the shared parser, whose default is to reject fragments (as http requires).
+jwks_uri_with_fragment_allowed_test() ->
+    Body = #{<<"jwks_uri">> => <<"https://idp.example.com/jwks#kid">>},
+    ?assertMatch({ok, #{jwks_uri := #{}}}, aws_auth_validate_oauth:parse_input(Body)).
+
+%% An issuer with a #fragment is REJECTED, unlike jwks_uri: OIDC discovery appends
+%% the well-known path to the issuer, which would land AFTER the '#' (httpc then
+%% drops it), so the discovery URL would be mangled exactly as a pre-existing
+%% query string mangles it.
+issuer_with_fragment_rejected_test() ->
+    Body = #{<<"issuer">> => <<"https://idp.example.com#frag">>},
+    ?assertMatch({error, input_invalid, _}, aws_auth_validate_oauth:parse_input(Body)).
+
 %% A URL with an out-of-range port (0) is rejected.
 url_port_zero_rejected_test() ->
     Body = #{<<"jwks_uri">> => <<"https://idp.example.com:0/jwks">>},

--- a/test/aws_auth_validate_oauth_tests.erl
+++ b/test/aws_auth_validate_oauth_tests.erl
@@ -76,10 +76,20 @@ url_with_userinfo_rejected_test() ->
     Body = #{<<"jwks_uri">> => <<"https://admin:secret@idp.example.com/jwks">>},
     ?assertMatch({error, input_invalid, _}, aws_auth_validate_oauth:validate(Body)).
 
-%% A URL with a pre-existing query string is rejected.
-url_with_query_rejected_test() ->
+%% A jwks_uri with a pre-existing query string is ACCEPTED in the pure phase: it
+%% is fetched verbatim (the live broker's uaa_jwks:get/2 does the same), so we
+%% must not reject a config the broker would accept. Exercised via the pure
+%% parse_input/1 (no network) so it stays deterministic; the query survives into
+%% the parsed jwks_uri.
+jwks_uri_with_query_allowed_test() ->
     Body = #{<<"jwks_uri">> => <<"https://idp.example.com/jwks?foo=bar">>},
-    ?assertMatch({error, input_invalid, _}, aws_auth_validate_oauth:validate(Body)).
+    ?assertMatch({ok, #{jwks_uri := #{}}}, aws_auth_validate_oauth:parse_input(Body)).
+
+%% An issuer with a pre-existing query string is still rejected: OIDC discovery
+%% appends the well-known path to it, so a query there is ambiguous.
+issuer_with_query_rejected_test() ->
+    Body = #{<<"issuer">> => <<"https://idp.example.com?foo=bar">>},
+    ?assertMatch({error, input_invalid, _}, aws_auth_validate_oauth:parse_input(Body)).
 
 %% A URL with an out-of-range port (0) is rejected.
 url_port_zero_rejected_test() ->

--- a/test/aws_auth_validate_shared_tests.erl
+++ b/test/aws_auth_validate_shared_tests.erl
@@ -183,9 +183,9 @@ hostname_check_mode_wildcard_test() ->
     ).
 
 %%--------------------------------------------------------------------
-%% aws_auth_validate_net: embedded_v4/1 shared unwrapper. The LDAP SSRF
-%% classifier (is_private_ip6/1) shares this helper, so its decoding must cover
-%% every v4-carrying v6 notation and leave native v6 (::, ::1) unwrapped.
+%% aws_auth_validate_net: embedded_v4/1 shared unwrapper. classify_ip/2 (shared
+%% by all three backends) uses this helper, so its decoding must cover every
+%% v4-carrying v6 notation and leave native v6 (::, ::1) unwrapped.
 %%--------------------------------------------------------------------
 
 embedded_v4_ipv4_mapped_test() ->

--- a/test/aws_auth_validate_tests.erl
+++ b/test/aws_auth_validate_tests.erl
@@ -364,6 +364,21 @@ server_flag_relaxes_loopback_only_test_() ->
             ?_assertEqual(
                 blocked,
                 aws_auth_validate_ldap:peer_allowed({ok, {{169, 254, 169, 254}, 80}})
+            ),
+            %% A v4-mapped loopback ::ffff:127.0.0.1 is unwrapped BEFORE the
+            %% loopback relaxation, so it relaxes under the flag exactly as the
+            %% bare v4 loopback does. Sharing classify_ip/2 is what guarantees
+            %% this; the prior hand-rolled path tested is_loopback on the raw v6
+            %% tuple and wrongly kept it denied.
+            ?_assertEqual(
+                false,
+                aws_auth_validate_ldap:is_denied_ip({0, 0, 0, 0, 0, 16#ffff, 16#7f00, 1})
+            ),
+            %% A v4-mapped IMDS ::ffff:169.254.169.254 stays denied even under
+            %% the flag -- relaxation is loopback-only, not any embedded v4.
+            ?_assertEqual(
+                true,
+                aws_auth_validate_ldap:is_denied_ip({0, 0, 0, 0, 0, 16#ffff, 16#a9fe, 16#a9fe})
             )
         ]}.
 
@@ -676,18 +691,18 @@ ldap_search_time_limit_seconds_floor_test() ->
     end.
 
 %%--------------------------------------------------------------------
-%% is_private_ip6/1 6to4 unwrapping (issue #154 coverage). is_allowed_server/1
-%% already covers the resolve path; these pin the classifier directly so a
-%% regression in the shared embedded_v4 unwrap is caught without DNS.
+%% is_denied_ip/1 6to4 unwrapping for v6 input (issue #154 coverage).
+%% is_allowed_server/1 already covers the resolve path; these pin the classifier
+%% directly so a regression in the shared embedded_v4 unwrap is caught without DNS.
 %%--------------------------------------------------------------------
 
-ldap_is_private_ip6_6to4_imds_blocked_test() ->
-    %% 2002:a9fe:a9fe:: wraps 169.254.169.254 (IMDS) -> private.
-    ?assert(aws_auth_validate_ldap:is_private_ip6({16#2002, 16#a9fe, 16#a9fe, 0, 0, 0, 0, 0})).
+ldap_is_denied_ip_6to4_imds_blocked_test() ->
+    %% 2002:a9fe:a9fe:: wraps 169.254.169.254 (IMDS) -> denied.
+    ?assert(aws_auth_validate_ldap:is_denied_ip({16#2002, 16#a9fe, 16#a9fe, 0, 0, 0, 0, 0})).
 
-ldap_is_private_ip6_6to4_public_allowed_test() ->
-    %% 2002:0808:0808:: wraps 8.8.8.8 (public) -> not private.
-    ?assertNot(aws_auth_validate_ldap:is_private_ip6({16#2002, 16#0808, 16#0808, 0, 0, 0, 0, 0})).
+ldap_is_denied_ip_6to4_public_allowed_test() ->
+    %% 2002:0808:0808:: wraps 8.8.8.8 (public) -> not denied.
+    ?assertNot(aws_auth_validate_ldap:is_denied_ip({16#2002, 16#0808, 16#0808, 0, 0, 0, 0, 0})).
 
 ldap_config_conflict_test() ->
     Body = base_body(#{<<"use_ssl">> => true, <<"use_starttls">> => true}),

--- a/test/aws_auth_validate_tests.erl
+++ b/test/aws_auth_validate_tests.erl
@@ -334,6 +334,69 @@ server_rejects_unresolvable_test() ->
         false, aws_auth_validate_ldap:is_allowed_server("this.host.does.not.exist.invalid")
     ).
 
+%% Test-only auth_validation_allow_private_networks relaxes ONLY loopback, not the
+%% whole denylist, so the LDAP backend does not get a broader test-mode bypass than
+%% aws_auth_validate_net grants http/oauth. Loopback (127/8, ::1) becomes reachable;
+%% IMDS/link-local/RFC1918/CGNAT stay denied even with the flag on.
+server_flag_relaxes_loopback_only_test_() ->
+    {setup,
+        fun() ->
+            application:set_env(aws, auth_validation_allow_private_networks, true)
+        end,
+        fun(_) ->
+            application:unset_env(aws, auth_validation_allow_private_networks)
+        end,
+        [
+            %% Loopback is now reachable (the intended local-slapd relaxation).
+            ?_assertEqual(true, aws_auth_validate_ldap:is_allowed_server("127.0.0.1")),
+            ?_assertEqual(true, aws_auth_validate_ldap:is_allowed_server("::1")),
+            %% IMDS is still denied even under the flag -- the whole point.
+            ?_assertEqual(
+                false, aws_auth_validate_ldap:is_allowed_server("169.254.169.254")
+            ),
+            %% RFC1918 and CGNAT stay denied too.
+            ?_assertEqual(false, aws_auth_validate_ldap:is_allowed_server("10.0.0.5")),
+            ?_assertEqual(false, aws_auth_validate_ldap:is_allowed_server("100.64.0.1")),
+            %% The post-connect peer check honours the same loopback-only relaxation.
+            ?_assertEqual(
+                ok, aws_auth_validate_ldap:peer_allowed({ok, {{127, 0, 0, 1}, 389}})
+            ),
+            ?_assertEqual(
+                blocked,
+                aws_auth_validate_ldap:peer_allowed({ok, {{169, 254, 169, 254}, 80}})
+            )
+        ]}.
+
+%%--------------------------------------------------------------------
+%% Port default (broker parity)
+%%--------------------------------------------------------------------
+
+%% An omitted port defaults to the broker's default (389) rather than being
+%% rejected input_invalid, so a config the live broker would accept validates.
+parse_port_defaults_to_389_when_absent_test() ->
+    ?assertEqual({ok, #{port => 389}}, aws_auth_validate_ldap:parse_port(#{}, #{})).
+
+%% A supplied in-range port is honoured unchanged.
+parse_port_honours_supplied_test() ->
+    ?assertEqual(
+        {ok, #{port => 636}},
+        aws_auth_validate_ldap:parse_port(#{<<"port">> => 636}, #{})
+    ).
+
+%% An out-of-range or non-integer port is still rejected.
+parse_port_rejects_out_of_range_test() ->
+    ?assertMatch(
+        {error, input_invalid, _}, aws_auth_validate_ldap:parse_port(#{<<"port">> => 0}, #{})
+    ),
+    ?assertMatch(
+        {error, input_invalid, _},
+        aws_auth_validate_ldap:parse_port(#{<<"port">> => 70000}, #{})
+    ),
+    ?assertMatch(
+        {error, input_invalid, _},
+        aws_auth_validate_ldap:parse_port(#{<<"port">> => <<"636">>}, #{})
+    ).
+
 %%--------------------------------------------------------------------
 %% Post-connect peer re-check (DNS-rebinding TOCTOU defence)
 %%--------------------------------------------------------------------


### PR DESCRIPTION
*Issue #, if available:* Closes #157, #158. Stacks additional hardening follow-ups with no individual issues.

Post-merge hardening follow-ups for the auth-validation endpoint, in the same vein as # 151-155. 

### 1. LDAP hardening
- **shared range-matching:** express the LDAP SSRF range policy as `?LDAP_DENIED_V4_CIDRS` / `?LDAP_DENIED_V6_CIDRS` consumed by the shared `aws_auth_validate_net:in_any_cidr/2`, replacing the hand-coded guard clauses. LDAP keeps its own broader list (all RFC1918/CGNAT/reserved, not just broker infra), but both backends now enumerate ranges in ONE vocabulary, so a future range or segment-math fix cannot silently apply to only one classifier. Mirrors the #153 `embedded_v4` unification, one layer up.
- **port parity:** default an omitted `port` to 389, matching `rabbit_auth_backend_ldap`'s application-env default (the broker does not bump to 636 for TLS). A config the live broker would accept no longer fails `input_invalid`.
- **loopback-only test flag:** the test-only `auth_validation_allow_private_networks` flag now relaxes ONLY loopback (via `is_denied_ip/1`, mirroring `aws_auth_validate_net:classify_denied/1`) instead of fully bypassing both SSRF checks. IMDS/link-local/RFC1918/CGNAT stay denied even under the flag, so the LDAP backend no longer gets a broader test-mode bypass than http/oauth. Both the pre-connect and post-connect peer checks always run.

### 2. FE/BE category drift + oauth jwks_uri query parity (#157, #158)
- **#157:** add `body_too_large` to `AWS_AUTH_VALIDATE_CATEGORY`. The backend returns `{error:"body_too_large"}` at HTTP 400, but the UI status map never had the matching key, so an oversized body fell through to the generic "Unexpected response (400)" banner. It was the sole backend category missing from the map.
- **#158:** allow a pre-existing query string on `jwks_uri` (both directly-supplied and OIDC-discovered). `jwks_uri` is fetched VERBATIM -- the live broker's `uaa_jwks:get/2` fetches it as-is -- so rejecting a query string `input_invalid` diverged too-strict from the broker. `issuer` keeps rejecting a query (OIDC discovery appends the well-known path). Threaded via a `QueryPolicy` (`allow_query | reject_query`) arg on `parse_url/2`.

### 3. Build fix
- Drop the now-unused `parse_url/1` wrapper (both call sites moved to `parse_url/2`). It only survived the local eunit build because it was in the `-ifdef(TEST)` export list; the production `make app` build (warnings-as-errors, no TEST exports) flagged it as unused. Test export updated to `parse_url/2`.

### Testing
- `erlfmt -c` clean on all `.erl` changes.
- Production `make app` build (warnings-as-errors) passes.
- Full clean eunit run green.
- Verified this branch merges cleanly on top of #156 (no conflicts; 728 tests pass on the combined tree).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
