### PR TITLE
fix(ldap): Align pre-connect SSRF check with resolve-all semantics

### DIFF
--- a/src/aws_auth_validate_ldap.erl
+++ b/src/aws_auth_validate_ldap.erl
@@ -51,6 +51,7 @@
 %% peer_allowed/1 is the post-connect SSRF re-check on a peername result;
 %% is_denied_ip/1 is the SSRF address classifier for v4 and v6 (delegating to the
 %% shared aws_auth_validate_net:classify_ip/2 with LDAP's denylist);
+%% all_addresses_allowed/1 is the pure resolved-address SSRF check (no inet);
 %% search_time_limit_seconds/0 is the post-bind search timeLimit. All are
 %% otherwise internal.
 -export([
@@ -59,6 +60,7 @@
     is_allowed_server/1,
     peer_allowed/1,
     is_denied_ip/1,
+    all_addresses_allowed/1,
     parse_port/2,
     search_time_limit_seconds/0
 ]).
@@ -538,19 +540,25 @@ parse_query_map([{Name, Value} | Rest], Acc, Parsed) ->
 
 is_nonempty_binary(B) -> is_binary(B) andalso byte_size(B) > 0.
 
-%% Server address validation: resolve the hostname and reject addresses in
-%% private, loopback, link-local, or metadata IP ranges. This prevents SSRF
-%% via the validation endpoint while still allowing legitimate LDAP servers.
+%% Server address validation: resolve the hostname to ALL addresses and reject
+%% if ANY resolves to a private, loopback, link-local, or metadata IP range.
+%% This prevents SSRF via the validation endpoint while still allowing
+%% legitimate LDAP servers.
 %%
 %% This is the FIRST of two SSRF checks (defence in depth). It resolves Server
-%% and rejects a blocked IP before any connection is attempted, so a malformed
-%% or obviously-internal target never opens a socket. On its own it is subject
-%% to a DNS-rebinding TOCTOU -- eldap:open/2 re-resolves the hostname, so the
-%% peer it connects to could differ from the IP vetted here. That window is
-%% closed by the SECOND check, verify_connected_peer/1, which re-validates the
-%% actual connected socket's peer (see do_ldap_bind/1). We keep this pre-connect
-%% check too: it rejects bad input cheaply (no socket, clearer input_invalid
-%% category) and avoids dialing out for the common case.
+%% to ALL A and AAAA records (via aws_auth_validate_net:resolve_all/1 -- the
+%% same resolve-all semantics used by the http/oauth backends) and rejects the
+%% whole server if ANY resolved address is blocked. A single benign A record
+%% can no longer mask a denied address behind the same hostname. Literal IP
+%% strings are classified directly without DNS.
+%%
+%% On its own this pre-connect check is subject to a DNS-rebinding TOCTOU --
+%% eldap:open/2 re-resolves the hostname, so the peer it connects to could
+%% differ from the IPs vetted here. That window is closed by the SECOND check,
+%% verify_connected_peer/1, which re-validates the actual connected socket's
+%% peer (see do_ldap_bind/1). We keep this pre-connect check too: it rejects
+%% bad input cheaply (no socket, clearer input_invalid category) and avoids
+%% dialing out for the common case.
 %%
 %% The test-only auth_validation_allow_private_networks flag relaxes ONLY
 %% loopback (see is_denied_ip/1), not the whole denylist -- it must not grant the
@@ -563,16 +571,28 @@ is_allowed_server(Server) ->
     check_server_ip(Server).
 
 check_server_ip(Server) ->
-    case inet:getaddr(Server, inet) of
+    case inet:parse_address(Server) of
         {ok, IP} ->
+            %% Server is a literal IP string -- classify directly, no DNS.
             not is_denied_ip(IP);
         {error, _} ->
-            %% Also try IPv6
-            case inet:getaddr(Server, inet6) of
-                {ok, IP6} -> not is_denied_ip(IP6);
-                {error, _} -> false
-            end
+            %% Server is a hostname -- resolve ALL A+AAAA records and deny if
+            %% ANY resolved address is in a blocked range (same resolve-all
+            %% semantics as aws_auth_validate_net:resolve_and_pin/2).
+            Addrs = aws_auth_validate_net:resolve_all(Server),
+            all_addresses_allowed(Addrs)
     end.
+
+%% Pure helper: given a list of already-resolved IP tuples, return true only if
+%% ALL are allowed (none denied) AND the list is non-empty. An empty list (DNS
+%% resolution failure) fails closed (returns false). This function does not call
+%% inet -- it operates on already-resolved addresses and is testable without
+%% mocking the DNS layer.
+-spec all_addresses_allowed([tuple()]) -> boolean().
+all_addresses_allowed([]) ->
+    false;
+all_addresses_allowed(Addrs) when is_list(Addrs) ->
+    not lists:any(fun is_denied_ip/1, Addrs).
 
 %% Classify a v4 or v6 address against LDAP's range policy via the shared
 %% aws_auth_validate_net:classify_ip/2 (which dispatches on tuple shape), passing

--- a/src/aws_auth_validate_net.erl
+++ b/src/aws_auth_validate_net.erl
@@ -3,12 +3,13 @@
 %% vim:ft=erlang:
 %% -*- mode: erlang; -*-
 
-%% Shared SSRF / DNS-rebinding network guard for the http and oauth validation
-%% backends. The ldap backend shares the address classifier (classify_ip/2) and
-%% URL parser (parse_url/2) here, but passes its OWN stricter denylist -- it
-%% denies ALL private/RFC1918/CGNAT ranges, not just broker infra -- and adds a
-%% post-connect peer re-check for eldap's re-resolve. See aws_auth_validate_ldap's
-%% is_denied_ip/1.
+%% Shared SSRF / DNS-rebinding network guard for the http, oauth, and ldap
+%% validation backends. The ldap backend shares the address classifier
+%% (classify_ip/2), URL parser (parse_url/2), and resolve_all/1 (DNS
+%% resolution to ALL A+AAAA addresses) here, but passes its OWN stricter
+%% denylist -- it denies ALL private/RFC1918/CGNAT ranges, not just broker
+%% infra -- and adds a post-connect peer re-check for eldap's re-resolve. See
+%% aws_auth_validate_ldap's is_denied_ip/1.
 %%
 %% The validator issues outbound requests to customer-supplied URLs from the
 %% broker's network position -- a textbook SSRF / confused-deputy surface.
@@ -40,6 +41,7 @@
     classify_address/2,
     classify_ip/2,
     embedded_v4/1,
+    resolve_all/1,
     resolve_and_pin/2,
     pin_url/2,
     parse_url/2,
@@ -282,6 +284,9 @@ resolve_hostname_and_pin(Url, Host, Policy) ->
     end.
 
 %% Resolve a hostname to all IPv4 + IPv6 addresses (best-effort per family).
+%% Used by resolve_and_pin/2 (http/oauth) and by the LDAP backend's pre-connect
+%% SSRF check (check_server_ip/1) -- both must resolve ALL addresses so a single
+%% benign A record cannot mask a denied one behind the same hostname.
 resolve_all(Host) ->
     V4 =
         case inet:getaddrs(Host, inet) of

--- a/test/aws_auth_validate_tests.erl
+++ b/test/aws_auth_validate_tests.erl
@@ -383,6 +383,75 @@ server_flag_relaxes_loopback_only_test_() ->
         ]}.
 
 %%--------------------------------------------------------------------
+%% all_addresses_allowed/1 -- pure resolved-address SSRF check
+%%--------------------------------------------------------------------
+%% Tests the pure function that takes already-resolved IP tuples and returns
+%% whether all are allowed. No inet mocking needed -- operates on tuples only.
+
+%% An empty list (resolution failure) must fail closed.
+all_addresses_allowed_empty_denies_test() ->
+    ?assertEqual(false, aws_auth_validate_ldap:all_addresses_allowed([])).
+
+%% A list containing only allowed (public) addresses passes.
+all_addresses_allowed_all_public_test() ->
+    ?assertEqual(
+        true,
+        aws_auth_validate_ldap:all_addresses_allowed([{8, 8, 8, 8}, {1, 1, 1, 1}])
+    ).
+
+%% A mixed list (one allowed + one denied) must deny (any-denied = deny).
+all_addresses_allowed_mixed_denies_test() ->
+    ?assertEqual(
+        false,
+        aws_auth_validate_ldap:all_addresses_allowed([{8, 8, 8, 8}, {10, 0, 0, 1}])
+    ).
+
+%% A single denied v4 literal must deny.
+all_addresses_allowed_single_denied_v4_test() ->
+    ?assertEqual(false, aws_auth_validate_ldap:all_addresses_allowed([{127, 0, 0, 1}])).
+
+%% A single allowed v4 literal must allow.
+all_addresses_allowed_single_allowed_v4_test() ->
+    ?assertEqual(true, aws_auth_validate_ldap:all_addresses_allowed([{8, 8, 4, 4}])).
+
+%% A v6-embedded-v4 denied address (::ffff:127.0.0.1) must deny -- the shared
+%% classify_ip/2 unwraps v4-mapped v6 before checking.
+all_addresses_allowed_v6_embedded_v4_denies_test() ->
+    ?assertEqual(
+        false,
+        aws_auth_validate_ldap:all_addresses_allowed([{0, 0, 0, 0, 0, 16#ffff, 16#7f00, 1}])
+    ).
+
+%% A public v6 address alone is allowed.
+all_addresses_allowed_single_public_v6_test() ->
+    ?assertEqual(
+        true,
+        aws_auth_validate_ldap:all_addresses_allowed([{16#2606, 16#4700, 0, 0, 0, 0, 0, 1}])
+    ).
+
+%% The loopback-only relaxation flag applies: under the flag, a list of only
+%% loopback addresses is allowed.
+all_addresses_allowed_loopback_flag_test_() ->
+    {setup,
+        fun() ->
+            application:set_env(aws, auth_validation_allow_private_networks, true)
+        end,
+        fun(_) ->
+            application:unset_env(aws, auth_validation_allow_private_networks)
+        end,
+        [
+            ?_assertEqual(
+                true,
+                aws_auth_validate_ldap:all_addresses_allowed([{127, 0, 0, 1}])
+            ),
+            %% IMDS stays denied even with the flag.
+            ?_assertEqual(
+                false,
+                aws_auth_validate_ldap:all_addresses_allowed([{169, 254, 169, 254}])
+            )
+        ]}.
+
+%%--------------------------------------------------------------------
 %% Port default (broker parity)
 %%--------------------------------------------------------------------
 


### PR DESCRIPTION
  - Export resolve_all/1 from aws_auth_validate_net so the LDAP backend can share the same DNS resolution as http/oauth
  - Rewrite check_server_ip/1 to resolve ALL A+AAAA records via resolve_all/1 for hostname inputs, denying if ANY resolved address is blocked (previously only resolved ONE address via inet:getaddr)
  - Literal IP strings are detected via inet:parse_address/1 and classified directly without DNS (preserving existing behavior)
  - Extract all_addresses_allowed/1 as a pure, inet-free helper that takes a list of resolved IP tuples and returns boolean -- testable without mocking
  - Add 8 eunit tests covering the pure function: empty list (fail closed), all-allowed, mixed (any-denied = deny), v6-embedded-v4, single denied/allowed, and loopback-flag relaxation semantics
  - Update module header comments to reflect LDAP's resolve_all usage

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
