### PR TITLE
OAuth Authz validation parity test enhancements

### DIFF
--- a/src/aws_auth_validate_oauth.erl
+++ b/src/aws_auth_validate_oauth.erl
@@ -41,9 +41,11 @@
 %%
 %% This reuses the broker's own crypto library (jose) so the signature decision
 %% matches what rabbit_auth_backend_oauth2 would compute -- a decision-parity
-%% claim analogous to the LDAP backend's, scoped to signature + exp/nbf/aud. It
-%% does NOT assert scope authorization; that stays an over-trust caveat for the
-%% customer docs, same as the LDAP dn_lookup_base and HTTP reachability checks.
+%% claim analogous to the LDAP backend's, scoped to signature + exp/nbf/aud.
+%% Scope authorization CAN now be checked via the optional `authz_check' block
+%% (delegated to aws_auth_validate_oauth_authz when the arity-4 scope API is
+%% available); see allowed_fields/0 for the full authz field set. Note: not all
+%% resource_server fields are overlaid yet -- a documented parity gap.
 %%
 %% A broker-side `client_credentials' grant (the broker fetching a token itself
 %% from a supplied token_endpoint + client_secret_arn) was considered and

--- a/test/aws_auth_validate_oauth_tests.erl
+++ b/test/aws_auth_validate_oauth_tests.erl
@@ -1032,6 +1032,66 @@ authz_iam_scope_alias_grants_access_test_() ->
         end)
     end}.
 
+%% -------- PARITY PIN: rabbitmq/rabbitmq-server discussion #16947 --------
+%%
+%% rabbit_auth_backend_oauth2 resolves additional_scopes_key via split_path/1:
+%%
+%%   split_path(Path) ->
+%%       binary:split(Path, <<".">>, [global, trim_all]).
+%%
+%% Flat claim keys containing dots -- typical for OIDC/STS-style URIs like
+%% <<"https://sts.amazonaws.com/tags">> -- are split into nested-map path
+%% segments (["https://sts", "amazonaws", "com/tags"]) and looked up as a
+%% deeply nested key in the flat claims map. The key is never found, so the
+%% scopes under it are never extracted.
+%%
+%% This test PINS the current (broken) behavior: the authz evaluator returns
+%% authz_unverified because it sees no effective scopes. When upstream fixes
+%% split_path (or adds a dedicated flat-key accessor for additional_scopes_key),
+%% this test MUST be revisited: the assertion should flip from authz_unverified
+%% to ok, and the change landed together with the broker dependency bump.
+%%
+%% This matches the project's parity stance: document upstream behavior, pin
+%% against drift, and surface regressions as test failures the moment the
+%% dependency changes.
+%% -------------------------------------------------------------------
+authz_dotted_additional_scopes_key_parity_pin_test_() ->
+    {setup, fun setup_httpc_mock/0, fun teardown_httpc_mock/1, fun(_) ->
+        maybe_skip_authz(fun() ->
+            #{jwk_pub := PubJwk, sign := Sign} = rsa_signer(<<"k1">>),
+            %% Token carries scopes under a dotted claim key (OIDC/STS-style URI).
+            %% split_path/1 will incorrectly split this on dots, breaking resolution.
+            Token = Sign(#{
+                <<"exp">> => future(),
+                <<"aud">> => <<"rabbitmq">>,
+                <<"https://sts.amazonaws.com/tags">> => [
+                    <<"rabbitmq.write:*/*">>, <<"rabbitmq.read:*/*">>
+                ]
+            }),
+            JwksBody = rabbit_json:encode(#{<<"keys">> => [PubJwk]}),
+            mock_httpc_response(200, JwksBody),
+            Body = (jwks_body())#{
+                <<"access_token">> => Token,
+                <<"resource_server_id">> => <<"rabbitmq">>,
+                <<"scope_prefix">> => <<"rabbitmq.">>,
+                %% Point additional_scopes_key at the dotted claim.
+                <<"additional_scopes_key">> => <<"https://sts.amazonaws.com/tags">>,
+                <<"authz_check">> => #{
+                    <<"resource">> => <<"my-queue">>,
+                    <<"permission">> => <<"write">>
+                }
+            },
+            Result = aws_auth_validate_oauth:validate(Body),
+            [
+                %% Current behavior: split_path splits the dotted key, lookup fails,
+                %% no scopes extracted -> authz_unverified. This will flip to ok once
+                %% upstream fixes the lookup.
+                ?_assertMatch({error, authz_unverified, _}, Result),
+                ?_assert(reason_contains(Result, "no scopes for this resource_server"))
+            ]
+        end)
+    end}.
+
 %% authz_check without an access_token is rejected in the pure phase.
 authz_check_without_token_rejected_test() ->
     Body = (jwks_body())#{

--- a/test/aws_auth_validate_oauth_tests.erl
+++ b/test/aws_auth_validate_oauth_tests.erl
@@ -1051,9 +1051,24 @@ authz_iam_scope_alias_grants_access_test_() ->
 %% this test MUST be revisited: the assertion should flip from authz_unverified
 %% to ok, and the change landed together with the broker dependency bump.
 %%
-%% This matches the project's parity stance: document upstream behavior, pin
-%% against drift, and surface regressions as test failures the moment the
-%% dependency changes.
+%% DORMANCY: the pin only RUNS once the broker ships the arity-4 scope API
+%% (resource_access/4). On an older dep, HAVE_OAUTH2_RESOURCE_SERVER is undefined,
+%% available/0 is false, and maybe_skip_authz/1 returns [] -- the body never
+%% executes. So a green suite does NOT mean "still broken as expected"; it may
+%% mean the pin was skipped. Concretely, if upstream backports only the
+%% split_path fix to a dep series WITHOUT the arity-4 API, this pin stays dormant
+%% and the regression slips through here. The pin fires only on a series with the
+%% full arity-4 API; treat the parity-bump revisit as the real backstop.
+%%
+%% FLIP SHAPE: the scope value below is deliberately `rabbitmq.'-prefixed. In the
+%% fixed backend, extract_scope_list_from_token_value/2 takes a LIST value
+%% VERBATIM (only a map value keyed by resource_server_id is prefix-injected), so
+%% after the scope_prefix "rabbitmq." strip this yields write:*/* and flips to ok.
+%% An unprefixed value here would be filtered to [] by the strip and never flip.
+%%
+%% This matches the project's parity stance: document upstream behavior and pin
+%% against drift, surfacing regressions as test failures once the dep ships the
+%% arity-4 API.
 %% -------------------------------------------------------------------
 authz_dotted_additional_scopes_key_parity_pin_test_() ->
     {setup, fun setup_httpc_mock/0, fun teardown_httpc_mock/1, fun(_) ->

--- a/test/aws_auth_validate_oauth_tests.erl
+++ b/test/aws_auth_validate_oauth_tests.erl
@@ -1051,6 +1051,14 @@ authz_iam_scope_alias_grants_access_test_() ->
 %% this test MUST be revisited: the assertion should flip from authz_unverified
 %% to ok, and the change landed together with the broker dependency bump.
 %%
+%% CONTROL: the authz_unverified assertion alone does not isolate the dotted-key
+%% cause -- authz_no_effective_scopes_after_prefix_test_ asserts the identical
+%% category and message for a wrong-prefix token, so ANY unresolved
+%% additional_scopes_key looks the same. The paired control case sends the SAME
+%% scopes under a NON-dotted key and asserts it reaches ok, making the dot the
+%% only variable: if the control ever stops granting, the breakage is in
+%% additional_scopes_key resolution generally, not in the dotted-key split.
+%%
 %% DORMANCY: the pin only RUNS once the broker ships the arity-4 scope API
 %% (resource_access/4). On an older dep, HAVE_OAUTH2_RESOURCE_SERVER is undefined,
 %% available/0 is false, and maybe_skip_authz/1 returns [] -- the body never
@@ -1074,35 +1082,42 @@ authz_dotted_additional_scopes_key_parity_pin_test_() ->
     {setup, fun setup_httpc_mock/0, fun teardown_httpc_mock/1, fun(_) ->
         maybe_skip_authz(fun() ->
             #{jwk_pub := PubJwk, sign := Sign} = rsa_signer(<<"k1">>),
-            %% Token carries scopes under a dotted claim key (OIDC/STS-style URI).
-            %% split_path/1 will incorrectly split this on dots, breaking resolution.
-            Token = Sign(#{
-                <<"exp">> => future(),
-                <<"aud">> => <<"rabbitmq">>,
-                <<"https://sts.amazonaws.com/tags">> => [
-                    <<"rabbitmq.write:*/*">>, <<"rabbitmq.read:*/*">>
-                ]
-            }),
             JwksBody = rabbit_json:encode(#{<<"keys">> => [PubJwk]}),
             mock_httpc_response(200, JwksBody),
-            Body = (jwks_body())#{
-                <<"access_token">> => Token,
-                <<"resource_server_id">> => <<"rabbitmq">>,
-                <<"scope_prefix">> => <<"rabbitmq.">>,
-                %% Point additional_scopes_key at the dotted claim.
-                <<"additional_scopes_key">> => <<"https://sts.amazonaws.com/tags">>,
-                <<"authz_check">> => #{
-                    <<"resource">> => <<"my-queue">>,
-                    <<"permission">> => <<"write">>
-                }
-            },
-            Result = aws_auth_validate_oauth:validate(Body),
+            %% Same scopes, same everything: only the claim KEY differs between the
+            %% two cases, so the dotted key is the sole variable.
+            Scopes = [<<"rabbitmq.write:*/*">>, <<"rabbitmq.read:*/*">>],
+            Validate = fun(ClaimKey) ->
+                Token = Sign(#{
+                    <<"exp">> => future(),
+                    <<"aud">> => <<"rabbitmq">>,
+                    ClaimKey => Scopes
+                }),
+                aws_auth_validate_oauth:validate((jwks_body())#{
+                    <<"access_token">> => Token,
+                    <<"resource_server_id">> => <<"rabbitmq">>,
+                    <<"scope_prefix">> => <<"rabbitmq.">>,
+                    <<"additional_scopes_key">> => ClaimKey,
+                    <<"authz_check">> => #{
+                        <<"resource">> => <<"my-queue">>,
+                        <<"permission">> => <<"write">>
+                    }
+                })
+            end,
+            Dotted = Validate(<<"https://sts.amazonaws.com/tags">>),
+            Control = Validate(<<"tags">>),
             [
                 %% Current behavior: split_path splits the dotted key, lookup fails,
                 %% no scopes extracted -> authz_unverified. This will flip to ok once
                 %% upstream fixes the lookup.
-                ?_assertMatch({error, authz_unverified, _}, Result),
-                ?_assert(reason_contains(Result, "no scopes for this resource_server"))
+                ?_assertMatch({error, authz_unverified, _}, Dotted),
+                ?_assert(reason_contains(Dotted, "no scopes for this resource_server")),
+                %% CONTROL: the identical scopes under a NON-dotted key DO resolve and
+                %% grant. Without this, the pin cannot tell the dotted-key mis-split
+                %% from any other no-effective-scopes cause (a renamed claim, a dropped
+                %% additional_scopes_key feature), since every such case yields the same
+                %% category and message as authz_no_effective_scopes_after_prefix_test_.
+                ?_assertEqual(ok, Control)
             ]
         end)
     end}.


### PR DESCRIPTION
Lands after #159

## What this adds

A parity-pin test for the OAuth authz validation endpoint that captures the current upstream behavior around dotted `additional_scopes_key` values (rabbitmq-server 16947), plus a small comment correction on the existing over-trust caveat.

rabbitmq-server 16947 documents that the OAuth backend resolves `additional_scopes_key` via `rabbit_auth_backend_oauth2:split_path/1`, which splits the key on every `.`:

```erlang
split_path(Path) -> binary:split(Path, <<".">>, [global, trim_all]).
```

A flat claim key that itself contains dots — e.g. an STS/OIDC key like `https://sts.amazonaws.com/tags` — is therefore split into a nested-map path (`["https://sts", "amazonaws", "com/tags"]`), the flat claim is never found, and its scopes are not extracted. The validation endpoint replays the broker's real scope-resolution code, so it faithfully reproduces this behavior.

## Changes

- **`test/aws_auth_validate_oauth_tests.erl`** — adds `authz_dotted_additional_scopes_key_parity_pin_test_`:
  - Mints a token carrying scopes under a flat dotted claim key (`https://sts.amazonaws.com/tags`), points `additional_scopes_key` at that key, and runs it through the real upstream `normalize_token_scope` / `get_expanded_scopes` / `resource_access` path (not mocks).
  - Asserts the current behavior: `{error, authz_unverified, _}` with the "no scopes for this resource_server" message, because `split_path/1` mis-splits the dotted key.
  - Gated by `maybe_skip_authz/1`, so it skips cleanly on a pre-floor broker series that lacks the arity-4 scope API rather than failing.
  - Pins upstream behavior: if `split_path` is later changed (or a dedicated flat-key accessor is added), this test flips and forces a coordinated broker-dependency bump — surfacing the drift as a test failure the moment the dependency changes.

- **`src/aws_auth_validate_oauth.erl`** — corrects the module's over-trust caveat comment to reflect that scope authorization can now be checked via the optional `authz_check` block (delegated to `aws_auth_validate_oauth_authz`), while noting the documented resource-server-field overlay parity gap.

## Why pin rather than fix

Fixing the dotted-key handling locally in the validation endpoint would make it report a grant the live broker would still refuse — a false pass, and exactly the parity regression the endpoint exists to avoid. The correct behavior is to mirror the current upstream behavior and pin it, so the endpoint and the real broker always agree. The follow-on escaped-dot support (once rabbitmq-server 16985 lands upstream) is tracked separately in #161, which builds on this PR.

## Verification

- `gmake eunit t=aws_auth_validate_oauth_tests` — all tests pass; the new pin test's assertions confirmed executing (not skipped) with the OAuth backend on the code path.
- `erlfmt -c` clean.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
