### PR TITLE
Add support for escaped . in authz validation requests

### DIFF
--- a/src/aws_auth_validate_oauth.erl
+++ b/src/aws_auth_validate_oauth.erl
@@ -41,9 +41,11 @@
 %%
 %% This reuses the broker's own crypto library (jose) so the signature decision
 %% matches what rabbit_auth_backend_oauth2 would compute -- a decision-parity
-%% claim analogous to the LDAP backend's, scoped to signature + exp/nbf/aud. It
-%% does NOT assert scope authorization; that stays an over-trust caveat for the
-%% customer docs, same as the LDAP dn_lookup_base and HTTP reachability checks.
+%% claim analogous to the LDAP backend's, scoped to signature + exp/nbf/aud.
+%% Scope authorization CAN now be checked via the optional `authz_check' block
+%% (delegated to aws_auth_validate_oauth_authz when the arity-4 scope API is
+%% available); see allowed_fields/0 for the full authz field set. Note: not all
+%% resource_server fields are overlaid yet -- a documented parity gap.
 %%
 %% A broker-side `client_credentials' grant (the broker fetching a token itself
 %% from a supplied token_endpoint + client_secret_arn) was considered and

--- a/src/aws_auth_validate_oauth_authz.erl
+++ b/src/aws_auth_validate_oauth_authz.erl
@@ -43,6 +43,11 @@
 %% The broker functions used (all verified pure -- no app-env / ETS / mnesia on
 %% this path; they read all config from the #resource_server{} record we build):
 %%   * rabbit_oauth2_resource_server:new_resource_server/1  -- record constructor
+%%   * rabbit_oauth2_schema:tokenize_additional_scopes_key/1 -- (when present) splits
+%%       the caller's `additional_scopes_key' the SAME way rabbitmq.conf does, so an
+%%       escaped `\.' stays a literal dot in a flat claim name (rabbitmq/rabbitmq-server
+%%       #16947). Absent on pre-fix series -> we pass the raw binary through and the
+%%       backend's own split_path/1 applies (see tokenize_additional_scopes_key/1).
 %%   * rabbit_auth_backend_oauth2:normalize_token_scope/2   -- alias / additional-
 %%       scopes-key / prefix-filter expansion (the IAM `scope_aliases' path)
 %%   * rabbit_auth_backend_oauth2:get_expanded_scopes/3     -- {vhost} placeholder
@@ -99,6 +104,7 @@
 -define(OAUTH2_MOD, rabbit_auth_backend_oauth2).
 -define(SCOPE_MOD, rabbit_oauth2_scope).
 -define(RS_MOD, rabbit_oauth2_resource_server).
+-define(SCHEMA_MOD, rabbit_oauth2_schema).
 
 %% Fixed reasons. NOTE on granularity vs R4: R4's fixed-category rule guards
 %% against leaking BROKER INFRASTRUCTURE or an SSRF target (hostnames, IPs, raw
@@ -312,7 +318,9 @@ evaluate(Params, Check, Claims) ->
     %% brokers that support it without a record-shape dependency.
     RS = RS0#resource_server{
         scope_aliases = maps:get(scope_aliases, Params, undefined),
-        additional_scopes_key = maps:get(additional_scopes_key, Params, undefined),
+        additional_scopes_key = tokenize_additional_scopes_key(
+            maps:get(additional_scopes_key, Params, undefined)
+        ),
         scope_prefix = maps:get(scope_prefix, Params, RS0#resource_server.scope_prefix)
     },
     Syntax = maps:get(scope_pattern_syntax, Params, wildcard),
@@ -371,6 +379,44 @@ decide(Scopes, Resource, PermAtom, Syntax) ->
 to_permission_atom(<<"configure">>) -> configure;
 to_permission_atom(<<"write">>) -> write;
 to_permission_atom(<<"read">>) -> read.
+
+%% Interpret the customer-supplied `additional_scopes_key' exactly as the broker's
+%% own config path does. The caller sends a plain string (the request contract is
+%% unchanged); its dots are ambiguous: an UNESCAPED `.' is a nesting separator,
+%% while an ESCAPED `\.' is a literal dot in a flat claim name -- the case that
+%% matters for STS/OIDC keys like `https://sts\.amazonaws\.com/.request_tags.scope'
+%% (rabbitmq/rabbitmq-server #16947).
+%%
+%% When the broker exposes rabbit_oauth2_schema:tokenize_additional_scopes_key/1
+%% (the post-#16947 series), we call it so the endpoint splits the key IDENTICALLY
+%% to `auth_oauth2.additional_scopes_key' in rabbitmq.conf: it returns [[binary()]]
+%% (a list of paths, each a list of segments) with `\.' kept literal, and the
+%% record's list-form `additional_scopes_key' clause consumes it WITHOUT re-splitting.
+%% Parity is preserved in both directions -- an unescaped key still tokenizes to the
+%% same nested path split_path/1 produced, so it still fails to resolve a flat dotted
+%% claim (the pinned #16947 behavior), and an escaped key now resolves.
+%%
+%% Fallback: on a pre-#16947 broker series the tokenizer is absent. We pass the raw
+%% binary through unchanged, so normalize_token_scope/2 takes its own binary clause
+%% (split_path/1) -- the endpoint behaves exactly as it did before this change. The
+%% feature stays available on old brokers; it simply lacks escaped-dot support there,
+%% matching what those brokers themselves can do.
+tokenize_additional_scopes_key(undefined) ->
+    undefined;
+tokenize_additional_scopes_key(Key) when is_binary(Key) ->
+    %% module_ready/1 (code:ensure_loaded) before function_exported/3: a bare
+    %% function_exported returns false for a beam that is on the path but not yet
+    %% loaded, which would make escaped-dot support depend on load order (the same
+    %% trap available/0 documents). ensure_loaded triggers the load if the beam is
+    %% present, so this reflects "is the tokenizer installed", not "has it been
+    %% called yet this boot".
+    case
+        module_ready(?SCHEMA_MOD) andalso
+            erlang:function_exported(?SCHEMA_MOD, tokenize_additional_scopes_key, 1)
+    of
+        true -> ?SCHEMA_MOD:tokenize_additional_scopes_key(Key);
+        false -> Key
+    end.
 
 -else.
 

--- a/test/aws_auth_validate_oauth_tests.erl
+++ b/test/aws_auth_validate_oauth_tests.erl
@@ -1016,6 +1016,66 @@ authz_iam_scope_alias_grants_access_test_() ->
         end)
     end}.
 
+%% -------- PARITY PIN: rabbitmq/rabbitmq-server discussion #16947 --------
+%%
+%% rabbit_auth_backend_oauth2 resolves additional_scopes_key via split_path/1:
+%%
+%%   split_path(Path) ->
+%%       binary:split(Path, <<".">>, [global, trim_all]).
+%%
+%% Flat claim keys containing dots -- typical for OIDC/STS-style URIs like
+%% <<"https://sts.amazonaws.com/tags">> -- are split into nested-map path
+%% segments (["https://sts", "amazonaws", "com/tags"]) and looked up as a
+%% deeply nested key in the flat claims map. The key is never found, so the
+%% scopes under it are never extracted.
+%%
+%% This test PINS the current (broken) behavior: the authz evaluator returns
+%% authz_unverified because it sees no effective scopes. When upstream fixes
+%% split_path (or adds a dedicated flat-key accessor for additional_scopes_key),
+%% this test MUST be revisited: the assertion should flip from authz_unverified
+%% to ok, and the change landed together with the broker dependency bump.
+%%
+%% This matches the project's parity stance: document upstream behavior, pin
+%% against drift, and surface regressions as test failures the moment the
+%% dependency changes.
+%% -------------------------------------------------------------------
+authz_dotted_additional_scopes_key_parity_pin_test_() ->
+    {setup, fun setup_httpc_mock/0, fun teardown_httpc_mock/1, fun(_) ->
+        maybe_skip_authz(fun() ->
+            #{jwk_pub := PubJwk, sign := Sign} = rsa_signer(<<"k1">>),
+            %% Token carries scopes under a dotted claim key (OIDC/STS-style URI).
+            %% split_path/1 will incorrectly split this on dots, breaking resolution.
+            Token = Sign(#{
+                <<"exp">> => future(),
+                <<"aud">> => <<"rabbitmq">>,
+                <<"https://sts.amazonaws.com/tags">> => [
+                    <<"rabbitmq.write:*/*">>, <<"rabbitmq.read:*/*">>
+                ]
+            }),
+            JwksBody = rabbit_json:encode(#{<<"keys">> => [PubJwk]}),
+            mock_httpc_response(200, JwksBody),
+            Body = (jwks_body())#{
+                <<"access_token">> => Token,
+                <<"resource_server_id">> => <<"rabbitmq">>,
+                <<"scope_prefix">> => <<"rabbitmq.">>,
+                %% Point additional_scopes_key at the dotted claim.
+                <<"additional_scopes_key">> => <<"https://sts.amazonaws.com/tags">>,
+                <<"authz_check">> => #{
+                    <<"resource">> => <<"my-queue">>,
+                    <<"permission">> => <<"write">>
+                }
+            },
+            Result = aws_auth_validate_oauth:validate(Body),
+            [
+                %% Current behavior: split_path splits the dotted key, lookup fails,
+                %% no scopes extracted -> authz_unverified. This will flip to ok once
+                %% upstream fixes the lookup.
+                ?_assertMatch({error, authz_unverified, _}, Result),
+                ?_assert(reason_contains(Result, "no scopes for this resource_server"))
+            ]
+        end)
+    end}.
+
 %% authz_check without an access_token is rejected in the pure phase.
 authz_check_without_token_rejected_test() ->
     Body = (jwks_body())#{

--- a/test/aws_auth_validate_oauth_tests.erl
+++ b/test/aws_auth_validate_oauth_tests.erl
@@ -1067,14 +1067,73 @@ authz_dotted_additional_scopes_key_parity_pin_test_() ->
             },
             Result = aws_auth_validate_oauth:validate(Body),
             [
-                %% Current behavior: split_path splits the dotted key, lookup fails,
-                %% no scopes extracted -> authz_unverified. This will flip to ok once
-                %% upstream fixes the lookup.
+                %% An UNESCAPED dotted key is split into a nested path
+                %% (["https://sts","amazonaws","com/tags"]) and never resolves the
+                %% flat claim -- authz_unverified. This is the intended behavior BOTH
+                %% before and after the #16947 fix: the fix does not make unescaped
+                %% dots resolve a flat key; it adds an ESCAPED form (\.) that does.
+                %% See authz_escaped_dotted_additional_scopes_key_test_ for the
+                %% escaped counterpart that resolves. If this ever flips to ok, an
+                %% upstream change altered unescaped-dot semantics -- revisit both.
                 ?_assertMatch({error, authz_unverified, _}, Result),
                 ?_assert(reason_contains(Result, "no scopes for this resource_server"))
             ]
         end)
     end}.
+
+%% Counterpart to the parity pin above: an ESCAPED dotted key (\.) IS resolvable
+%% via the #16947 fix. rabbit_oauth2_schema:tokenize_additional_scopes_key/1 keeps
+%% "\." literal, so "https://sts\.amazonaws\.com/tags" tokenizes to the single flat
+%% segment [<<"https://sts.amazonaws.com/tags">>] and the flat claim IS found.
+%%
+%% Gated twice: maybe_skip_authz (arity-4 scope API) AND the tokenizer's presence.
+%% On a pre-#16947 broker the endpoint falls back to passing the raw binary (old
+%% split_path behavior), so the escaped key would NOT resolve there -- skipping is
+%% correct, not a failure, exactly as the endpoint's fallback intends.
+authz_escaped_dotted_additional_scopes_key_test_() ->
+    {setup, fun setup_httpc_mock/0, fun teardown_httpc_mock/1, fun(_) ->
+        case tokenizer_available() of
+            false ->
+                [];
+            true ->
+                maybe_skip_authz(fun() ->
+                    #{jwk_pub := PubJwk, sign := Sign} = rsa_signer(<<"k1">>),
+                    %% Same flat dotted claim key as the parity pin, resolved this
+                    %% time by ESCAPING the dots in additional_scopes_key.
+                    Token = Sign(#{
+                        <<"exp">> => future(),
+                        <<"aud">> => <<"rabbitmq">>,
+                        <<"https://sts.amazonaws.com/tags">> => [
+                            <<"rabbitmq.write:*/*">>, <<"rabbitmq.read:*/*">>
+                        ]
+                    }),
+                    JwksBody = rabbit_json:encode(#{<<"keys">> => [PubJwk]}),
+                    mock_httpc_response(200, JwksBody),
+                    Body = (jwks_body())#{
+                        <<"access_token">> => Token,
+                        <<"resource_server_id">> => <<"rabbitmq">>,
+                        <<"scope_prefix">> => <<"rabbitmq.">>,
+                        %% Escaped dots (\.) keep the URI a single flat claim key.
+                        <<"additional_scopes_key">> =>
+                            <<"https://sts\\.amazonaws\\.com/tags">>,
+                        <<"authz_check">> => #{
+                            <<"resource">> => <<"my-queue">>,
+                            <<"permission">> => <<"write">>
+                        }
+                    },
+                    %% Flat claim found -> rabbitmq.write:*/* -> prefix strips to
+                    %% write:*/* -> grants write on /my-queue.
+                    [?_assertEqual(ok, aws_auth_validate_oauth:validate(Body))]
+                end)
+        end
+    end}.
+
+%% True when the broker exposes the post-#16947 tokenizer the endpoint relies on
+%% for escaped-dot support. Mirrors the runtime probe in
+%% aws_auth_validate_oauth_authz:tokenize_additional_scopes_key/1.
+tokenizer_available() ->
+    (code:ensure_loaded(rabbit_oauth2_schema) =/= {error, nofile}) andalso
+        erlang:function_exported(rabbit_oauth2_schema, tokenize_additional_scopes_key, 1).
 
 %% authz_check without an access_token is rejected in the pure phase.
 authz_check_without_token_rejected_test() ->


### PR DESCRIPTION
This PR lands after both #159, #160, and rabbitmq-server 16985 merge.

rabbitmq-server 16947 brought to light issues with how "." splitting is handled, and rabbitmq-server 16985 adds support for escaping dots (like `\.`). Since said PR introduces such a change to the upstream OAuth backend, there needs to be proper support on the validation endpoint to maintain parity.

## Background

The upstream OAuth backend resolves `additional_scopes_key` by splitting the key on `.` into a nested-map path (`rabbit_auth_backend_oauth2:split_path/1`). A flat claim key that itself contains dots — e.g. an STS/OIDC key like `https://sts.amazonaws.com/tags` — is therefore split into `["https://sts", "amazonaws", "com/tags"]` and never found. rabbitmq-server#16985 fixes this by:

- adding an escaped form `\.` (a literal dot in a segment) via `rabbit_oauth2_schema:tokenize_additional_scopes_key/1`, which produces a pre-tokenized `[[binary()]]` (list of paths, each a list of segments); and
- teaching the record's `additional_scopes_key` to accept that list form directly (a new `is_list/1` clause on `extract_token_value/4` / `extract_scopes_from_additional_scopes_key/2`), so a pre-split key is consumed without being re-split.

Because the validation endpoint replays the broker's real scope-resolution code, it must interpret `additional_scopes_key` identically — otherwise an escaped key that the live broker would resolve would be reported as `authz_unverified`, breaking parity in the safe-but-misleading direction.

## This PR adds said support by:

- **Delegating tokenization to the broker's own `rabbit_oauth2_schema:tokenize_additional_scopes_key/1`** rather than reimplementing the escape logic. This keeps the same "execute the broker's code, don't mirror it" guarantee the authz layer already relies on: the endpoint splits `additional_scopes_key` byte-for-byte the way `auth_oauth2.additional_scopes_key` does in `rabbitmq.conf`, so an escaped `\.` stays a literal dot in a flat claim name and an unescaped `.` remains a nesting separator.
- **Confining the change to `aws_auth_validate_oauth_authz:evaluate/3`** (a new `tokenize_additional_scopes_key/1` helper that the record overlay routes through). The pure parse phase in `aws_auth_validate_oauth` is untouched — it still validates `additional_scopes_key` as a plain binary and never depends on the OAuth backend being loaded.
- **Keeping the request contract unchanged.** Callers still send `additional_scopes_key` as a plain string; `allowed_fields/0`, the shape validation, and the response categories are all unchanged. This is purely additive — no new fields, no new statuses.
- **Falling back gracefully on pre-fix broker series.** When `rabbit_oauth2_schema:tokenize_additional_scopes_key/1` is not exported (a broker without rabbitmq-server#16985), the helper passes the raw binary through unchanged, so `normalize_token_scope/2` takes its existing binary/`split_path/1` clause and the endpoint behaves exactly as it does today. The feature stays available on old brokers; it simply lacks escaped-dot support there, matching what those brokers themselves can do. No change to the `HAVE_OAUTH2_RESOURCE_SERVER` compile gate or `available/0`.
- **Guarding against load order.** The helper calls `code:ensure_loaded/1` before `erlang:function_exported/3` (a bare `function_exported` returns `false` for a beam that is on the path but not yet loaded, which would make escaped-dot support depend on load order — the same trap `available/0` already documents).
- **Preserving parity in both directions, verified by tests:**
  - `authz_escaped_dotted_additional_scopes_key_test_` (new) — an escaped key `https://sts\.amazonaws\.com/tags` resolves the flat claim and grants (`ok`). Double-gated on `maybe_skip_authz/1` (the arity-4 scope API) **and** tokenizer presence, so it skips cleanly on a pre-fix broker rather than failing.
  - `authz_dotted_additional_scopes_key_parity_pin_test_` (from #160) — an unescaped key still splits and does not resolve a flat dotted claim (`authz_unverified`). Its comment is corrected to state that the fix adds an escaped form; it does **not** make unescaped dots resolve a flat key.

## Verification

- `gmake eunit t=aws_auth_validate_oauth_tests` — all tests pass; escaped→`ok` and unescaped→`authz_unverified` confirmed executing (not skipped) with the fixed OAuth backend on the code path.
- Manually exercised end-to-end through `PUT /api/aws/auth/validate/oauth` against a broker built with rabbitmq-server#16985: same token carrying a flat dotted claim, escaped `additional_scopes_key` → **204**, unescaped → **422 authz_unverified**.
- `erlfmt -c` clean.

## Notes for reviewers

- **Stacking / merge order:** this branch is cut on top of #160, so until #160 lands, a diff against `main` shows both the parity-pin commit (#160) and the escaped-dot commit. Land order is #159 → #160 → (rabbitmq-server#16985 upstream) → this PR.
- **Draft until the upstream dep lands.** The tokenizer this PR calls (`rabbit_oauth2_schema:tokenize_additional_scopes_key/1`) only exists once rabbitmq-server#16985 merges. Its signature/return shape should be re-confirmed before this PR leaves draft, since the upstream implementation may still change.
- **CI coverage caveat:** the escaped-dot test only *executes* where the tokenizer is present; against a pre-#16985 OAuth backend it skips (by design). Green CI proves the escaped path only when CI builds against a broker series that includes the fix.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
