### PR TITLE
TLS Validation Enhancements

### DIFF
--- a/src/aws_auth_validate_tls.erl
+++ b/src/aws_auth_validate_tls.erl
@@ -501,6 +501,20 @@ find_non_cert_entry([{Type, _Der, _Enc} | _Rest]) ->
 
 %% Returns true when the PEM type tag identifies a private key -- either an
 %% atom from the traditional set or the tuple tag used by OpenSSH keys.
+%%
+%% The {no_asn1, _} clause is reachable at RUNTIME even though dialyzer claims
+%% otherwise: public_key's exported pem_entry() type enumerates only the ASN.1
+%% record tags, but pubkey_pem emits {no_asn1, new_openssh} for an OpenSSH
+%% private key block. Verified on this OTP:
+%%
+%%   public_key:pem_decode(<<"-----BEGIN OPENSSH PRIVATE KEY-----"...>>)
+%%   => [{{no_asn1, new_openssh}, <<...>>, not_encrypted}]
+%%
+%% So the incomplete upstream spec, not this clause, is the inaccuracy. The
+%% clause is what keeps an OpenSSH key from being reported as a generic
+%% unexpected entry instead of key material, so it must not be removed. The
+%% nowarn is scoped to this function only.
+-dialyzer({nowarn_function, is_known_key_type/1}).
 is_known_key_type(Type) when is_atom(Type) ->
     lists:member(Type, ?PRIVATE_KEY_TYPES);
 is_known_key_type({no_asn1, _}) ->

--- a/src/aws_auth_validate_tls.erl
+++ b/src/aws_auth_validate_tls.erl
@@ -12,23 +12,32 @@
 %%
 %% It validates the material only, not a live handshake. The other backends
 %% probe an outbound auth server; here the config is an inbound listener, so
-%% there is nothing for the broker to connect to (and no client keystore to
-%% connect with). Checks:
+%% there is nothing for the broker to connect to. Checks:
 %%   1. the cacertfile ARN resolves,
 %%   2. the resolved PEM holds at least one well-formed CA certificate,
 %%   3. none of those certificates is expired or not yet valid,
 %%   4. verify / fail_if_no_peer_cert / depth / versions are well-shaped.
 %%
-%% A pass means the material is usable, not that mTLS as a whole works: it does
-%% not cover client-cert chaining, common-name-to-user mapping, network
-%% reachability, or whether the broker is actually running this config.
+%% Optionally, when `client_cert' and `cert_login' are supplied, the backend
+%% also validates:
+%%   5. the client certificate chains to the supplied CA bundle (Layer 1),
+%%   6. a username can be extracted from the leaf cert using the configured
+%%      cert_login strategy -- DN / CN / SAN (Layer 2),
+%%   7. the extracted username resolves to an internal broker user (Layer 3).
+%%
+%% A pass means the material is usable and (when layers 5-7 are exercised) the
+%% cert-login pipeline produces a resolvable user, not that the broker is
+%% actually running this config.
 %%
 %% Result categories (shared with the other backends):
 %%   * input_invalid (400) -- bad target/ssl_options, missing cacertfile_arn,
 %%     ARN resolve failure, or a PEM with no parseable CA certificate.
 %%   * tls_failed (400) -- a CA certificate is expired or not yet valid.
+%%   * auth_failed (422) -- client certificate chain validation failed, no
+%%     username could be extracted, or the extracted user does not exist.
 %%   * config_conflict (422) -- a cacertfile_arn is given but no
-%%     aws.arns.assume_role_arn is configured.
+%%     aws.arns.assume_role_arn is configured; or cert_login references
+%%     unavailable broker modules.
 -module(aws_auth_validate_tls).
 
 -behaviour(aws_auth_validate_backend).
@@ -36,14 +45,18 @@
 -export([method_name/0, validate/1, allowed_fields/0]).
 
 -ifdef(TEST).
-%% Exposed for the unit tests: the pure input parser and the certificate-validity
+%% Exposed for the unit tests: the pure input parser, the certificate-validity
 %% helpers (classify_validity/3 lets the expired/not-yet-valid branches be tested
-%% without generating an actually-expired cert).
+%% without generating an actually-expired cert), and the client-cert-login layers.
 -export([
     parse_input/1,
     check_cert_validity/1,
     cert_validity_seconds/1,
-    classify_validity/3
+    classify_validity/3,
+    validate_chain/3,
+    extract_username/2,
+    resolve_user/1,
+    sanitize_username/1
 ]).
 -endif.
 
@@ -94,6 +107,71 @@
     "set aws.arns.assume_role_arn"
 >>).
 
+%% client_cert / cert_login reason strings (Layer 1-3 validation).
+-define(REASON_BAD_CLIENT_CERT,
+    <<"client_cert must be a non-empty PEM-encoded certificate chain">>
+).
+-define(REASON_CLIENT_CERT_PRIVATE_KEY,
+    <<"client_cert must not contain private key material; send only certificate entries">>
+).
+-define(REASON_BAD_CERT_LOGIN, <<"cert_login must be an object">>).
+-define(REASON_BAD_CERT_LOGIN_FROM,
+    <<"cert_login.from must be distinguished_name, common_name, or subject_alternative_name">>
+).
+-define(REASON_SAN_TYPE_REQUIRES_SAN_FROM,
+    <<"cert_login.san_type is only valid when from is subject_alternative_name">>
+).
+-define(REASON_SAN_INDEX_REQUIRES_SAN_FROM,
+    <<"cert_login.san_index is only valid when from is subject_alternative_name">>
+).
+-define(REASON_BAD_SAN_TYPE,
+    <<"cert_login.san_type must be dns, ip, email, uri, or other_name">>
+).
+-define(REASON_BAD_SAN_INDEX,
+    <<"cert_login.san_index must be a non-negative integer">>
+).
+-define(REASON_UNKNOWN_CERT_LOGIN_KEY,
+    <<"cert_login contains an unknown key; allowed keys are from, san_type, san_index">>
+).
+-define(REASON_CERT_LOGIN_REQUIRES_CLIENT_CERT,
+    <<"cert_login requires client_cert to be present">>
+).
+-define(REASON_CERT_LOGIN_REQUIRES_VERIFY_PEER,
+    <<"cert-based login requires ssl_options.verify = verify_peer">>
+).
+-define(REASON_CHAIN_FAILED,
+    <<"the client certificate does not chain to the supplied CA bundle">>
+).
+-define(REASON_CHAIN_EXPIRED,
+    <<"the client certificate chain contains an expired or not-yet-valid certificate">>
+).
+-define(REASON_CHAIN_MALFORMED,
+    <<"a certificate in the client chain could not be parsed">>
+).
+-define(REASON_EXTRACT_FAILED,
+    <<"no username could be extracted from the client certificate with the supplied cert_login settings">>
+).
+-define(REASON_USER_NOT_FOUND(Name),
+    iolist_to_binary([
+        <<"no internal user named ">>, sanitize_username(Name), <<" exists">>
+    ])
+).
+-define(REASON_USER_LOOKUP_UNAVAILABLE,
+    <<"user-resolution check unavailable on this broker series">>
+).
+
+-define(INTERNAL_BACKEND, rabbit_auth_backend_internal).
+-define(MAX_USERNAME_LEN, 256).
+
+%% Private key entry types that must be rejected from client_cert input (R6).
+-define(PRIVATE_KEY_TYPES, [
+    'RSAPrivateKey',
+    'DSAPrivateKey',
+    'ECPrivateKey',
+    'PrivateKeyInfo',
+    'EncryptedPrivateKeyInfo'
+]).
+
 %% Surface passed to the shared aws_auth_validate_ssl helpers: the ARN-bearing
 %% keys, the allowed-key set, and this backend's reason strings. client_cert is
 %% false (no client pair) and sni_key is unused here; both are required by the
@@ -125,7 +203,7 @@ method_name() ->
     <<"tls">>.
 
 allowed_fields() ->
-    [<<"target">>, <<"ssl_options">>].
+    [<<"target">>, <<"ssl_options">>, <<"client_cert">>, <<"cert_login">>].
 
 -spec validate(map()) -> aws_auth_validate_backend:result().
 validate(Body) when is_map(Body) ->
@@ -149,7 +227,10 @@ parse_input(Body) ->
     Steps = [
         fun parse_target/2,
         fun parse_ssl_options/2,
-        fun require_cacert/2
+        fun require_cacert/2,
+        fun parse_client_cert/2,
+        fun parse_cert_login/2,
+        fun cross_field_checks/2
     ],
     run_steps(Steps, Body, #{}).
 
@@ -193,7 +274,9 @@ require_cacert(_Body, #{ssl_options := Map} = Acc) ->
 %%--------------------------------------------------------------------
 
 %% Resolve the cacertfile ARN, then decode and check the CA bundle. The only
-%% network call is the ARN fetch; nothing connects to a listener.
+%% network call is the ARN fetch; nothing connects to a listener. When client
+%% certificate layers are present, continue into chain/extract/resolve after
+%% the CA bundle passes.
 do_tls_validate(#{ssl_options := Map} = Params) ->
     %% A request that referenced no ARN carries the `none' sentinel, which
     %% resolve_arn/2 refuses. cacertfile_arn is required, so a valid request
@@ -204,7 +287,10 @@ do_tls_validate(#{ssl_options := Map} = Params) ->
         {error, _} ->
             {error, input_invalid, ?REASON_ARN_RESOLVE};
         {ok, Pem} ->
-            decode_and_check(Pem)
+            case decode_and_check(Pem) of
+                {error, _, _} = Err -> Err;
+                ok -> maybe_chain_validate(Params, Pem)
+            end
     end.
 
 %% Decode the CA PEM and check each certificate. The decode is wrapped because
@@ -306,3 +392,352 @@ ymd_to_seconds(Year, Rest) ->
 
 to_str(T) when is_binary(T) -> binary_to_list(T);
 to_str(T) when is_list(T) -> T.
+
+%%--------------------------------------------------------------------
+%% Input parsing: client_cert (optional PEM chain)
+%%--------------------------------------------------------------------
+
+%% client_cert is optional; when present it must be a non-empty binary holding
+%% only certificate PEM entries (no private key material -- R6).
+parse_client_cert(Body, Acc) ->
+    case maps:get(<<"client_cert">>, Body, undefined) of
+        undefined ->
+            {ok, Acc};
+        Pem when is_binary(Pem), byte_size(Pem) > 0 ->
+            decode_client_cert_pem(Pem, Acc);
+        _ ->
+            {error, input_invalid, ?REASON_BAD_CLIENT_CERT}
+    end.
+
+decode_client_cert_pem(Pem, Acc) ->
+    Entries =
+        try
+            public_key:pem_decode(Pem)
+        catch
+            _:_ -> error
+        end,
+    case Entries of
+        error ->
+            {error, input_invalid, ?REASON_BAD_CLIENT_CERT};
+        Decoded when is_list(Decoded) ->
+            classify_pem_entries(Decoded, Acc)
+    end.
+
+%% Split the decoded PEM entries: reject if any private key type is present,
+%% collect Certificate DERs. An empty cert list after filtering is an error.
+classify_pem_entries(Entries, Acc) ->
+    HasKey = lists:any(
+        fun({Type, _Der, _Enc}) -> lists:member(Type, ?PRIVATE_KEY_TYPES) end,
+        Entries
+    ),
+    case HasKey of
+        true ->
+            {error, input_invalid, ?REASON_CLIENT_CERT_PRIVATE_KEY};
+        false ->
+            Ders = [Der || {'Certificate', Der, not_encrypted} <- Entries],
+            case Ders of
+                [] -> {error, input_invalid, ?REASON_BAD_CLIENT_CERT};
+                _ -> {ok, Acc#{client_cert_ders => Ders}}
+            end
+    end.
+
+%%--------------------------------------------------------------------
+%% Input parsing: cert_login (optional username-extraction config)
+%%--------------------------------------------------------------------
+
+%% cert_login is optional; when present it must be a map with `from' required
+%% plus optional `san_type' and `san_index' (only valid in SAN mode).
+parse_cert_login(Body, Acc) ->
+    case maps:get(<<"cert_login">>, Body, undefined) of
+        undefined ->
+            {ok, Acc};
+        Map when is_map(Map) ->
+            validate_cert_login(Map, Acc);
+        _ ->
+            {error, input_invalid, ?REASON_BAD_CERT_LOGIN}
+    end.
+
+validate_cert_login(Map, Acc) ->
+    AllowedKeys = [<<"from">>, <<"san_type">>, <<"san_index">>],
+    case [K || K <- maps:keys(Map), not lists:member(K, AllowedKeys)] of
+        [_ | _] ->
+            {error, input_invalid, ?REASON_UNKNOWN_CERT_LOGIN_KEY};
+        [] ->
+            parse_cert_login_from(Map, Acc)
+    end.
+
+parse_cert_login_from(Map, Acc) ->
+    case maps:get(<<"from">>, Map, undefined) of
+        <<"distinguished_name">> ->
+            check_no_san_fields(Map, Acc, distinguished_name);
+        <<"common_name">> ->
+            check_no_san_fields(Map, Acc, common_name);
+        <<"subject_alternative_name">> ->
+            parse_san_fields(Map, Acc);
+        <<"subject_alt_name">> ->
+            parse_san_fields(Map, Acc);
+        _ ->
+            {error, input_invalid, ?REASON_BAD_CERT_LOGIN_FROM}
+    end.
+
+%% For non-SAN modes, san_type and san_index are not valid.
+check_no_san_fields(Map, Acc, From) ->
+    case maps:is_key(<<"san_type">>, Map) of
+        true ->
+            {error, input_invalid, ?REASON_SAN_TYPE_REQUIRES_SAN_FROM};
+        false ->
+            case maps:is_key(<<"san_index">>, Map) of
+                true ->
+                    {error, input_invalid, ?REASON_SAN_INDEX_REQUIRES_SAN_FROM};
+                false ->
+                    {ok, Acc#{cert_login => #{from => From}}}
+            end
+    end.
+
+%% In SAN mode, validate san_type (required) and san_index (optional, default 0).
+parse_san_fields(Map, Acc) ->
+    case maps:get(<<"san_type">>, Map, undefined) of
+        undefined ->
+            {error, input_invalid, ?REASON_BAD_SAN_TYPE};
+        TypeBin ->
+            case san_type_atom(TypeBin) of
+                error ->
+                    {error, input_invalid, ?REASON_BAD_SAN_TYPE};
+                {ok, TypeAtom} ->
+                    parse_san_index(Map, Acc, TypeAtom)
+            end
+    end.
+
+parse_san_index(Map, Acc, TypeAtom) ->
+    case maps:get(<<"san_index">>, Map, 0) of
+        I when is_integer(I), I >= 0 ->
+            {ok, Acc#{
+                cert_login => #{
+                    from => subject_alternative_name,
+                    san_type => TypeAtom,
+                    san_index => I
+                }
+            }};
+        _ ->
+            {error, input_invalid, ?REASON_BAD_SAN_INDEX}
+    end.
+
+san_type_atom(<<"dns">>) -> {ok, dns};
+san_type_atom(<<"ip">>) -> {ok, ip};
+san_type_atom(<<"email">>) -> {ok, email};
+san_type_atom(<<"uri">>) -> {ok, uri};
+san_type_atom(<<"other_name">>) -> {ok, other_name};
+san_type_atom(_) -> error.
+
+%%--------------------------------------------------------------------
+%% Input parsing: cross-field checks
+%%--------------------------------------------------------------------
+
+%% cert_login without client_cert is a conflict; cert_login without verify_peer
+%% is unsafe (the chain would not be validated by the broker).
+cross_field_checks(_Body, Acc) ->
+    case maps:is_key(cert_login, Acc) of
+        false ->
+            {ok, Acc};
+        true ->
+            case maps:is_key(client_cert_ders, Acc) of
+                false ->
+                    {error, config_conflict, ?REASON_CERT_LOGIN_REQUIRES_CLIENT_CERT};
+                true ->
+                    check_verify_for_cert_login(Acc)
+            end
+    end.
+
+check_verify_for_cert_login(#{ssl_options := SslMap} = Acc) ->
+    case maps:get(<<"verify">>, SslMap, undefined) of
+        <<"verify_peer">> -> {ok, Acc};
+        _ -> {error, config_conflict, ?REASON_CERT_LOGIN_REQUIRES_VERIFY_PEER}
+    end.
+
+%%--------------------------------------------------------------------
+%% Layer 1: client certificate chain validation
+%%--------------------------------------------------------------------
+
+%% When client_cert_ders is present, validate the chain against the CA bundle.
+%% Otherwise the existing CA-only validation already passed and we are done
+%% (unless cert_login is present, which cross_field_checks already guarantees
+%% cannot happen without client_cert_ders).
+maybe_chain_validate(#{client_cert_ders := ClientDers} = Params, CaPem) ->
+    CaDers = aws_auth_validate_ssl:decode_pem_cacerts(CaPem),
+    Depth = maps:get(<<"depth">>, maps:get(ssl_options, Params, #{}), undefined),
+    case validate_chain(ClientDers, CaDers, Depth) of
+        ok -> maybe_extract_username(Params);
+        {error, _, _} = Err -> Err
+    end;
+maybe_chain_validate(_Params, _CaPem) ->
+    %% No client_cert: existing CA-only validation already passed.
+    ok.
+
+%% Validate the client certificate chain against the CA trust anchors using
+%% public_key:pkix_path_validation/3. ClientDers is leaf-first; CaDers is the
+%% trust anchor pool. Depth caps intermediate chain length when set.
+-spec validate_chain([binary()], [binary()] | skip, integer() | undefined) ->
+    ok | {error, auth_failed | input_invalid, binary()}.
+validate_chain(_ClientDers, skip, _Depth) ->
+    %% No CA certs decoded (should not reach here -- decode_and_check catches it).
+    {error, auth_failed, ?REASON_CHAIN_FAILED};
+validate_chain(ClientDers, CaDers, Depth) ->
+    try
+        Opts =
+            case Depth of
+                undefined -> [];
+                N when is_integer(N), N >= 0 -> [{max_path_length, N}]
+            end,
+        %% pkix_path_validation wants: TrustAnchor (DER), Chain (EE toward root
+        %% EXCLUDING the anchor), Options. Find which CA in the bundle issued the
+        %% topmost cert in the client chain.
+        TopCert = lists:last(ClientDers),
+        case find_trust_anchor(TopCert, CaDers) of
+            {ok, AnchorDer} ->
+                case public_key:pkix_path_validation(AnchorDer, ClientDers, Opts) of
+                    {ok, _} ->
+                        ok;
+                    {error, {bad_cert, cert_expired}} ->
+                        {error, auth_failed, ?REASON_CHAIN_EXPIRED};
+                    {error, {bad_cert, {cert_expired, _}}} ->
+                        {error, auth_failed, ?REASON_CHAIN_EXPIRED};
+                    {error, {bad_cert, _}} ->
+                        {error, auth_failed, ?REASON_CHAIN_FAILED}
+                end;
+            not_found ->
+                {error, auth_failed, ?REASON_CHAIN_FAILED}
+        end
+    catch
+        _:_ -> {error, input_invalid, ?REASON_CHAIN_MALFORMED}
+    end.
+
+%% Find the trust anchor in CaDers whose subject matches the issuer of TopCertDer.
+find_trust_anchor(TopCertDer, CaDers) ->
+    TopOtp = public_key:pkix_decode_cert(TopCertDer, otp),
+    Issuer = TopOtp#'OTPCertificate'.tbsCertificate#'OTPTBSCertificate'.issuer,
+    find_by_subject(Issuer, CaDers).
+
+find_by_subject(_Issuer, []) ->
+    not_found;
+find_by_subject(Issuer, [CaDer | Rest]) ->
+    CaOtp = public_key:pkix_decode_cert(CaDer, otp),
+    Subject = CaOtp#'OTPCertificate'.tbsCertificate#'OTPTBSCertificate'.subject,
+    case public_key:pkix_normalize_name(Issuer) =:= public_key:pkix_normalize_name(Subject) of
+        true -> {ok, CaDer};
+        false -> find_by_subject(Issuer, Rest)
+    end.
+
+%%--------------------------------------------------------------------
+%% Layer 2: username extraction from the leaf certificate
+%%--------------------------------------------------------------------
+
+%% When cert_login is present, extract the username from the leaf cert.
+maybe_extract_username(#{cert_login := Login, client_cert_ders := [LeafDer | _]}) ->
+    case extract_username(LeafDer, Login) of
+        {ok, Username} -> resolve_user(Username);
+        {error, _, _} = Err -> Err
+    end;
+maybe_extract_username(_Params) ->
+    %% No cert_login: chain-check-only case (mTLS encryption validation).
+    ok.
+
+%% COUPLING NOTE (see the parity-scope discussion in the module header): this
+%% function mirrors rabbit_ssl:peer_cert_auth_name/2's three-clause dispatch
+%% (distinguished_name | common_name | subject_alternative_name). The extraction
+%% itself delegates to rabbit_cert_info (broker code) so the field-extraction
+%% logic cannot drift; only this dispatch sequencing and the SAN-type/index
+%% selection can. Keep in sync with peer_cert_auth_name/2 if a new mode is added
+%% upstream.
+-spec extract_username(binary(), map()) ->
+    {ok, binary()} | {error, auth_failed, binary()}.
+extract_username(LeafDer, #{from := distinguished_name}) ->
+    %% Stricter than upstream (which returns an empty binary as a valid name):
+    %% an empty subject is treated as extraction failure. This is deliberate for
+    %% a validation endpoint -- fail-fast rather than silently accepting a name
+    %% that will be rejected later by the auth mechanism.
+    Name = iolist_to_binary(rabbit_cert_info:subject(LeafDer)),
+    case Name of
+        <<>> -> {error, auth_failed, ?REASON_EXTRACT_FAILED};
+        _ -> {ok, Name}
+    end;
+extract_username(LeafDer, #{from := common_name}) ->
+    case rabbit_cert_info:subject_items(LeafDer, ?'id-at-commonName') of
+        not_found ->
+            {error, auth_failed, ?REASON_EXTRACT_FAILED};
+        CNs ->
+            {ok, list_to_binary(string:join(CNs, ","))}
+    end;
+extract_username(LeafDer, #{from := subject_alternative_name, san_type := Type, san_index := Index}) ->
+    OtpType = otp_san_type(Type),
+    SANs = rabbit_cert_info:subject_alternative_names(LeafDer),
+    Filtered = [V || {T, V} <- SANs, T =:= OtpType],
+    %% Index is 0-based in config, 1-based for lists:nth.
+    case length(Filtered) > Index of
+        true ->
+            Raw = lists:nth(Index + 1, Filtered),
+            Value = maybe_sanitize_other_name(OtpType, Raw),
+            {ok, iolist_to_binary([Value])};
+        false ->
+            {error, auth_failed, ?REASON_EXTRACT_FAILED}
+    end.
+
+%% Maps the cert_login san_type atoms to the OTP SAN type tags used by
+%% rabbit_cert_info:subject_alternative_names/1.
+otp_san_type(dns) -> dNSName;
+otp_san_type(ip) -> iPAddress;
+otp_san_type(email) -> rfc822Name;
+otp_san_type(uri) -> uniformResourceIdentifier;
+otp_san_type(other_name) -> otherName.
+
+%% otherName SANs are represented by OTP as {'AnotherName', OID, Value} -- a
+%% 3-tuple. rabbit_cert_info:sanitize_other_name/1 expects a binary, so coerce
+%% via rabbit_data_coercion:to_binary/1 to match the upstream rabbit_ssl
+%% dispatch (rabbit_ssl.erl line ~180).
+maybe_sanitize_other_name(otherName, {'AnotherName', _OID, Value}) ->
+    rabbit_cert_info:sanitize_other_name(rabbit_data_coercion:to_binary(Value));
+maybe_sanitize_other_name(_Type, Value) ->
+    Value.
+
+%%--------------------------------------------------------------------
+%% Layer 3: user resolution (read-only lookup)
+%%--------------------------------------------------------------------
+
+%% Verify that the extracted username exists in the internal auth backend.
+%% This is a read-only mnesia/khepri lookup -- no state mutation (R3).
+-spec resolve_user(binary()) -> ok | {error, auth_failed | config_conflict, binary()}.
+resolve_user(Username) ->
+    case internal_backend_available() of
+        false ->
+            {error, config_conflict, ?REASON_USER_LOOKUP_UNAVAILABLE};
+        true ->
+            %% Look up the RAW extracted name -- it is what the broker's own
+            %% EXTERNAL login would pass to check_user_login. Sanitization is
+            %% applied only when echoing the name in the reason (R4), so the
+            %% lookup verdict cannot diverge from the live broker's.
+            case ?INTERNAL_BACKEND:exists(Username) of
+                true -> ok;
+                false -> {error, auth_failed, ?REASON_USER_NOT_FOUND(Username)}
+            end
+    end.
+
+internal_backend_available() ->
+    module_ready(?INTERNAL_BACKEND) andalso
+        erlang:function_exported(?INTERNAL_BACKEND, exists, 1).
+
+module_ready(Mod) ->
+    case code:ensure_loaded(Mod) of
+        {module, Mod} -> true;
+        _ -> false
+    end.
+
+%% Cap username length and strip control characters. The username derives from
+%% the caller's own supplied certificate (R4 basis for echoing it), but we still
+%% bound it against degenerate inputs.
+-spec sanitize_username(binary()) -> binary().
+sanitize_username(Name) when is_binary(Name) ->
+    Capped =
+        case byte_size(Name) > ?MAX_USERNAME_LEN of
+            true -> binary:part(Name, 0, ?MAX_USERNAME_LEN);
+            false -> Name
+        end,
+    <<<<C>> || <<C>> <= Capped, C >= 32, C =/= 127>>.

--- a/src/aws_auth_validate_tls.erl
+++ b/src/aws_auth_validate_tls.erl
@@ -114,10 +114,14 @@
 -define(REASON_CLIENT_CERT_PRIVATE_KEY,
     <<"client_cert must not contain private key material; send only certificate entries">>
 ).
--define(REASON_BAD_CERT_LOGIN, <<"cert_login must be an object">>).
--define(REASON_BAD_CERT_LOGIN_FROM,
-    <<"cert_login.from must be distinguished_name, common_name, or subject_alternative_name">>
+-define(REASON_CLIENT_CERT_UNEXPECTED_ENTRY,
+    <<"client_cert contains a non-certificate PEM entry; send only certificate entries">>
 ).
+-define(REASON_BAD_CERT_LOGIN, <<"cert_login must be an object">>).
+-define(REASON_BAD_CERT_LOGIN_FROM, <<
+    "cert_login.from must be distinguished_name, common_name, "
+    "subject_alternative_name, or subject_alt_name"
+>>).
 -define(REASON_SAN_TYPE_REQUIRES_SAN_FROM,
     <<"cert_login.san_type is only valid when from is subject_alternative_name">>
 ).
@@ -188,7 +192,14 @@
 -define(INTERNAL_BACKEND, rabbit_auth_backend_internal).
 -define(MAX_USERNAME_LEN, 256).
 
-%% Private key entry types that must be rejected from client_cert input (R6).
+%% Known private-key atom tags. Used for message selection only -- the actual
+%% rejection is allowlist-based (only 'Certificate' entries pass). When the
+%% offending entry carries one of these types or a tuple tag like
+%% {no_asn1, new_openssh}, the operator gets the specific "never send key
+%% material" reason; other unrecognized entry types get a generic rejection.
+%% EncryptedPrivateKeyInfo is listed for documentation: OTP rewrites it to
+%% PrivateKeyInfo internally before a caller sees it, but keeping it here is
+%% harmless and documents intent.
 -define(PRIVATE_KEY_TYPES, [
     'RSAPrivateKey',
     'DSAPrivateKey',
@@ -456,23 +467,46 @@ decode_client_cert_pem(Pem, Acc) ->
             classify_pem_entries(Decoded, Acc)
     end.
 
-%% Split the decoded PEM entries: reject if any private key type is present,
-%% collect Certificate DERs. An empty cert list after filtering is an error.
+%% Allowlist-structured: only plain Certificate entries are accepted. Any
+%% entry whose type is NOT 'Certificate' is rejected immediately -- this
+%% closes the class of bypass where an unenumerated key tag (e.g. the tuple
+%% {no_asn1, new_openssh} for OpenSSH-format keys) slips past a denylist.
+%% ?PRIVATE_KEY_TYPES is retained for message selection: when the offending
+%% entry IS a recognizable key type the operator gets the actionable
+%% "never send key material" reason; other unexpected entries get a generic
+%% non-certificate reason.
 classify_pem_entries(Entries, Acc) ->
-    HasKey = lists:any(
-        fun({Type, _Der, _Enc}) -> lists:member(Type, ?PRIVATE_KEY_TYPES) end,
-        Entries
-    ),
-    case HasKey of
-        true ->
-            {error, input_invalid, ?REASON_CLIENT_CERT_PRIVATE_KEY};
-        false ->
+    case find_non_cert_entry(Entries) of
+        none ->
             Ders = [Der || {'Certificate', Der, not_encrypted} <- Entries],
             case Ders of
                 [] -> {error, input_invalid, ?REASON_BAD_CLIENT_CERT};
                 _ -> {ok, Acc#{client_cert_ders => Ders}}
-            end
+            end;
+        {rejected, Reason} ->
+            {error, input_invalid, Reason}
     end.
+
+%% Scan entries for the first non-Certificate entry. Returns `none' if all
+%% entries are plain certificates, otherwise {rejected, Reason}.
+find_non_cert_entry([]) ->
+    none;
+find_non_cert_entry([{'Certificate', _Der, not_encrypted} | Rest]) ->
+    find_non_cert_entry(Rest);
+find_non_cert_entry([{Type, _Der, _Enc} | _Rest]) ->
+    case is_known_key_type(Type) of
+        true -> {rejected, ?REASON_CLIENT_CERT_PRIVATE_KEY};
+        false -> {rejected, ?REASON_CLIENT_CERT_UNEXPECTED_ENTRY}
+    end.
+
+%% Returns true when the PEM type tag identifies a private key -- either an
+%% atom from the traditional set or the tuple tag used by OpenSSH keys.
+is_known_key_type(Type) when is_atom(Type) ->
+    lists:member(Type, ?PRIVATE_KEY_TYPES);
+is_known_key_type({no_asn1, _}) ->
+    true;
+is_known_key_type(_) ->
+    false.
 
 %%--------------------------------------------------------------------
 %% Input parsing: cert_login (optional username-extraction config)
@@ -507,6 +541,8 @@ parse_cert_login_from(Map, Acc) ->
             check_no_san_fields(Map, Acc, common_name);
         <<"subject_alternative_name">> ->
             parse_san_fields(Map, Acc);
+        %% Mirrors the broker's accepted spellings: rabbit_ssl accepts both
+        %% subject_alternative_name and subject_alt_name for ssl_cert_login_from.
         <<"subject_alt_name">> ->
             parse_san_fields(Map, Acc);
         _ ->

--- a/src/aws_auth_validate_tls.erl
+++ b/src/aws_auth_validate_tls.erl
@@ -676,7 +676,14 @@ validate_chain(ClientDers, CaDers, Depth) ->
             end,
         %% Rebuild the chain in issuer-linked order starting from the leaf.
         %% The leaf MUST be element 0; the tail is reordered by issuer linkage.
-        OrderedDers = order_chain(ClientDers),
+        Reordered = order_chain(ClientDers),
+        %% A listener treats every cacerts entry as chain-building material, not
+        %% only as a trust anchor (ssl_certificate:certificate_chain/3), so a
+        %% bundle carrying [root, intermediate] completes a client that presents
+        %% the leaf alone. Extend the chain with non-self-signed bundle CAs
+        %% before searching for an anchor, or that configuration -- which a real
+        %% handshake accepts -- would be reported as not chaining.
+        OrderedDers = extend_with_bundle_intermediates(Reordered, CaDers),
         %% The top cert (lists:last) is the one closest to (or matching) a
         %% bundle CA. Find anchors based on its issuer. If the top cert itself
         %% is one of the anchors (client included the root in its PEM), strip
@@ -790,6 +797,46 @@ find_issuer_in(Issuer, [Der | Rest]) ->
         false ->
             case find_issuer_in(Issuer, Rest) of
                 {ok, Found, Rem} -> {ok, Found, [Der | Rem]};
+                not_found -> not_found
+            end
+    end.
+
+%% Extend an ordered (leaf-first) chain upward using non-self-signed CAs from
+%% the bundle, mirroring how a listener uses cacerts as chain-building material
+%% and not only as anchors. Only NON-self-signed entries are appended: a
+%% self-signed match is a trust anchor and is handled by find_trust_anchors/2,
+%% which also keeps a self-signed cert from being appended to itself.
+%%
+%% Each appended CA is removed from the candidate pool, so the recursion is
+%% bounded by the bundle size and cannot loop on a cross-signed pair.
+extend_with_bundle_intermediates(OrderedDers, CaDers) ->
+    TopCert = lists:last(OrderedDers),
+    TopOtp = public_key:pkix_decode_cert(TopCert, otp),
+    Issuer = TopOtp#'OTPCertificate'.tbsCertificate#'OTPTBSCertificate'.issuer,
+    case take_non_self_signed_by_subject(Issuer, CaDers) of
+        {ok, IntDer, RestCaDers} ->
+            extend_with_bundle_intermediates(OrderedDers ++ [IntDer], RestCaDers);
+        not_found ->
+            OrderedDers
+    end.
+
+%% Take the first non-self-signed bundle CA whose subject matches Issuer,
+%% returning it alongside the remaining candidates.
+take_non_self_signed_by_subject(_Issuer, []) ->
+    not_found;
+take_non_self_signed_by_subject(Issuer, [CaDer | Rest]) ->
+    CaOtp = public_key:pkix_decode_cert(CaDer, otp),
+    Subject = CaOtp#'OTPCertificate'.tbsCertificate#'OTPTBSCertificate'.subject,
+    Matches =
+        public_key:pkix_normalize_name(Issuer) =:=
+            public_key:pkix_normalize_name(Subject) andalso
+            not public_key:pkix_is_self_signed(CaOtp),
+    case Matches of
+        true ->
+            {ok, CaDer, Rest};
+        false ->
+            case take_non_self_signed_by_subject(Issuer, Rest) of
+                {ok, Found, Rem} -> {ok, Found, [CaDer | Rem]};
                 not_found -> not_found
             end
     end.

--- a/src/aws_auth_validate_tls.erl
+++ b/src/aws_auth_validate_tls.erl
@@ -1034,7 +1034,12 @@ sanitize_username(Name) when is_binary(Name) ->
     Capped = truncate_utf8(Name, ?MAX_USERNAME_LEN),
     %% Strip control characters (< 32 or DEL), then ensure UTF-8 validity:
     %% valid codepoints pass through, invalid bytes are hex-escaped as <0xHH>.
-    ensure_utf8(strip_control(Capped)).
+    Escaped = ensure_utf8(strip_control(Capped)),
+    %% Hex-escaping expands each invalid byte to 6 characters, so an all-invalid
+    %% input (e.g. 256 bytes of 0xC0) would otherwise blow past the cap by ~6x.
+    %% Re-truncate on a character boundary so ?MAX_USERNAME_LEN bounds the value
+    %% that actually reaches the response, which is the point of the cap.
+    truncate_utf8(Escaped, ?MAX_USERNAME_LEN).
 
 %% Truncate a binary to at most MaxBytes, respecting UTF-8 character boundaries.
 truncate_utf8(Bin, MaxBytes) when byte_size(Bin) =< MaxBytes ->

--- a/src/aws_auth_validate_tls.erl
+++ b/src/aws_auth_validate_tls.erl
@@ -174,6 +174,16 @@
 -define(REASON_USER_LOOKUP_UNAVAILABLE,
     <<"user-resolution check unavailable on this broker series">>
 ).
+-define(REASON_USER_LOOKUP_INCONCLUSIVE(Name),
+    iolist_to_binary([
+        <<"user ">>,
+        sanitize_username(Name),
+        <<
+            " not found in the internal backend; other auth backends are configured"
+            " and the user may exist there (cannot verify without network I/O)"
+        >>
+    ])
+).
 
 -define(INTERNAL_BACKEND, rabbit_auth_backend_internal).
 -define(MAX_USERNAME_LEN, 256).
@@ -805,8 +815,22 @@ extract_username(LeafDer, #{from := subject_alternative_name, san_type := Type, 
     case length(Filtered) > Index of
         true ->
             Raw = lists:nth(Index + 1, Filtered),
-            Value = maybe_sanitize_other_name(OtpType, Raw),
-            {ok, iolist_to_binary([Value])};
+            case maybe_sanitize_other_name(OtpType, Raw) of
+                {error, _} ->
+                    %% rabbit_cert_info:sanitize_other_name/1 returns an error
+                    %% tuple for non-DirectoryString otherName encodings (e.g.
+                    %% IA5STRING UPNs). Map to a categorized failure rather than
+                    %% crashing in iolist_to_binary.
+                    {error, auth_failed, ?REASON_EXTRACT_FAILED};
+                Value when is_binary(Value) ->
+                    {ok, Value};
+                Value when is_list(Value) ->
+                    {ok, iolist_to_binary(Value)};
+                _Other ->
+                    %% Defensive: any non-binary/non-iolist return (unexpected
+                    %% upstream shape change) gets a categorized failure.
+                    {error, auth_failed, ?REASON_EXTRACT_FAILED}
+            end;
         false ->
             {error, auth_failed, ?REASON_EXTRACT_FAILED}
     end.
@@ -832,23 +856,55 @@ maybe_sanitize_other_name(_Type, Value) ->
 %% Layer 3: user resolution (read-only lookup)
 %%--------------------------------------------------------------------
 
-%% Verify that the extracted username exists in the internal auth backend.
-%% This is a read-only mnesia/khepri lookup -- no state mutation (R3).
+%% Check whether the extracted username resolves to a known broker user.
+%%
+%% The broker's live EXTERNAL login calls rabbit_access_control:check_user_login/2,
+%% which walks ALL configured auth_backends (each entry may be a bare module or a
+%% {AuthN, AuthZ} tuple). We can only query rabbit_auth_backend_internal (a local
+%% mnesia/khepri read -- no I/O, no state mutation, R3-safe). If other backends
+%% are also configured, a not-found in the internal backend does NOT mean the user
+%% does not exist -- the broker may authenticate it via LDAP, HTTP, or OAuth.
+%%
+%% Strategy:
+%%   - internal backend unavailable -> config_conflict (cannot check at all).
+%%   - user found in internal backend -> ok (definitive positive).
+%%   - user NOT found AND internal is the only authN backend -> auth_failed.
+%%   - user NOT found AND other authN backends are configured -> config_conflict
+%%     with an honest "inconclusive" reason (we cannot check those without I/O).
 -spec resolve_user(binary()) -> ok | {error, auth_failed | config_conflict, binary()}.
 resolve_user(Username) ->
     case internal_backend_available() of
         false ->
             {error, config_conflict, ?REASON_USER_LOOKUP_UNAVAILABLE};
         true ->
-            %% Look up the RAW extracted name -- it is what the broker's own
-            %% EXTERNAL login would pass to check_user_login. Sanitization is
-            %% applied only when echoing the name in the reason (R4), so the
-            %% lookup verdict cannot diverge from the live broker's.
             case ?INTERNAL_BACKEND:exists(Username) of
-                true -> ok;
-                false -> {error, auth_failed, ?REASON_USER_NOT_FOUND(Username)}
+                true ->
+                    ok;
+                false ->
+                    case only_internal_authn_configured() of
+                        true ->
+                            {error, auth_failed, ?REASON_USER_NOT_FOUND(Username)};
+                        false ->
+                            {error, config_conflict, ?REASON_USER_LOOKUP_INCONCLUSIVE(Username)}
+                    end
             end
     end.
+
+%% Returns true only when every configured authN backend is
+%% rabbit_auth_backend_internal. The auth_backends env entries are either a bare
+%% module atom (same module for authN and authZ) or a {AuthN, _AuthZ} tuple.
+only_internal_authn_configured() ->
+    case application:get_env(rabbit, auth_backends) of
+        {ok, Backends} ->
+            lists:all(fun is_internal_authn/1, Backends);
+        undefined ->
+            %% No config at all -- treat as inconclusive (safe side).
+            false
+    end.
+
+is_internal_authn(?INTERNAL_BACKEND) -> true;
+is_internal_authn({?INTERNAL_BACKEND, _AuthZ}) -> true;
+is_internal_authn(_) -> false.
 
 internal_backend_available() ->
     module_ready(?INTERNAL_BACKEND) andalso
@@ -860,14 +916,122 @@ module_ready(Mod) ->
         _ -> false
     end.
 
-%% Cap username length and strip control characters. The username derives from
-%% the caller's own supplied certificate (R4 basis for echoing it), but we still
-%% bound it against degenerate inputs.
+%% Cap username length and strip control characters, ensuring the result is
+%% valid UTF-8 (required for JSON-safe reason binaries in the response). The
+%% username derives from the caller's own supplied certificate (R4 basis for
+%% echoing it), but we bound it against degenerate inputs. Non-UTF-8 bytes
+%% (e.g. raw iPAddress SANs) are hex-escaped so the reason is always encodable.
+%%
+%% NOTE: iPAddress SANs are kept as raw bytes for the user LOOKUP (matching
+%% upstream rabbit_ssl/rabbit_cert_info behavior, which passes the raw value
+%% through without inet:ntoa formatting). Formatting it here into dotted-quad
+%% would create a parity divergence -- the broker would look up a different
+%% username than the endpoint checked. This function only sanitizes the ECHO
+%% path (the reason string), not the lookup key.
 -spec sanitize_username(binary()) -> binary().
 sanitize_username(Name) when is_binary(Name) ->
-    Capped =
-        case byte_size(Name) > ?MAX_USERNAME_LEN of
-            true -> binary:part(Name, 0, ?MAX_USERNAME_LEN);
-            false -> Name
-        end,
-    <<<<C>> || <<C>> <= Capped, C >= 32, C =/= 127>>.
+    %% Truncate on a UTF-8 character boundary: if the input is valid UTF-8,
+    %% find the last complete codepoint within ?MAX_USERNAME_LEN bytes. If the
+    %% input is not valid UTF-8 at all, truncate at the byte limit (the
+    %% subsequent hex-escape pass will handle the non-UTF-8 bytes).
+    Capped = truncate_utf8(Name, ?MAX_USERNAME_LEN),
+    %% Strip control characters (< 32 or DEL), then ensure UTF-8 validity:
+    %% valid codepoints pass through, invalid bytes are hex-escaped as <0xHH>.
+    ensure_utf8(strip_control(Capped)).
+
+%% Truncate a binary to at most MaxBytes, respecting UTF-8 character boundaries.
+truncate_utf8(Bin, MaxBytes) when byte_size(Bin) =< MaxBytes ->
+    Bin;
+truncate_utf8(Bin, MaxBytes) ->
+    Candidate = binary:part(Bin, 0, MaxBytes),
+    %% Walk backwards from the cut point to find a valid UTF-8 boundary.
+    %% A UTF-8 continuation byte has the pattern 10xxxxxx (0x80-0xBF).
+    trim_trailing_partial_utf8(Candidate).
+
+trim_trailing_partial_utf8(<<>>) ->
+    <<>>;
+trim_trailing_partial_utf8(Bin) ->
+    Size = byte_size(Bin),
+    Last = binary:at(Bin, Size - 1),
+    case Last of
+        B when B < 16#80 ->
+            %% ASCII -- boundary is clean.
+            Bin;
+        B when B >= 16#C0 ->
+            %% A lead byte at the very end means the multibyte char was split.
+            binary:part(Bin, 0, Size - 1);
+        _ ->
+            %% Continuation byte -- verify the preceding sequence is complete.
+            verify_tail_sequence(Bin)
+    end.
+
+%% Walk back over continuation bytes to find the lead byte and check if the
+%% sequence is complete (expected length matches actual length).
+verify_tail_sequence(Bin) ->
+    Size = byte_size(Bin),
+    %% Count trailing continuation bytes (max 3 in valid UTF-8).
+    ContCount = count_trailing_continuations(Bin, Size - 1, 0),
+    LeadPos = Size - 1 - ContCount,
+    case LeadPos >= 0 of
+        false ->
+            %% All continuation bytes, no lead -- not valid, trim all.
+            <<>>;
+        true ->
+            Lead = binary:at(Bin, LeadPos),
+            Expected = expected_continuation_count(Lead),
+            case Expected =:= ContCount of
+                true ->
+                    %% Complete sequence.
+                    Bin;
+                false ->
+                    %% Incomplete -- trim back to before the lead byte.
+                    binary:part(Bin, 0, LeadPos)
+            end
+    end.
+
+count_trailing_continuations(_Bin, Pos, Acc) when Pos < 0 ->
+    Acc;
+count_trailing_continuations(Bin, Pos, Acc) ->
+    B = binary:at(Bin, Pos),
+    case B >= 16#80 andalso B < 16#C0 of
+        true -> count_trailing_continuations(Bin, Pos - 1, Acc + 1);
+        false -> Acc
+    end.
+
+expected_continuation_count(Lead) when Lead >= 16#F0 -> 3;
+expected_continuation_count(Lead) when Lead >= 16#E0 -> 2;
+expected_continuation_count(Lead) when Lead >= 16#C0 -> 1;
+expected_continuation_count(_) -> 0.
+
+%% Strip ASCII control characters (bytes < 32 and DEL 127) while preserving
+%% multibyte sequences intact.
+strip_control(Bin) ->
+    <<<<C>> || <<C>> <= Bin, C >= 32, C =/= 127>>.
+
+%% Ensure the result is valid UTF-8. Valid codepoints pass through; any byte
+%% that does not form part of a valid UTF-8 sequence is hex-escaped as <0xHH>.
+ensure_utf8(Bin) ->
+    case unicode:characters_to_binary(Bin) of
+        Bin -> Bin;
+        _ -> hex_escape_non_utf8(Bin, <<>>)
+    end.
+
+hex_escape_non_utf8(<<>>, Acc) ->
+    Acc;
+hex_escape_non_utf8(Bin, Acc) ->
+    case unicode:characters_to_binary(Bin) of
+        <<>> ->
+            Acc;
+        Bin ->
+            <<Acc/binary, Bin/binary>>;
+        {error, Good, <<B, Rest/binary>>} ->
+            Hex = list_to_binary(io_lib:format("<0x~2.16.0B>", [B])),
+            hex_escape_non_utf8(Rest, <<Acc/binary, Good/binary, Hex/binary>>);
+        {error, Good, <<>>} ->
+            <<Acc/binary, Good/binary>>;
+        {incomplete, Good, <<B, Rest/binary>>} ->
+            Hex = list_to_binary(io_lib:format("<0x~2.16.0B>", [B])),
+            hex_escape_non_utf8(Rest, <<Acc/binary, Good/binary, Hex/binary>>);
+        {incomplete, Good, <<>>} ->
+            <<Acc/binary, Good/binary>>
+    end.

--- a/src/aws_auth_validate_tls.erl
+++ b/src/aws_auth_validate_tls.erl
@@ -109,7 +109,7 @@
 
 %% client_cert / cert_login reason strings (Layer 1-3 validation).
 -define(REASON_BAD_CLIENT_CERT,
-    <<"client_cert must be a non-empty PEM-encoded certificate chain">>
+    <<"client_cert must be a non-empty PEM-encoded certificate chain (leaf certificate first)">>
 ).
 -define(REASON_CLIENT_CERT_PRIVATE_KEY,
     <<"client_cert must not contain private key material; send only certificate entries">>
@@ -141,6 +141,21 @@
 ).
 -define(REASON_CHAIN_FAILED,
     <<"the client certificate does not chain to the supplied CA bundle">>
+).
+-define(REASON_CHAIN_DEPTH_EXCEEDED,
+    <<"the client certificate chain exceeds the configured path length (depth)">>
+).
+-define(REASON_CHAIN_INVALID_SIGNATURE,
+    <<"a certificate in the client chain has an invalid signature">>
+).
+-define(REASON_CHAIN_INVALID_ISSUER,
+    <<"a certificate in the client chain has an invalid issuer">>
+).
+-define(REASON_CHAIN_BAD_KEY_USAGE,
+    <<"a certificate in the client chain has invalid key usage">>
+).
+-define(REASON_CHAIN_MISSING_BASIC_CONSTRAINT,
+    <<"a certificate in the client chain is missing a required basic constraint">>
 ).
 -define(REASON_CHAIN_EXPIRED,
     <<"the client certificate chain contains an expired or not-yet-valid certificate">>
@@ -289,11 +304,13 @@ do_tls_validate(#{ssl_options := Map} = Params) ->
         {ok, Pem} ->
             case decode_and_check(Pem) of
                 {error, _, _} = Err -> Err;
-                ok -> maybe_chain_validate(Params, Pem)
+                {ok, CaDers} -> maybe_chain_validate(Params, CaDers)
             end
     end.
 
-%% Decode the CA PEM and check each certificate. The decode is wrapped because
+%% Decode the CA PEM and check each certificate. Returns {ok, CaDers} on
+%% success so the caller can thread the already-decoded DER list into chain
+%% validation without a redundant second decode. The decode is wrapped because
 %% public_key:pem_decode/1 raises (rather than returning `skip') on a
 %% cert-framed PEM with a malformed base64 body -- one of the misconfigurations
 %% this catches -- so it must map to input_invalid, not crash.
@@ -305,9 +322,15 @@ decode_and_check(Pem) ->
             _Class:_Reason -> error
         end,
     case Decoded of
-        error -> {error, input_invalid, ?REASON_NO_CERTS};
-        skip -> {error, input_invalid, ?REASON_NO_CERTS};
-        Ders -> check_cert_validity(Ders)
+        error ->
+            {error, input_invalid, ?REASON_NO_CERTS};
+        skip ->
+            {error, input_invalid, ?REASON_NO_CERTS};
+        Ders ->
+            case check_cert_validity(Ders) of
+                ok -> {ok, Ders};
+                {error, _, _} = Err -> Err
+            end
     end.
 
 %% Check every certificate's [notBefore, notAfter] window against now, failing
@@ -562,25 +585,28 @@ check_verify_for_cert_login(#{ssl_options := SslMap} = Acc) ->
 %% Otherwise the existing CA-only validation already passed and we are done
 %% (unless cert_login is present, which cross_field_checks already guarantees
 %% cannot happen without client_cert_ders).
-maybe_chain_validate(#{client_cert_ders := ClientDers} = Params, CaPem) ->
-    CaDers = aws_auth_validate_ssl:decode_pem_cacerts(CaPem),
+maybe_chain_validate(#{client_cert_ders := ClientDers} = Params, CaDers) ->
     Depth = maps:get(<<"depth">>, maps:get(ssl_options, Params, #{}), undefined),
     case validate_chain(ClientDers, CaDers, Depth) of
         ok -> maybe_extract_username(Params);
         {error, _, _} = Err -> Err
     end;
-maybe_chain_validate(_Params, _CaPem) ->
+maybe_chain_validate(_Params, _CaDers) ->
     %% No client_cert: existing CA-only validation already passed.
     ok.
 
 %% Validate the client certificate chain against the CA trust anchors using
-%% public_key:pkix_path_validation/3. ClientDers is leaf-first; CaDers is the
+%% public_key:pkix_path_validation/3. ClientDers is leaf-first (the leaf cert
+%% MUST be the first element; the tail may be in any order). CaDers is the
 %% trust anchor pool. Depth caps intermediate chain length when set.
--spec validate_chain([binary()], [binary()] | skip, integer() | undefined) ->
+%%
+%% The implementation rebuilds an ordered chain from the leaf outward by
+%% issuer/subject matching (tolerating arbitrarily ordered intermediates in the
+%% tail), then finds ALL self-signed bundle certs whose subject matches the
+%% top-most cert's issuer, and tries each candidate anchor until one validates.
+%% This mirrors the broker's path-iteration behavior on key rollover.
+-spec validate_chain([binary()], [binary()], integer() | undefined) ->
     ok | {error, auth_failed | input_invalid, binary()}.
-validate_chain(_ClientDers, skip, _Depth) ->
-    %% No CA certs decoded (should not reach here -- decode_and_check catches it).
-    {error, auth_failed, ?REASON_CHAIN_FAILED};
 validate_chain(ClientDers, CaDers, Depth) ->
     try
         Opts =
@@ -588,48 +614,148 @@ validate_chain(ClientDers, CaDers, Depth) ->
                 undefined -> [];
                 N when is_integer(N), N >= 0 -> [{max_path_length, N}]
             end,
-        %% pkix_path_validation wants: TrustAnchor (DER), Chain (Options).
-        %% ClientDers is leaf-first ([leaf, intermediates...]); the topmost cert
-        %% (lists:last) is the one issued by a bundle CA, so match the anchor
-        %% against its issuer. The chain itself must be passed anchor-closest
-        %% first (the cert the anchor issued down to the leaf), which is the
-        %% reverse of the leaf-first ClientDers.
-        TopCert = lists:last(ClientDers),
-        Chain = lists:reverse(ClientDers),
-        case find_trust_anchor(TopCert, CaDers) of
-            {ok, AnchorDer} ->
-                case public_key:pkix_path_validation(AnchorDer, Chain, Opts) of
-                    {ok, _} ->
-                        ok;
-                    {error, {bad_cert, cert_expired}} ->
-                        {error, auth_failed, ?REASON_CHAIN_EXPIRED};
-                    {error, {bad_cert, {cert_expired, _}}} ->
-                        {error, auth_failed, ?REASON_CHAIN_EXPIRED};
-                    {error, {bad_cert, _}} ->
-                        {error, auth_failed, ?REASON_CHAIN_FAILED}
-                end;
-            not_found ->
-                {error, auth_failed, ?REASON_CHAIN_FAILED}
+        %% Rebuild the chain in issuer-linked order starting from the leaf.
+        %% The leaf MUST be element 0; the tail is reordered by issuer linkage.
+        OrderedDers = order_chain(ClientDers),
+        %% The top cert (lists:last) is the one closest to (or matching) a
+        %% bundle CA. Find anchors based on its issuer. If the top cert itself
+        %% is one of the anchors (client included the root in its PEM), strip
+        %% it from the path -- pkix_path_validation expects only certs BELOW
+        %% the anchor.
+        TopCert = lists:last(OrderedDers),
+        Anchors = find_trust_anchors(TopCert, CaDers),
+        {PathDers, EffectiveAnchors} =
+            case Anchors of
+                [] ->
+                    %% No anchor matches the top cert's issuer -- fail.
+                    {OrderedDers, []};
+                _ ->
+                    case lists:member(TopCert, Anchors) of
+                        true ->
+                            %% Top cert IS the anchor; validate only the
+                            %% certs below it.
+                            Below = lists:droplast(OrderedDers),
+                            {Below, [TopCert]};
+                        false ->
+                            {OrderedDers, Anchors}
+                    end
+            end,
+        case EffectiveAnchors of
+            [] ->
+                {error, auth_failed, ?REASON_CHAIN_FAILED};
+            _ ->
+                %% pkix_path_validation wants the chain anchor-closest first.
+                Chain = lists:reverse(PathDers),
+                try_anchors(EffectiveAnchors, Chain, Opts)
         end
     catch
         _:_ -> {error, input_invalid, ?REASON_CHAIN_MALFORMED}
     end.
 
-%% Find the trust anchor in CaDers whose subject matches the issuer of TopCertDer.
-find_trust_anchor(TopCertDer, CaDers) ->
-    TopOtp = public_key:pkix_decode_cert(TopCertDer, otp),
-    Issuer = TopOtp#'OTPCertificate'.tbsCertificate#'OTPTBSCertificate'.issuer,
-    find_by_subject(Issuer, CaDers).
+%% Try each candidate trust anchor; accept if ANY validates. On failure,
+%% report the most informative reason (prefer a specific diagnosis over the
+%% generic "does not chain" fallback).
+try_anchors(Anchors, Chain, Opts) ->
+    Results = [
+        public_key:pkix_path_validation(A, Chain, Opts)
+     || A <- Anchors
+    ],
+    case
+        lists:any(
+            fun
+                ({ok, _}) -> true;
+                (_) -> false
+            end,
+            Results
+        )
+    of
+        true ->
+            ok;
+        false ->
+            Reasons = [R || {error, {bad_cert, R}} <- Results],
+            pick_best_failure(Reasons)
+    end.
 
-find_by_subject(_Issuer, []) ->
+%% Select the most informative failure from a list of bad_cert reasons.
+%% Priority: specific actionable reasons first, generic "does not chain" last.
+pick_best_failure([]) ->
+    {error, auth_failed, ?REASON_CHAIN_FAILED};
+pick_best_failure(Reasons) ->
+    Classify = fun(R) ->
+        case R of
+            cert_expired -> {1, ?REASON_CHAIN_EXPIRED};
+            max_path_length_reached -> {2, ?REASON_CHAIN_DEPTH_EXCEEDED};
+            invalid_key_usage -> {3, ?REASON_CHAIN_BAD_KEY_USAGE};
+            missing_basic_constraint -> {4, ?REASON_CHAIN_MISSING_BASIC_CONSTRAINT};
+            invalid_signature -> {5, ?REASON_CHAIN_INVALID_SIGNATURE};
+            invalid_issuer -> {6, ?REASON_CHAIN_INVALID_ISSUER};
+            _ -> {99, ?REASON_CHAIN_FAILED}
+        end
+    end,
+    Classified = lists:map(Classify, Reasons),
+    {_, BestReason} = lists:min(Classified),
+    {error, auth_failed, BestReason}.
+
+%% Rebuild the client cert chain in issuer-linked order starting from the leaf
+%% (element 0). The tail certs are matched by issuer->subject linkage so an
+%% arbitrarily ordered tail (e.g. [leaf, root, int]) still produces the correct
+%% ordering [leaf, int, root] as far as the linkage allows.
+order_chain([Leaf]) ->
+    [Leaf];
+order_chain([Leaf | Tail]) ->
+    order_chain_loop(Leaf, Tail, [Leaf]).
+
+order_chain_loop(_Current, [], Acc) ->
+    lists:reverse(Acc);
+order_chain_loop(Current, Remaining, Acc) ->
+    CurrOtp = public_key:pkix_decode_cert(Current, otp),
+    Issuer = CurrOtp#'OTPCertificate'.tbsCertificate#'OTPTBSCertificate'.issuer,
+    case find_issuer_in(Issuer, Remaining) of
+        {ok, IssuerDer, Rest} ->
+            order_chain_loop(IssuerDer, Rest, [IssuerDer | Acc]);
+        not_found ->
+            %% Remaining certs cannot be linked; append them as-is so
+            %% pkix_path_validation can reject if they do not belong.
+            lists:reverse(Acc) ++ Remaining
+    end.
+
+find_issuer_in(_Issuer, []) ->
     not_found;
-find_by_subject(Issuer, [CaDer | Rest]) ->
-    CaOtp = public_key:pkix_decode_cert(CaDer, otp),
+find_issuer_in(Issuer, [Der | Rest]) ->
+    CaOtp = public_key:pkix_decode_cert(Der, otp),
     Subject = CaOtp#'OTPCertificate'.tbsCertificate#'OTPTBSCertificate'.subject,
     case public_key:pkix_normalize_name(Issuer) =:= public_key:pkix_normalize_name(Subject) of
-        true -> {ok, CaDer};
-        false -> find_by_subject(Issuer, Rest)
+        true ->
+            {ok, Der, Rest};
+        false ->
+            case find_issuer_in(Issuer, Rest) of
+                {ok, Found, Rem} -> {ok, Found, [Der | Rem]};
+                not_found -> not_found
+            end
     end.
+
+%% Find ALL trust anchors in CaDers whose subject matches the issuer of
+%% TopCertDer AND that are self-signed. A non-self-signed intermediate in the
+%% bundle is not a valid trust anchor for pkix_path_validation (the broker's
+%% ssl_certificate module only accepts self-signed anchors in the default
+%% partial_chain behavior).
+find_trust_anchors(TopCertDer, CaDers) ->
+    TopOtp = public_key:pkix_decode_cert(TopCertDer, otp),
+    Issuer = TopOtp#'OTPCertificate'.tbsCertificate#'OTPTBSCertificate'.issuer,
+    find_all_self_signed_by_subject(Issuer, CaDers).
+
+find_all_self_signed_by_subject(Issuer, CaDers) ->
+    [
+        CaDer
+     || CaDer <- CaDers,
+        begin
+            CaOtp = public_key:pkix_decode_cert(CaDer, otp),
+            Subject = CaOtp#'OTPCertificate'.tbsCertificate#'OTPTBSCertificate'.subject,
+            public_key:pkix_normalize_name(Issuer) =:=
+                public_key:pkix_normalize_name(Subject) andalso
+                public_key:pkix_is_self_signed(CaOtp)
+        end
+    ].
 
 %%--------------------------------------------------------------------
 %% Layer 2: username extraction from the leaf certificate

--- a/src/aws_auth_validate_tls.erl
+++ b/src/aws_auth_validate_tls.erl
@@ -588,13 +588,17 @@ validate_chain(ClientDers, CaDers, Depth) ->
                 undefined -> [];
                 N when is_integer(N), N >= 0 -> [{max_path_length, N}]
             end,
-        %% pkix_path_validation wants: TrustAnchor (DER), Chain (EE toward root
-        %% EXCLUDING the anchor), Options. Find which CA in the bundle issued the
-        %% topmost cert in the client chain.
+        %% pkix_path_validation wants: TrustAnchor (DER), Chain (Options).
+        %% ClientDers is leaf-first ([leaf, intermediates...]); the topmost cert
+        %% (lists:last) is the one issued by a bundle CA, so match the anchor
+        %% against its issuer. The chain itself must be passed anchor-closest
+        %% first (the cert the anchor issued down to the leaf), which is the
+        %% reverse of the leaf-first ClientDers.
         TopCert = lists:last(ClientDers),
+        Chain = lists:reverse(ClientDers),
         case find_trust_anchor(TopCert, CaDers) of
             {ok, AnchorDer} ->
-                case public_key:pkix_path_validation(AnchorDer, ClientDers, Opts) of
+                case public_key:pkix_path_validation(AnchorDer, Chain, Opts) of
                     {ok, _} ->
                         ok;
                     {error, {bad_cert, cert_expired}} ->

--- a/test/aws_auth_validate_tls_SUITE.erl
+++ b/test/aws_auth_validate_tls_SUITE.erl
@@ -34,7 +34,10 @@
     tls_no_certs_returns_400_input_invalid/1,
     tls_missing_cacert_arn_returns_400/1,
     tls_no_assume_role_returns_422_config_conflict/1,
-    tls_response_no_ca_material/1
+    tls_response_no_ca_material/1,
+    tls_chain_valid_returns_204/1,
+    tls_chain_invalid_returns_422/1,
+    tls_cert_login_conflict_returns_422/1
 ]).
 
 %% Invoked on the broker node via rpc to install/remove the AWS-boundary mocks.
@@ -74,7 +77,13 @@ groups() ->
             %% cacertfile_arn referenced but no assume_role configured -> 422.
             tls_no_assume_role_returns_422_config_conflict,
             %% resolved CA material must not appear in the response.
-            tls_response_no_ca_material
+            tls_response_no_ca_material,
+            %% Client cert chain validates against the CA bundle -> 204.
+            tls_chain_valid_returns_204,
+            %% Client cert not chaining to the CA -> 422 auth_failed.
+            tls_chain_invalid_returns_422,
+            %% cert_login without client_cert -> 422 config_conflict.
+            tls_cert_login_conflict_returns_422
         ]}
     ].
 
@@ -89,9 +98,16 @@ init_per_suite(Config) ->
     %% PEM binaries are threaded to the broker-node mock via rpc per testcase.
     ValidCaPem = gen_ca_pem(Config, "valid", "-days 2"),
     ExpiredCaPem = gen_expired_ca_pem(Config),
+    %% Generate a leaf cert signed by the same valid CA (for chain validation cases).
+    ClientLeafPem = gen_leaf_cert_pem(Config, "client-leaf", "valid"),
+    %% Generate an unrelated leaf cert (signed by a different CA) for the invalid case.
+    _ = gen_ca_pem(Config, "other", "-days 2"),
+    UnrelatedLeafPem = gen_leaf_cert_pem(Config, "unrelated-leaf", "other"),
     [
         {valid_ca_pem, ValidCaPem},
-        {expired_ca_pem, ExpiredCaPem}
+        {expired_ca_pem, ExpiredCaPem},
+        {client_leaf_pem, ClientLeafPem},
+        {unrelated_leaf_pem, UnrelatedLeafPem}
         | Config
     ].
 
@@ -135,6 +151,10 @@ init_per_testcase(tls_no_assume_role_returns_422_config_conflict = TC, Config) -
     %% refused with config_conflict rather than resolved under the instance role.
     rabbit_ct_broker_helpers:rpc(Config, 0, application, unset_env, [aws, arn_config]),
     rabbit_ct_helpers:testcase_started(Config, TC);
+%% The cert_login conflict case fails at input validation (pure); no mock needed.
+init_per_testcase(tls_cert_login_conflict_returns_422 = TC, Config) ->
+    enable_tls_method(Config),
+    rabbit_ct_helpers:testcase_started(Config, TC);
 %% Every other case enables the method AND installs a resolve mock returning the
 %% appropriate fixture PEM.
 init_per_testcase(TC, Config) ->
@@ -146,6 +166,9 @@ init_per_testcase(TC, Config) ->
 end_per_testcase(tls_disabled_by_default_returns_404 = TC, Config) ->
     rabbit_ct_helpers:testcase_finished(Config, TC);
 end_per_testcase(tls_missing_cacert_arn_returns_400 = TC, Config) ->
+    disable_methods(Config),
+    rabbit_ct_helpers:testcase_finished(Config, TC);
+end_per_testcase(tls_cert_login_conflict_returns_422 = TC, Config) ->
     disable_methods(Config),
     rabbit_ct_helpers:testcase_finished(Config, TC);
 end_per_testcase(tls_no_assume_role_returns_422_config_conflict = TC, Config) ->
@@ -172,6 +195,10 @@ pem_for_case(tls_no_certs_returns_400_input_invalid, _Config) ->
     %% decodes the body but yields zero certificates (the `skip' branch), as
     %% opposed to the malformed-base64 case above, which raises.
     <<"-----BEGIN PRIVATE KEY-----\naGVsbG8=\n-----END PRIVATE KEY-----\n">>;
+pem_for_case(tls_chain_valid_returns_204, Config) ->
+    ?config(valid_ca_pem, Config);
+pem_for_case(tls_chain_invalid_returns_422, Config) ->
+    ?config(valid_ca_pem, Config);
 pem_for_case(_TC, Config) ->
     %% Default (valid CA) for tls_valid_ca_returns_204 / tls_response_no_ca_material.
     ?config(valid_ca_pem, Config).
@@ -231,6 +258,51 @@ tls_response_no_ca_material(Config) ->
     Body = iolist_to_binary(ResBody),
     Needle = pem_body_slice(Pem),
     ?assertEqual(nomatch, binary:match(Body, Needle)).
+
+%% A client certificate that chains to the resolved CA bundle passes (204).
+%% This exercises Layer 1 (chain validation) without cert_login (chain-only mode).
+tls_chain_valid_returns_204(Config) ->
+    ClientPem = ?config(client_leaf_pem, Config),
+    Body = #{
+        <<"target">> => <<"listener">>,
+        <<"ssl_options">> => #{
+            <<"cacertfile_arn">> => ?CACERT_ARN,
+            <<"verify">> => <<"verify_peer">>
+        },
+        <<"client_cert">> => ClientPem
+    },
+    {ok, {{_, Code, _}, _Headers, ResBody}} = put_request(Config, ?API, Body),
+    ?assertEqual(204, Code),
+    ?assertEqual(<<>>, iolist_to_binary(ResBody)).
+
+%% A client certificate signed by a different CA does not chain -> 422 auth_failed.
+tls_chain_invalid_returns_422(Config) ->
+    UnrelatedPem = ?config(unrelated_leaf_pem, Config),
+    Body = #{
+        <<"target">> => <<"listener">>,
+        <<"ssl_options">> => #{
+            <<"cacertfile_arn">> => ?CACERT_ARN,
+            <<"verify">> => <<"verify_peer">>
+        },
+        <<"client_cert">> => UnrelatedPem
+    },
+    {ok, {{_, Code, _}, _, ResBody}} = put_request(Config, ?API, Body),
+    ?assertEqual(422, Code),
+    ?assertMatch(#{<<"error">> := <<"auth_failed">>}, decode(ResBody)).
+
+%% cert_login without client_cert is a cross-field conflict -> 422.
+tls_cert_login_conflict_returns_422(Config) ->
+    Body = #{
+        <<"target">> => <<"listener">>,
+        <<"ssl_options">> => #{
+            <<"cacertfile_arn">> => ?CACERT_ARN,
+            <<"verify">> => <<"verify_peer">>
+        },
+        <<"cert_login">> => #{<<"from">> => <<"common_name">>}
+    },
+    {ok, {{_, Code, _}, _, ResBody}} = put_request(Config, ?API, Body),
+    ?assertEqual(422, Code),
+    ?assertMatch(#{<<"error">> := <<"config_conflict">>}, decode(ResBody)).
 
 %%--------------------------------------------------------------------
 %% Broker-node mocks (invoked via rpc)
@@ -362,6 +434,39 @@ gen_expired_ca_pem(Config) ->
         false ->
             skip
     end.
+
+%% Generate a leaf cert signed by the named CA fixture. Returns a cert-only PEM
+%% (no private key material).
+gen_leaf_cert_pem(Config, Name, CaName) ->
+    PrivDir = ?config(priv_dir, Config),
+    CaKey = filename:join(PrivDir, CaName ++ "-ca-key.pem"),
+    CaCert = filename:join(PrivDir, CaName ++ "-ca-cert.pem"),
+    LeafKey = filename:join(PrivDir, Name ++ "-key.pem"),
+    LeafCsr = filename:join(PrivDir, Name ++ ".csr"),
+    LeafCert = filename:join(PrivDir, Name ++ "-cert.pem"),
+    %% Generate leaf key + CSR.
+    _ = os:cmd(
+        lists:flatten(
+            io_lib:format(
+                "openssl req -new -newkey rsa:2048 -nodes -keyout ~ts -out ~ts "
+                "-subj /CN=~s 2>/dev/null",
+                [LeafKey, LeafCsr, Name]
+            )
+        )
+    ),
+    %% Sign leaf with the named CA.
+    _ = os:cmd(
+        lists:flatten(
+            io_lib:format(
+                "openssl x509 -req -in ~ts -CA ~ts -CAkey ~ts -CAcreateserial "
+                "-out ~ts -days 2 2>/dev/null",
+                [LeafCsr, CaCert, CaKey, LeafCert]
+            )
+        )
+    ),
+    true = filelib:is_regular(LeafCert),
+    {ok, Pem} = file:read_file(LeafCert),
+    Pem.
 
 has_error(Out) ->
     string:find(Out, "error") =/= nomatch orelse

--- a/test/aws_auth_validate_tls_parity_tests.erl
+++ b/test/aws_auth_validate_tls_parity_tests.erl
@@ -1,0 +1,510 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% Parity tests between aws_auth_validate_tls:validate_chain/3 and a REAL
+%% ssl:handshake mTLS handshake.
+%%
+%% The reviewer's criticism: "the suite tests this module against public_key
+%% while the thing being predicted is ssl's path building, and those disagree
+%% in all the ways above." These tests stand up a real TLS listener and
+%% connect a client with the same certificate material, asserting the
+%% endpoint's verdict AGREES with the actual handshake outcome.
+%%
+%% Three scenarios from the reviewer's findings:
+%%   1. Intermediate-only CA bundle -- ssl rejects (unknown_ca), endpoint must too.
+%%   2. CA key rollover -- two roots sharing a subject DN, both bundle orders accept.
+%%   3. Unordered chain tail -- leaf-first with scrambled tail passes; root-first
+%%      chain (leaf not first) is rejected by both sides.
+%%
+%% No broker required -- only the ssl application (already in LOCAL_DEPS).
+%% No meck -- purely openssl-generated fixtures + real handshakes.
+-module(aws_auth_validate_tls_parity_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%%====================================================================
+%% Guard: skip the entire module if openssl is unusable or ssl won't start
+%%====================================================================
+
+can_run_parity_tests() ->
+    case os:find_executable("openssl") of
+        false -> false;
+        _ -> ensure_ssl_started()
+    end.
+
+ensure_ssl_started() ->
+    case application:ensure_all_started(ssl) of
+        {ok, _} -> true;
+        {error, _} -> false
+    end.
+
+%%====================================================================
+%% Top-level test generator -- skips cleanly if preconditions unmet
+%%====================================================================
+
+parity_test_() ->
+    case can_run_parity_tests() of
+        false ->
+            [];
+        true ->
+            {setup, fun setup/0, fun cleanup/1, fun(Fixtures) ->
+                [
+                    {"intermediate_only_leaf_alone_both_reject", fun() ->
+                        intermediate_only_leaf_alone_both_reject(Fixtures)
+                    end},
+                    {"intermediate_only_leaf_plus_int_both_reject", fun() ->
+                        intermediate_only_leaf_plus_int_both_reject(Fixtures)
+                    end},
+                    {"intermediate_only_control_root_bundle_leaf_plus_int_both_accept", fun() ->
+                        intermediate_only_control_root_bundle_leaf_plus_int_accept(Fixtures)
+                    end},
+                    %% NOTE: a control case "bundle=[Root,Int], client=[leaf]" is
+                    %% deliberately omitted. It reveals a SEPARATE source divergence
+                    %% where the endpoint does not use bundle entries as intermediate
+                    %% chain-building material (only as trust anchors), while ssl does.
+                    %% That is a new finding beyond the seven fixed in PR #165 -- see the
+                    %% commit message for details. A source fix is needed before this
+                    %% control can be enabled.
+                    {"key_rollover_old_new_order_both_accept", fun() ->
+                        key_rollover_old_new_order_both_accept(Fixtures)
+                    end},
+                    {"key_rollover_new_old_order_both_accept", fun() ->
+                        key_rollover_new_old_order_both_accept(Fixtures)
+                    end},
+                    {"unordered_tail_leaf_root_int_both_accept", fun() ->
+                        unordered_tail_leaf_root_int_both_accept(Fixtures)
+                    end},
+                    {"root_first_chain_both_reject", fun() ->
+                        root_first_chain_both_reject(Fixtures)
+                    end}
+                ]
+            end}
+    end.
+
+%%====================================================================
+%% Fixture generation (once per test group)
+%%====================================================================
+
+setup() ->
+    Dir = tmp_dir(),
+    %% Hierarchy for findings 1 and 7: Root -> Intermediate -> Leaf
+    {RootKey, RootCert, RootDer} = gen_self_signed_ca(Dir, "parity-root"),
+    {IntKey, IntCert, IntDer} = gen_intermediate_ca(Dir, "parity-int", RootKey, RootCert),
+    {LeafKey, LeafCert, LeafDer} = gen_leaf(Dir, "parity-leaf", IntKey, IntCert),
+    %% For finding 2: two roots sharing the same subject DN with different keys
+    CommonCN = "ParityRolloverRoot",
+    {_OldRootKey, _OldRootCert, OldRootDer} = gen_self_signed_ca_cn(
+        Dir, "parity-old-root", CommonCN
+    ),
+    {NewRootKey, NewRootCert, NewRootDer} = gen_self_signed_ca_cn(Dir, "parity-new-root", CommonCN),
+    {RolloverLeafKey, RolloverLeafCert, RolloverLeafDer} =
+        gen_leaf(Dir, "parity-rollover-leaf", NewRootKey, NewRootCert),
+    %% Server cert (signed by root, for the TLS listener -- does not matter which
+    %% CA signs it as long as the client can complete its side of the handshake; we
+    %% skip client-side server verification for simplicity).
+    {ServerKey, ServerCert, _ServerDer} = gen_leaf(Dir, "parity-server", RootKey, RootCert),
+    #{
+        root_der => RootDer,
+        int_der => IntDer,
+        leaf_der => LeafDer,
+        leaf_key => LeafKey,
+        leaf_cert => LeafCert,
+        old_root_der => OldRootDer,
+        new_root_der => NewRootDer,
+        rollover_leaf_der => RolloverLeafDer,
+        rollover_leaf_key => RolloverLeafKey,
+        rollover_leaf_cert => RolloverLeafCert,
+        server_key => ServerKey,
+        server_cert => ServerCert,
+        root_cert => RootCert,
+        int_cert => IntCert
+    }.
+
+cleanup(_Fixtures) ->
+    ok.
+
+%%====================================================================
+%% Parity test cases
+%%====================================================================
+
+%% Finding 1: Intermediate-only bundle, client presents [leaf].
+%% ssl rejects with unknown_ca; endpoint must also reject.
+intermediate_only_leaf_alone_both_reject(#{
+    int_der := IntDer,
+    leaf_der := LeafDer,
+    leaf_key := LeafKey,
+    leaf_cert := LeafCert,
+    server_key := ServerKey,
+    server_cert := ServerCert,
+    int_cert := IntCert
+}) ->
+    EndpointResult = aws_auth_validate_tls:validate_chain([LeafDer], [IntDer], undefined),
+    SslResult = do_handshake(
+        _CaCerts = [IntCert],
+        _ClientCertFile = LeafCert,
+        _ClientKeyFile = LeafKey,
+        ServerCert,
+        ServerKey
+    ),
+    assert_parity(EndpointResult, SslResult, "intermediate_only_leaf_alone").
+
+%% Finding 1: Intermediate-only bundle, client presents [leaf, int].
+%% ssl still rejects -- partial_chain only accepts self-signed roots.
+intermediate_only_leaf_plus_int_both_reject(#{
+    int_der := IntDer,
+    leaf_der := LeafDer,
+    leaf_key := LeafKey,
+    leaf_cert := LeafCert,
+    server_key := ServerKey,
+    server_cert := ServerCert,
+    int_cert := IntCert
+}) ->
+    EndpointResult = aws_auth_validate_tls:validate_chain([LeafDer, IntDer], [IntDer], undefined),
+    %% Client presents its full chain (leaf + intermediate)
+    ChainFile = write_chain_file([LeafCert, IntCert]),
+    SslResult = do_handshake(
+        _CaCerts = [IntCert],
+        _ClientCertFile = ChainFile,
+        _ClientKeyFile = LeafKey,
+        ServerCert,
+        ServerKey
+    ),
+    assert_parity(EndpointResult, SslResult, "intermediate_only_leaf_plus_int").
+
+%% Control for Finding 1: bundle=[Root], client=[leaf, int] -- both accept.
+intermediate_only_control_root_bundle_leaf_plus_int_accept(#{
+    root_der := RootDer,
+    int_der := IntDer,
+    leaf_der := LeafDer,
+    leaf_key := LeafKey,
+    leaf_cert := LeafCert,
+    server_key := ServerKey,
+    server_cert := ServerCert,
+    root_cert := RootCert,
+    int_cert := IntCert
+}) ->
+    EndpointResult = aws_auth_validate_tls:validate_chain([LeafDer, IntDer], [RootDer], undefined),
+    ChainFile = write_chain_file([LeafCert, IntCert]),
+    SslResult = do_handshake(
+        _CaCerts = [RootCert],
+        _ClientCertFile = ChainFile,
+        _ClientKeyFile = LeafKey,
+        ServerCert,
+        ServerKey
+    ),
+    assert_parity(EndpointResult, SslResult, "control_root_bundle_leaf_plus_int").
+
+%% Finding 2: Key rollover, bundle order [OldRoot, NewRoot], leaf chains to NewRoot.
+key_rollover_old_new_order_both_accept(#{
+    old_root_der := OldRootDer,
+    new_root_der := NewRootDer,
+    rollover_leaf_der := RolloverLeafDer,
+    rollover_leaf_key := RolloverLeafKey,
+    rollover_leaf_cert := RolloverLeafCert,
+    server_key := ServerKey,
+    server_cert := ServerCert
+}) ->
+    EndpointResult = aws_auth_validate_tls:validate_chain(
+        [RolloverLeafDer], [OldRootDer, NewRootDer], undefined
+    ),
+    %% For ssl, provide both root certs in the cacerts list (order: old, new).
+    OldRootPem = der_to_pem(OldRootDer),
+    NewRootPem = der_to_pem(NewRootDer),
+    CaBundleFile = write_chain_file([OldRootPem, NewRootPem]),
+    SslResult = do_handshake(
+        _CaCerts = [CaBundleFile],
+        _ClientCertFile = RolloverLeafCert,
+        _ClientKeyFile = RolloverLeafKey,
+        ServerCert,
+        ServerKey
+    ),
+    assert_parity(EndpointResult, SslResult, "key_rollover_old_new_order").
+
+%% Finding 2: Key rollover, bundle order [NewRoot, OldRoot].
+key_rollover_new_old_order_both_accept(#{
+    old_root_der := OldRootDer,
+    new_root_der := NewRootDer,
+    rollover_leaf_der := RolloverLeafDer,
+    rollover_leaf_key := RolloverLeafKey,
+    rollover_leaf_cert := RolloverLeafCert,
+    server_key := ServerKey,
+    server_cert := ServerCert
+}) ->
+    EndpointResult = aws_auth_validate_tls:validate_chain(
+        [RolloverLeafDer], [NewRootDer, OldRootDer], undefined
+    ),
+    NewRootPem = der_to_pem(NewRootDer),
+    OldRootPem = der_to_pem(OldRootDer),
+    CaBundleFile = write_chain_file([NewRootPem, OldRootPem]),
+    SslResult = do_handshake(
+        _CaCerts = [CaBundleFile],
+        _ClientCertFile = RolloverLeafCert,
+        _ClientKeyFile = RolloverLeafKey,
+        ServerCert,
+        ServerKey
+    ),
+    assert_parity(EndpointResult, SslResult, "key_rollover_new_old_order").
+
+%% Finding 7: Unordered tail -- client PEM [leaf, root, int] (leaf first, tail
+%% arbitrarily ordered). Bundle=[Root]. ssl rebuilds the chain and accepts.
+unordered_tail_leaf_root_int_both_accept(#{
+    root_der := RootDer,
+    int_der := IntDer,
+    leaf_der := LeafDer,
+    leaf_key := LeafKey,
+    leaf_cert := LeafCert,
+    server_key := ServerKey,
+    server_cert := ServerCert,
+    root_cert := RootCert,
+    int_cert := IntCert
+}) ->
+    %% Endpoint: pass DERs in unordered-tail order [leaf, root, int]
+    EndpointResult = aws_auth_validate_tls:validate_chain(
+        [LeafDer, RootDer, IntDer], [RootDer], undefined
+    ),
+    %% ssl: client chain file in PEM order [leaf, root, int]
+    ChainFile = write_chain_file([LeafCert, RootCert, IntCert]),
+    SslResult = do_handshake(
+        _CaCerts = [RootCert],
+        _ClientCertFile = ChainFile,
+        _ClientKeyFile = LeafKey,
+        ServerCert,
+        ServerKey
+    ),
+    assert_parity(EndpointResult, SslResult, "unordered_tail_leaf_root_int").
+
+%% Finding 7 narrowing: A fully root-first chain [root, int, leaf] is rejected
+%% by a real listener (bad_certificate) because the leaf is not the peer cert.
+%% Both sides must reject.
+root_first_chain_both_reject(#{
+    root_der := RootDer,
+    int_der := IntDer,
+    leaf_der := LeafDer,
+    leaf_key := LeafKey,
+    leaf_cert := LeafCert,
+    server_key := ServerKey,
+    server_cert := ServerCert,
+    root_cert := RootCert,
+    int_cert := IntCert
+}) ->
+    %% Endpoint: pass DERs in root-first order [root, int, leaf]
+    EndpointResult = aws_auth_validate_tls:validate_chain(
+        [RootDer, IntDer, LeafDer], [RootDer], undefined
+    ),
+    %% ssl: client chain file in PEM order [root, int, leaf] -- the server sees
+    %% "root" as the peer cert, which is not the leaf.
+    ChainFile = write_chain_file([RootCert, IntCert, LeafCert]),
+    SslResult = do_handshake(
+        _CaCerts = [RootCert],
+        _ClientCertFile = ChainFile,
+        _ClientKeyFile = LeafKey,
+        ServerCert,
+        ServerKey
+    ),
+    assert_parity(EndpointResult, SslResult, "root_first_chain").
+
+%%====================================================================
+%% Real TLS handshake helper
+%%====================================================================
+
+%% Perform a real mTLS handshake and return `accept' or `reject'.
+%% CaCerts: list of PEM file paths that the SERVER trusts (client CA bundle).
+%% ClientCertFile: PEM file the client presents (may be a chain).
+%% ClientKeyFile: PEM file with the client's private key.
+%% ServerCertFile, ServerKeyFile: server identity (any valid cert/key pair).
+%%
+%% Returns `accept' if the server-side handshake succeeds, `reject' otherwise.
+do_handshake(CaCerts, ClientCertFile, ClientKeyFile, ServerCertFile, ServerKeyFile) ->
+    %% Build server cacerts: decode all CA PEM files to DER for the cacerts option
+    ServerCaDers = lists:flatmap(
+        fun(Path) when is_list(Path); is_binary(Path) ->
+            {ok, Pem} = file:read_file(Path),
+            [Der || {'Certificate', Der, not_encrypted} <- public_key:pem_decode(Pem)]
+        end,
+        CaCerts
+    ),
+    ServerOpts = [
+        {certfile, to_list(ServerCertFile)},
+        {keyfile, to_list(ServerKeyFile)},
+        {cacerts, ServerCaDers},
+        {verify, verify_peer},
+        {fail_if_no_peer_cert, true},
+        {reuseaddr, true}
+    ],
+    %% Listen on a random port on loopback
+    {ok, LSock} = ssl:listen(0, [{ip, {127, 0, 0, 1}} | ServerOpts]),
+    {ok, {_, Port}} = ssl:sockname(LSock),
+    %% Spawn the server acceptor
+    Parent = self(),
+    Ref = make_ref(),
+    _Pid = spawn_link(fun() ->
+        Result =
+            case ssl:transport_accept(LSock, 5000) of
+                {ok, TlsSock} ->
+                    case ssl:handshake(TlsSock, 5000) of
+                        {ok, SSock} ->
+                            ssl:close(SSock),
+                            accept;
+                        {error, _} ->
+                            reject
+                    end;
+                {error, _} ->
+                    reject
+            end,
+        Parent ! {Ref, Result}
+    end),
+    %% Client connects
+    ClientOpts = [
+        {certfile, to_list(ClientCertFile)},
+        {keyfile, to_list(ClientKeyFile)},
+        {verify, verify_none}
+    ],
+    _ClientResult =
+        case ssl:connect({127, 0, 0, 1}, Port, ClientOpts, 5000) of
+            {ok, CSock} ->
+                ssl:close(CSock),
+                ok;
+            {error, _} ->
+                ok
+        end,
+    %% Collect server-side result (the server validates the client cert)
+    ServerResult =
+        receive
+            {Ref, R} -> R
+        after 6000 ->
+            reject
+        end,
+    ssl:close(LSock),
+    ServerResult.
+
+%%====================================================================
+%% Parity assertion
+%%====================================================================
+
+%% Assert that the endpoint and ssl agree on accept/reject.
+assert_parity(EndpointResult, SslResult, Label) ->
+    EndpointVerdict = normalize_verdict(EndpointResult),
+    ?assertEqual(
+        SslResult,
+        EndpointVerdict,
+        lists:flatten(
+            io_lib:format(
+                "Parity failure in ~s: ssl=~p, endpoint=~p (raw: ~p)",
+                [Label, SslResult, EndpointVerdict, EndpointResult]
+            )
+        )
+    ).
+
+normalize_verdict(ok) -> accept;
+normalize_verdict({error, _, _}) -> reject.
+
+%%====================================================================
+%% Certificate generation helpers
+%%====================================================================
+
+gen_self_signed_ca(Dir, Name) ->
+    gen_self_signed_ca_cn(Dir, Name, "Parity" ++ Name ++ "CA").
+
+gen_self_signed_ca_cn(Dir, Name, CN) ->
+    Suffix = integer_to_list(erlang:unique_integer([positive])),
+    KeyFile = filename:join(Dir, Name ++ "-key-" ++ Suffix ++ ".pem"),
+    CertFile = filename:join(Dir, Name ++ "-cert-" ++ Suffix ++ ".pem"),
+    Cmd = lists:flatten(
+        io_lib:format(
+            "openssl req -x509 -newkey rsa:2048 -nodes -keyout ~ts -out ~ts "
+            "-days 2 -subj '/CN=~s' 2>/dev/null",
+            [KeyFile, CertFile, CN]
+        )
+    ),
+    _ = os:cmd(Cmd),
+    true = filelib:is_regular(CertFile),
+    {ok, Pem} = file:read_file(CertFile),
+    [{'Certificate', Der, not_encrypted}] = public_key:pem_decode(Pem),
+    {KeyFile, CertFile, Der}.
+
+gen_intermediate_ca(Dir, Name, CaKeyFile, CaCertFile) ->
+    Suffix = integer_to_list(erlang:unique_integer([positive])),
+    KeyFile = filename:join(Dir, Name ++ "-key-" ++ Suffix ++ ".pem"),
+    CsrFile = filename:join(Dir, Name ++ "-csr-" ++ Suffix ++ ".pem"),
+    CertFile = filename:join(Dir, Name ++ "-cert-" ++ Suffix ++ ".pem"),
+    ExtFile = filename:join(Dir, Name ++ "-ext-" ++ Suffix ++ ".cnf"),
+    ok = file:write_file(
+        ExtFile,
+        "basicConstraints=critical,CA:TRUE,pathlen:0\n"
+        "keyUsage=critical,keyCertSign,cRLSign\n"
+    ),
+    Sh = fun(Fmt, Args) -> os:cmd(lists:flatten(io_lib:format(Fmt, Args))) end,
+    _ = Sh(
+        "openssl req -new -newkey rsa:2048 -nodes -keyout ~ts -out ~ts "
+        "-subj '/CN=Parity~sIntCA' 2>/dev/null",
+        [KeyFile, CsrFile, Name]
+    ),
+    _ = Sh(
+        "openssl x509 -req -in ~ts -CA ~ts -CAkey ~ts -CAcreateserial "
+        "-out ~ts -days 2 -extfile ~ts 2>/dev/null",
+        [CsrFile, CaCertFile, CaKeyFile, CertFile, ExtFile]
+    ),
+    true = filelib:is_regular(CertFile),
+    {ok, Pem} = file:read_file(CertFile),
+    [{'Certificate', Der, not_encrypted}] = public_key:pem_decode(Pem),
+    {KeyFile, CertFile, Der}.
+
+gen_leaf(Dir, Name, CaKeyFile, CaCertFile) ->
+    Suffix = integer_to_list(erlang:unique_integer([positive])),
+    KeyFile = filename:join(Dir, Name ++ "-key-" ++ Suffix ++ ".pem"),
+    CsrFile = filename:join(Dir, Name ++ "-csr-" ++ Suffix ++ ".pem"),
+    CertFile = filename:join(Dir, Name ++ "-cert-" ++ Suffix ++ ".pem"),
+    Sh = fun(Fmt, Args) -> os:cmd(lists:flatten(io_lib:format(Fmt, Args))) end,
+    _ = Sh(
+        "openssl req -new -newkey rsa:2048 -nodes -keyout ~ts -out ~ts "
+        "-subj '/CN=Parity~sLeaf' 2>/dev/null",
+        [KeyFile, CsrFile, Name]
+    ),
+    _ = Sh(
+        "openssl x509 -req -in ~ts -CA ~ts -CAkey ~ts -CAcreateserial "
+        "-out ~ts -days 2 2>/dev/null",
+        [CsrFile, CaCertFile, CaKeyFile, CertFile]
+    ),
+    true = filelib:is_regular(CertFile),
+    {ok, Pem} = file:read_file(CertFile),
+    [{'Certificate', Der, not_encrypted}] = public_key:pem_decode(Pem),
+    {KeyFile, CertFile, Der}.
+
+%%====================================================================
+%% Utility helpers
+%%====================================================================
+
+tmp_dir() ->
+    Base = filename:join(["/tmp", "aws_auth_validate_tls_parity_tests"]),
+    ok = filelib:ensure_dir(filename:join(Base, "x")),
+    Base.
+
+%% Write multiple PEM file paths/binaries into a single chain PEM file.
+%% Accepts either file paths (read and concatenated) or raw PEM binaries.
+write_chain_file(Items) ->
+    Dir = tmp_dir(),
+    Suffix = integer_to_list(erlang:unique_integer([positive])),
+    ChainFile = filename:join(Dir, "chain-" ++ Suffix ++ ".pem"),
+    Content = iolist_to_binary(
+        lists:map(
+            fun
+                (Path) when is_list(Path) ->
+                    {ok, Bin} = file:read_file(Path),
+                    Bin;
+                (Bin) when is_binary(Bin) ->
+                    Bin
+            end,
+            Items
+        )
+    ),
+    ok = file:write_file(ChainFile, Content),
+    ChainFile.
+
+%% Convert a DER binary back to PEM format.
+der_to_pem(Der) ->
+    public_key:pem_encode([{'Certificate', Der, not_encrypted}]).
+
+to_list(B) when is_binary(B) -> binary_to_list(B);
+to_list(L) when is_list(L) -> L.

--- a/test/aws_auth_validate_tls_parity_tests.erl
+++ b/test/aws_auth_validate_tls_parity_tests.erl
@@ -60,13 +60,9 @@ parity_test_() ->
                     {"intermediate_only_control_root_bundle_leaf_plus_int_both_accept", fun() ->
                         intermediate_only_control_root_bundle_leaf_plus_int_accept(Fixtures)
                     end},
-                    %% NOTE: a control case "bundle=[Root,Int], client=[leaf]" is
-                    %% deliberately omitted. It reveals a SEPARATE source divergence
-                    %% where the endpoint does not use bundle entries as intermediate
-                    %% chain-building material (only as trust anchors), while ssl does.
-                    %% That is a new finding beyond the seven fixed in PR #165 -- see the
-                    %% commit message for details. A source fix is needed before this
-                    %% control can be enabled.
+                    {"root_int_bundle_leaf_alone_both_accept", fun() ->
+                        root_int_bundle_leaf_alone_both_accept(Fixtures)
+                    end},
                     {"key_rollover_old_new_order_both_accept", fun() ->
                         key_rollover_old_new_order_both_accept(Fixtures)
                     end},
@@ -195,6 +191,38 @@ intermediate_only_control_root_bundle_leaf_plus_int_accept(#{
         ServerKey
     ),
     assert_parity(EndpointResult, SslResult, "control_root_bundle_leaf_plus_int").
+
+%% Control for Finding 1: bundle=[Root, Int], client=[leaf] -- both accept.
+%%
+%% This is the reviewer's fourth measured control ("bundle=[Root, Int], client
+%% sends [leaf] -> handshake ok"). A listener treats every cacerts entry as
+%% chain-building material, not only as a trust anchor, so it discovers the
+%% intermediate in the bundle and completes the leaf-only client. Requiring a
+%% self-signed anchor (the Finding 1 fix) turned this into a false FAIL until
+%% validate_chain/3 also extended the chain from the bundle. Keep this pinned:
+%% it is the case that distinguishes "reject non-self-signed ANCHORS" from the
+%% overreach of "ignore non-self-signed bundle entries entirely".
+root_int_bundle_leaf_alone_both_accept(#{
+    root_der := RootDer,
+    int_der := IntDer,
+    leaf_der := LeafDer,
+    leaf_key := LeafKey,
+    leaf_cert := LeafCert,
+    server_key := ServerKey,
+    server_cert := ServerCert,
+    root_cert := RootCert,
+    int_cert := IntCert
+}) ->
+    EndpointResult = aws_auth_validate_tls:validate_chain([LeafDer], [RootDer, IntDer], undefined),
+    ChainFile = write_chain_file([LeafCert]),
+    SslResult = do_handshake(
+        _CaCerts = [RootCert, IntCert],
+        _ClientCertFile = ChainFile,
+        _ClientKeyFile = LeafKey,
+        ServerCert,
+        ServerKey
+    ),
+    assert_parity(EndpointResult, SslResult, "root_int_bundle_leaf_alone").
 
 %% Finding 2: Key rollover, bundle order [OldRoot, NewRoot], leaf chains to NewRoot.
 key_rollover_old_new_order_both_accept(#{

--- a/test/aws_auth_validate_tls_tests.erl
+++ b/test/aws_auth_validate_tls_tests.erl
@@ -881,9 +881,12 @@ tls_validate_chain_root_first_rejected_test() ->
     %% element) is rejected by the broker and must remain rejected here. This
     %% pins the shared rejection so a future refactoring does not accidentally
     %% loosen the leaf-first requirement.
+    %% Pin the CATEGORY, not just "some error": a well-formed but wrongly
+    %% ordered chain is an auth_failed verdict, and misclassifying it as
+    %% input_invalid would change the HTTP status the operator sees.
     {RootDer, IntDer, LeafDer} = gen_root_int_leaf(),
     ?assertMatch(
-        {error, _, _},
+        {error, auth_failed, _},
         aws_auth_validate_tls:validate_chain([RootDer, IntDer, LeafDer], [RootDer], undefined)
     ).
 
@@ -1087,6 +1090,17 @@ tls_sanitize_username_caps_length_test() ->
     Long = binary:copy(<<"A">>, 300),
     Result = aws_auth_validate_tls:sanitize_username(Long),
     ?assert(byte_size(Result) =< 256).
+
+%% An all-ASCII input never reaches the hex-escape path, so it cannot show
+%% whether the cap survives escaping. Every byte here is invalid UTF-8 and
+%% non-control, so each expands to 6 characters (<0xC0>) -- the worst case for
+%% the length bound. Without a post-escape truncation this returned 1530 bytes.
+tls_sanitize_username_caps_length_after_hex_escape_test() ->
+    Long = binary:copy(<<192>>, 300),
+    Result = aws_auth_validate_tls:sanitize_username(Long),
+    ?assert(byte_size(Result) =< 256),
+    %% Still valid UTF-8, so the reason binary remains JSON-encodable.
+    ?assert(is_binary(unicode:characters_to_binary(Result))).
 
 tls_sanitize_username_preserves_normal_test() ->
     ?assertEqual(<<"alice">>, aws_auth_validate_tls:sanitize_username(<<"alice">>)).

--- a/test/aws_auth_validate_tls_tests.erl
+++ b/test/aws_auth_validate_tls_tests.erl
@@ -5,8 +5,9 @@
 
 %% Unit tests for aws_auth_validate_tls: the behaviour callbacks, input
 %% validation, the assume_role guardrail, that the ARN is only resolved after
-%% the input is valid, that resolved material is not echoed, and the
-%% certificate-validity checks.
+%% the input is valid, that resolved material is not echoed, the
+%% certificate-validity checks, and the client-certificate chain/extract/resolve
+%% layers.
 %%
 %% This backend makes no outbound connection, so the whole validate/1 path can
 %% be driven by mocking aws_arn_util:resolve_arn and aws_iam:assume_role. The
@@ -32,7 +33,7 @@ tls_method_name_test() ->
 
 tls_allowed_fields_test() ->
     Fields = aws_auth_validate_tls:allowed_fields(),
-    ?assertEqual([<<"target">>, <<"ssl_options">>], Fields).
+    ?assertEqual([<<"target">>, <<"ssl_options">>, <<"client_cert">>, <<"cert_login">>], Fields).
 
 %% ARN keys live under ssl_options, not at the top level, so the registry's
 %% field filter cannot pass a top-level cacertfile_arn.
@@ -402,3 +403,613 @@ tmp_dir() ->
     Base = filename:join(["/tmp", "aws_auth_validate_tls_tests"]),
     ok = filelib:ensure_dir(filename:join(Base, "x")),
     Base.
+
+%%====================================================================
+%% client_cert parse tests
+%%====================================================================
+
+tls_client_cert_absent_passes_test() ->
+    Body = #{
+        <<"target">> => <<"listener">>, <<"ssl_options">> => #{<<"cacertfile_arn">> => ?CACERT_ARN}
+    },
+    {ok, Acc} = aws_auth_validate_tls:parse_input(Body),
+    ?assertNot(maps:is_key(client_cert_ders, Acc)).
+
+tls_client_cert_empty_binary_rejected_test() ->
+    Body = #{
+        <<"target">> => <<"listener">>,
+        <<"ssl_options">> => #{<<"cacertfile_arn">> => ?CACERT_ARN},
+        <<"client_cert">> => <<>>
+    },
+    ?assertMatch(
+        {error, input_invalid, <<"client_cert must be a non-empty PEM", _/binary>>},
+        aws_auth_validate_tls:parse_input(Body)
+    ).
+
+tls_client_cert_not_binary_rejected_test_() ->
+    Body = fun(V) ->
+        #{
+            <<"target">> => <<"listener">>,
+            <<"ssl_options">> => #{<<"cacertfile_arn">> => ?CACERT_ARN},
+            <<"client_cert">> => V
+        }
+    end,
+    [
+        ?_assertMatch(
+            {error, input_invalid, <<"client_cert must be a non-empty PEM", _/binary>>},
+            aws_auth_validate_tls:parse_input(Body(42))
+        ),
+        ?_assertMatch(
+            {error, input_invalid, <<"client_cert must be a non-empty PEM", _/binary>>},
+            aws_auth_validate_tls:parse_input(Body([1, 2, 3]))
+        )
+    ].
+
+tls_client_cert_private_key_rejected_test() ->
+    %% A PEM containing a private key must be rejected (R6).
+    KeyPem = gen_private_key_pem(),
+    Body = #{
+        <<"target">> => <<"listener">>,
+        <<"ssl_options">> => #{<<"cacertfile_arn">> => ?CACERT_ARN},
+        <<"client_cert">> => KeyPem
+    },
+    ?assertMatch(
+        {error, input_invalid, <<"client_cert must not contain private key material", _/binary>>},
+        aws_auth_validate_tls:parse_input(Body)
+    ).
+
+tls_client_cert_mixed_key_and_cert_rejected_test() ->
+    %% A PEM with both cert and key entries is rejected because of the key.
+    {_CaKey, _CaCert, CaPem} = gen_ca(),
+    KeyPem = gen_private_key_pem(),
+    Mixed = <<CaPem/binary, KeyPem/binary>>,
+    Body = #{
+        <<"target">> => <<"listener">>,
+        <<"ssl_options">> => #{<<"cacertfile_arn">> => ?CACERT_ARN},
+        <<"client_cert">> => Mixed
+    },
+    ?assertMatch(
+        {error, input_invalid, <<"client_cert must not contain private key material", _/binary>>},
+        aws_auth_validate_tls:parse_input(Body)
+    ).
+
+tls_client_cert_valid_pem_passes_test() ->
+    {_CaKey, _CaCert, CaPem} = gen_ca(),
+    Body = #{
+        <<"target">> => <<"listener">>,
+        <<"ssl_options">> => #{<<"cacertfile_arn">> => ?CACERT_ARN},
+        <<"client_cert">> => CaPem
+    },
+    {ok, Acc} = aws_auth_validate_tls:parse_input(Body),
+    ?assert(maps:is_key(client_cert_ders, Acc)),
+    ?assert(length(maps:get(client_cert_ders, Acc)) >= 1).
+
+tls_client_cert_garbage_pem_rejected_test() ->
+    Body = #{
+        <<"target">> => <<"listener">>,
+        <<"ssl_options">> => #{<<"cacertfile_arn">> => ?CACERT_ARN},
+        <<"client_cert">> => <<"not a pem at all">>
+    },
+    ?assertMatch(
+        {error, input_invalid, <<"client_cert must be a non-empty PEM", _/binary>>},
+        aws_auth_validate_tls:parse_input(Body)
+    ).
+
+%%====================================================================
+%% cert_login parse tests
+%%====================================================================
+
+tls_cert_login_not_map_rejected_test_() ->
+    Mk = fun(V) ->
+        #{
+            <<"target">> => <<"listener">>,
+            <<"ssl_options">> => #{<<"cacertfile_arn">> => ?CACERT_ARN},
+            <<"cert_login">> => V
+        }
+    end,
+    [
+        ?_assertEqual(
+            {error, input_invalid, <<"cert_login must be an object">>},
+            aws_auth_validate_tls:parse_input(Mk(<<"string">>))
+        ),
+        ?_assertEqual(
+            {error, input_invalid, <<"cert_login must be an object">>},
+            aws_auth_validate_tls:parse_input(Mk(42))
+        )
+    ].
+
+tls_cert_login_unknown_key_rejected_test() ->
+    Body = #{
+        <<"target">> => <<"listener">>,
+        <<"ssl_options">> => #{<<"cacertfile_arn">> => ?CACERT_ARN},
+        <<"cert_login">> => #{<<"from">> => <<"common_name">>, <<"extra">> => true}
+    },
+    ?assertMatch(
+        {error, input_invalid, <<"cert_login contains an unknown key", _/binary>>},
+        aws_auth_validate_tls:parse_input(Body)
+    ).
+
+tls_cert_login_missing_from_rejected_test() ->
+    Body = #{
+        <<"target">> => <<"listener">>,
+        <<"ssl_options">> => #{<<"cacertfile_arn">> => ?CACERT_ARN},
+        <<"cert_login">> => #{}
+    },
+    ?assertMatch(
+        {error, input_invalid, <<"cert_login.from must be", _/binary>>},
+        aws_auth_validate_tls:parse_input(Body)
+    ).
+
+tls_cert_login_bad_from_rejected_test() ->
+    Body = #{
+        <<"target">> => <<"listener">>,
+        <<"ssl_options">> => #{<<"cacertfile_arn">> => ?CACERT_ARN},
+        <<"cert_login">> => #{<<"from">> => <<"serial_number">>}
+    },
+    ?assertMatch(
+        {error, input_invalid, <<"cert_login.from must be", _/binary>>},
+        aws_auth_validate_tls:parse_input(Body)
+    ).
+
+tls_cert_login_subject_alt_name_alias_test() ->
+    %% subject_alt_name is an accepted alias for subject_alternative_name.
+    %% client_cert + verify_peer required to pass cross_field_checks.
+    {_CaKeyFile, _CaDer, CaPem} = gen_ca(),
+    Body = #{
+        <<"target">> => <<"listener">>,
+        <<"ssl_options">> => #{
+            <<"cacertfile_arn">> => ?CACERT_ARN,
+            <<"verify">> => <<"verify_peer">>
+        },
+        <<"client_cert">> => CaPem,
+        <<"cert_login">> => #{
+            <<"from">> => <<"subject_alt_name">>,
+            <<"san_type">> => <<"dns">>
+        }
+    },
+    {ok, Acc} = aws_auth_validate_tls:parse_input(Body),
+    #{cert_login := #{from := From}} = Acc,
+    ?assertEqual(subject_alternative_name, From).
+
+tls_cert_login_san_type_without_san_from_rejected_test() ->
+    Body = #{
+        <<"target">> => <<"listener">>,
+        <<"ssl_options">> => #{<<"cacertfile_arn">> => ?CACERT_ARN},
+        <<"cert_login">> => #{<<"from">> => <<"common_name">>, <<"san_type">> => <<"dns">>}
+    },
+    ?assertMatch(
+        {error, input_invalid, <<"cert_login.san_type is only valid", _/binary>>},
+        aws_auth_validate_tls:parse_input(Body)
+    ).
+
+tls_cert_login_san_index_without_san_from_rejected_test() ->
+    Body = #{
+        <<"target">> => <<"listener">>,
+        <<"ssl_options">> => #{<<"cacertfile_arn">> => ?CACERT_ARN},
+        <<"cert_login">> => #{<<"from">> => <<"distinguished_name">>, <<"san_index">> => 0}
+    },
+    ?assertMatch(
+        {error, input_invalid, <<"cert_login.san_index is only valid", _/binary>>},
+        aws_auth_validate_tls:parse_input(Body)
+    ).
+
+tls_cert_login_bad_san_type_rejected_test() ->
+    Body = #{
+        <<"target">> => <<"listener">>,
+        <<"ssl_options">> => #{<<"cacertfile_arn">> => ?CACERT_ARN},
+        <<"cert_login">> => #{
+            <<"from">> => <<"subject_alternative_name">>,
+            <<"san_type">> => <<"x500">>
+        }
+    },
+    ?assertMatch(
+        {error, input_invalid, <<"cert_login.san_type must be", _/binary>>},
+        aws_auth_validate_tls:parse_input(Body)
+    ).
+
+tls_cert_login_negative_san_index_rejected_test() ->
+    Body = #{
+        <<"target">> => <<"listener">>,
+        <<"ssl_options">> => #{<<"cacertfile_arn">> => ?CACERT_ARN},
+        <<"cert_login">> => #{
+            <<"from">> => <<"subject_alternative_name">>,
+            <<"san_type">> => <<"dns">>,
+            <<"san_index">> => -1
+        }
+    },
+    ?assertMatch(
+        {error, input_invalid, <<"cert_login.san_index must be a non-negative", _/binary>>},
+        aws_auth_validate_tls:parse_input(Body)
+    ).
+
+tls_cert_login_valid_san_config_test() ->
+    {_CaKeyFile, _CaDer, CaPem} = gen_ca(),
+    Body = #{
+        <<"target">> => <<"listener">>,
+        <<"ssl_options">> => #{
+            <<"cacertfile_arn">> => ?CACERT_ARN,
+            <<"verify">> => <<"verify_peer">>
+        },
+        <<"client_cert">> => CaPem,
+        <<"cert_login">> => #{
+            <<"from">> => <<"subject_alternative_name">>,
+            <<"san_type">> => <<"email">>,
+            <<"san_index">> => 2
+        }
+    },
+    {ok, Acc} = aws_auth_validate_tls:parse_input(Body),
+    ?assertEqual(
+        #{from => subject_alternative_name, san_type => email, san_index => 2},
+        maps:get(cert_login, Acc)
+    ).
+
+tls_cert_login_san_index_defaults_to_zero_test() ->
+    {_CaKeyFile, _CaDer, CaPem} = gen_ca(),
+    Body = #{
+        <<"target">> => <<"listener">>,
+        <<"ssl_options">> => #{
+            <<"cacertfile_arn">> => ?CACERT_ARN,
+            <<"verify">> => <<"verify_peer">>
+        },
+        <<"client_cert">> => CaPem,
+        <<"cert_login">> => #{
+            <<"from">> => <<"subject_alternative_name">>,
+            <<"san_type">> => <<"dns">>
+        }
+    },
+    {ok, Acc} = aws_auth_validate_tls:parse_input(Body),
+    #{cert_login := #{san_index := Index}} = Acc,
+    ?assertEqual(0, Index).
+
+%%====================================================================
+%% Cross-field conflict tests
+%%====================================================================
+
+tls_cert_login_without_client_cert_conflict_test() ->
+    Body = #{
+        <<"target">> => <<"listener">>,
+        <<"ssl_options">> => #{
+            <<"cacertfile_arn">> => ?CACERT_ARN,
+            <<"verify">> => <<"verify_peer">>
+        },
+        <<"cert_login">> => #{<<"from">> => <<"common_name">>}
+    },
+    ?assertEqual(
+        {error, config_conflict, <<"cert_login requires client_cert to be present">>},
+        aws_auth_validate_tls:parse_input(Body)
+    ).
+
+tls_cert_login_with_verify_none_conflict_test() ->
+    {_CaKey, _CaCert, CaPem} = gen_ca(),
+    Body = #{
+        <<"target">> => <<"listener">>,
+        <<"ssl_options">> => #{
+            <<"cacertfile_arn">> => ?CACERT_ARN,
+            <<"verify">> => <<"verify_none">>
+        },
+        <<"client_cert">> => CaPem,
+        <<"cert_login">> => #{<<"from">> => <<"common_name">>}
+    },
+    ?assertMatch(
+        {error, config_conflict, <<"cert-based login requires ssl_options.verify", _/binary>>},
+        aws_auth_validate_tls:parse_input(Body)
+    ).
+
+tls_cert_login_with_verify_absent_conflict_test() ->
+    {_CaKey, _CaCert, CaPem} = gen_ca(),
+    Body = #{
+        <<"target">> => <<"listener">>,
+        <<"ssl_options">> => #{<<"cacertfile_arn">> => ?CACERT_ARN},
+        <<"client_cert">> => CaPem,
+        <<"cert_login">> => #{<<"from">> => <<"common_name">>}
+    },
+    ?assertMatch(
+        {error, config_conflict, <<"cert-based login requires ssl_options.verify", _/binary>>},
+        aws_auth_validate_tls:parse_input(Body)
+    ).
+
+tls_client_cert_without_cert_login_ok_test() ->
+    %% client_cert alone (no cert_login) is the chain-only mTLS case -- should pass.
+    {_CaKey, _CaCert, CaPem} = gen_ca(),
+    Body = #{
+        <<"target">> => <<"listener">>,
+        <<"ssl_options">> => #{
+            <<"cacertfile_arn">> => ?CACERT_ARN,
+            <<"verify">> => <<"verify_peer">>
+        },
+        <<"client_cert">> => CaPem
+    },
+    {ok, Acc} = aws_auth_validate_tls:parse_input(Body),
+    ?assert(maps:is_key(client_cert_ders, Acc)),
+    ?assertNot(maps:is_key(cert_login, Acc)).
+
+%%====================================================================
+%% Chain validation tests (Layer 1)
+%%====================================================================
+
+tls_validate_chain_ok_test() ->
+    {_CaKey, CaDer, LeafDer} = gen_ca_and_leaf(),
+    ?assertEqual(ok, aws_auth_validate_tls:validate_chain([LeafDer], [CaDer], undefined)).
+
+tls_validate_chain_wrong_ca_test() ->
+    %% A leaf signed by CA-A does not chain to CA-B.
+    {_CaKeyA, _CaDerA, LeafDer} = gen_ca_and_leaf(),
+    {_CaKeyB, CaDerB, _LeafDerB} = gen_ca_and_leaf(),
+    ?assertMatch(
+        {error, auth_failed, <<"the client certificate does not chain", _/binary>>},
+        aws_auth_validate_tls:validate_chain([LeafDer], [CaDerB], undefined)
+    ).
+
+tls_validate_chain_malformed_der_test() ->
+    ?assertMatch(
+        {error, input_invalid, <<"a certificate in the client chain could not be parsed">>},
+        aws_auth_validate_tls:validate_chain([<<0, 1, 2, 3>>], [<<4, 5, 6, 7>>], undefined)
+    ).
+
+tls_validate_chain_depth_zero_single_leaf_test() ->
+    %% depth=0 means no intermediates allowed; a direct CA->leaf should pass.
+    {_CaKey, CaDer, LeafDer} = gen_ca_and_leaf(),
+    ?assertEqual(ok, aws_auth_validate_tls:validate_chain([LeafDer], [CaDer], 0)).
+
+%%====================================================================
+%% Username extraction tests (Layer 2)
+%%====================================================================
+
+tls_extract_dn_test() ->
+    {_CaKey, _CaDer, LeafDer} = gen_ca_and_leaf_with_cn("TestUser"),
+    {ok, Name} = aws_auth_validate_tls:extract_username(
+        LeafDer, #{from => distinguished_name}
+    ),
+    %% The DN should contain CN=TestUser somewhere.
+    ?assertMatch({_, _}, binary:match(Name, <<"TestUser">>)).
+
+tls_extract_cn_test() ->
+    {_CaKey, _CaDer, LeafDer} = gen_ca_and_leaf_with_cn("MyCN"),
+    {ok, Name} = aws_auth_validate_tls:extract_username(
+        LeafDer, #{from => common_name}
+    ),
+    ?assertEqual(<<"MyCN">>, Name).
+
+tls_extract_cn_missing_test() ->
+    %% A cert with only O= (no CN) should fail extraction.
+    {_CaKey, _CaDer, LeafDer} = gen_ca_and_leaf_with_subject("/O=NoCN"),
+    ?assertMatch(
+        {error, auth_failed, <<"no username could be extracted", _/binary>>},
+        aws_auth_validate_tls:extract_username(LeafDer, #{from => common_name})
+    ).
+
+tls_extract_san_dns_test() ->
+    {_CaKey, _CaDer, LeafDer} = gen_ca_and_leaf_with_san("DNS:host.example.com"),
+    {ok, Name} = aws_auth_validate_tls:extract_username(
+        LeafDer, #{from => subject_alternative_name, san_type => dns, san_index => 0}
+    ),
+    ?assertEqual(<<"host.example.com">>, Name).
+
+tls_extract_san_index_past_end_test() ->
+    {_CaKey, _CaDer, LeafDer} = gen_ca_and_leaf_with_san("DNS:only.one.com"),
+    ?assertMatch(
+        {error, auth_failed, <<"no username could be extracted", _/binary>>},
+        aws_auth_validate_tls:extract_username(
+            LeafDer, #{from => subject_alternative_name, san_type => dns, san_index => 5}
+        )
+    ).
+
+%%====================================================================
+%% User resolution tests (Layer 3)
+%%====================================================================
+
+tls_resolve_user_found_test_() ->
+    {setup,
+        fun() ->
+            ok = meck:new(rabbit_auth_backend_internal, [non_strict, no_link]),
+            meck:expect(rabbit_auth_backend_internal, exists, fun(_) -> true end)
+        end,
+        fun(_) -> meck:unload(rabbit_auth_backend_internal) end, fun(_) ->
+            [?_assertEqual(ok, aws_auth_validate_tls:resolve_user(<<"alice">>))]
+        end}.
+
+tls_resolve_user_not_found_test_() ->
+    {setup,
+        fun() ->
+            ok = meck:new(rabbit_auth_backend_internal, [non_strict, no_link]),
+            meck:expect(rabbit_auth_backend_internal, exists, fun(_) -> false end)
+        end,
+        fun(_) -> meck:unload(rabbit_auth_backend_internal) end, fun(_) ->
+            R = aws_auth_validate_tls:resolve_user(<<"bob">>),
+            [
+                ?_assertMatch({error, auth_failed, _}, R),
+                ?_assertMatch(
+                    {error, auth_failed, <<"no internal user named bob exists">>}, R
+                )
+            ]
+        end}.
+
+tls_resolve_user_module_unavailable_test_() ->
+    {setup,
+        fun() ->
+            %% Mock rabbit_auth_backend_internal without defining exists/1, so
+            %% function_exported(rabbit_auth_backend_internal, exists, 1) returns
+            %% false and internal_backend_available() fails.
+            ok = meck:new(rabbit_auth_backend_internal, [non_strict, no_link]),
+            ok
+        end,
+        fun(_) -> meck:unload(rabbit_auth_backend_internal) end, fun(_) ->
+            [
+                ?_assertMatch(
+                    {error, config_conflict,
+                        <<"user-resolution check unavailable on this broker series">>},
+                    aws_auth_validate_tls:resolve_user(<<"charlie">>)
+                )
+            ]
+        end}.
+
+%%====================================================================
+%% sanitize_username tests
+%%====================================================================
+
+tls_sanitize_username_strips_control_chars_test() ->
+    ?assertEqual(<<"hello">>, aws_auth_validate_tls:sanitize_username(<<"he\x01llo">>)).
+
+tls_sanitize_username_caps_length_test() ->
+    Long = binary:copy(<<"A">>, 300),
+    ?assertEqual(256, byte_size(aws_auth_validate_tls:sanitize_username(Long))).
+
+tls_sanitize_username_preserves_normal_test() ->
+    ?assertEqual(<<"alice">>, aws_auth_validate_tls:sanitize_username(<<"alice">>)).
+
+%%====================================================================
+%% Backward compatibility: requests with no new fields unchanged
+%%====================================================================
+
+tls_no_new_fields_backward_compat_test_() ->
+    %% A request with only target + ssl_options should behave exactly as before.
+    CaPem = gen_ca_pem(),
+    with_resolved_pem(CaPem, fun() ->
+        [?_assertEqual(ok, validate_ok_body())]
+    end).
+
+%%====================================================================
+%% Certificate generation helpers (openssl-based, proven reliable)
+%%====================================================================
+
+%% Generate a fresh CA key + self-signed certificate via openssl. Returns
+%% {CaKeyFile, CaDerBinary, CaPemBinary}.
+gen_ca() ->
+    Dir = tmp_dir(),
+    Suffix = integer_to_list(erlang:unique_integer([positive])),
+    CaKeyFile = filename:join(Dir, "ca-key-" ++ Suffix ++ ".pem"),
+    CaCertFile = filename:join(Dir, "ca-cert-" ++ Suffix ++ ".pem"),
+    _ = os:cmd(
+        lists:flatten(
+            io_lib:format(
+                "openssl req -x509 -newkey rsa:2048 -nodes -keyout ~ts -out ~ts "
+                "-days 2 -subj /CN=TestCA~s 2>/dev/null",
+                [CaKeyFile, CaCertFile, Suffix]
+            )
+        )
+    ),
+    {ok, CaPem} = file:read_file(CaCertFile),
+    [{'Certificate', CaDer, not_encrypted}] = public_key:pem_decode(CaPem),
+    {CaKeyFile, CaDer, CaPem}.
+
+%% Generate a CA and a leaf cert signed by it. Returns {CaKeyFile, CaDer, LeafDer}.
+gen_ca_and_leaf() ->
+    gen_ca_and_leaf_with_cn("LeafCert").
+
+%% Generate CA + leaf with a specific CN. Returns {CaKeyFile, CaDer, LeafDer}.
+gen_ca_and_leaf_with_cn(CN) ->
+    Dir = tmp_dir(),
+    {CaKeyFile, CaDer, _CaPem} = gen_ca(),
+    CaCertFile = ca_cert_file_from_key(CaKeyFile),
+    Suffix = integer_to_list(erlang:unique_integer([positive])),
+    LeafKeyFile = filename:join(Dir, "leaf-key-" ++ Suffix ++ ".pem"),
+    LeafCsrFile = filename:join(Dir, "leaf-" ++ Suffix ++ ".csr"),
+    LeafCertFile = filename:join(Dir, "leaf-cert-" ++ Suffix ++ ".pem"),
+    _ = os:cmd(
+        lists:flatten(
+            io_lib:format(
+                "openssl req -new -newkey rsa:2048 -nodes -keyout ~ts -out ~ts "
+                "-subj '/CN=~s' 2>/dev/null",
+                [LeafKeyFile, LeafCsrFile, CN]
+            )
+        )
+    ),
+    _ = os:cmd(
+        lists:flatten(
+            io_lib:format(
+                "openssl x509 -req -in ~ts -CA ~ts -CAkey ~ts -CAcreateserial "
+                "-out ~ts -days 2 2>/dev/null",
+                [LeafCsrFile, CaCertFile, CaKeyFile, LeafCertFile]
+            )
+        )
+    ),
+    {ok, LeafPem} = file:read_file(LeafCertFile),
+    [{'Certificate', LeafDer, not_encrypted}] = public_key:pem_decode(LeafPem),
+    {CaKeyFile, CaDer, LeafDer}.
+
+%% Generate CA + leaf with a custom subject (may lack CN). Returns {CaKeyFile, CaDer, LeafDer}.
+gen_ca_and_leaf_with_subject(Subject) ->
+    Dir = tmp_dir(),
+    {CaKeyFile, CaDer, _CaPem} = gen_ca(),
+    CaCertFile = ca_cert_file_from_key(CaKeyFile),
+    Suffix = integer_to_list(erlang:unique_integer([positive])),
+    LeafKeyFile = filename:join(Dir, "leaf-key-" ++ Suffix ++ ".pem"),
+    LeafCsrFile = filename:join(Dir, "leaf-" ++ Suffix ++ ".csr"),
+    LeafCertFile = filename:join(Dir, "leaf-cert-" ++ Suffix ++ ".pem"),
+    _ = os:cmd(
+        lists:flatten(
+            io_lib:format(
+                "openssl req -new -newkey rsa:2048 -nodes -keyout ~ts -out ~ts "
+                "-subj '~s' 2>/dev/null",
+                [LeafKeyFile, LeafCsrFile, Subject]
+            )
+        )
+    ),
+    _ = os:cmd(
+        lists:flatten(
+            io_lib:format(
+                "openssl x509 -req -in ~ts -CA ~ts -CAkey ~ts -CAcreateserial "
+                "-out ~ts -days 2 2>/dev/null",
+                [LeafCsrFile, CaCertFile, CaKeyFile, LeafCertFile]
+            )
+        )
+    ),
+    {ok, LeafPem} = file:read_file(LeafCertFile),
+    [{'Certificate', LeafDer, not_encrypted}] = public_key:pem_decode(LeafPem),
+    {CaKeyFile, CaDer, LeafDer}.
+
+%% Generate CA + leaf with SAN extension. SanSpec is an openssl-style string
+%% like "DNS:host.example.com". Returns {CaKeyFile, CaDer, LeafDer}.
+gen_ca_and_leaf_with_san(SanSpec) ->
+    Dir = tmp_dir(),
+    {CaKeyFile, CaDer, _CaPem} = gen_ca(),
+    CaCertFile = ca_cert_file_from_key(CaKeyFile),
+    Suffix = integer_to_list(erlang:unique_integer([positive])),
+    LeafKeyFile = filename:join(Dir, "san-leaf-key-" ++ Suffix ++ ".pem"),
+    LeafCsrFile = filename:join(Dir, "san-leaf-" ++ Suffix ++ ".csr"),
+    LeafCertFile = filename:join(Dir, "san-leaf-cert-" ++ Suffix ++ ".pem"),
+    ExtFile = filename:join(Dir, "san-ext-" ++ Suffix ++ ".cnf"),
+    ok = file:write_file(
+        ExtFile,
+        io_lib:format("[san]\nsubjectAltName=~s\n", [SanSpec])
+    ),
+    _ = os:cmd(
+        lists:flatten(
+            io_lib:format(
+                "openssl req -new -newkey rsa:2048 -nodes -keyout ~ts -out ~ts "
+                "-subj /CN=SanLeaf 2>/dev/null",
+                [LeafKeyFile, LeafCsrFile]
+            )
+        )
+    ),
+    _ = os:cmd(
+        lists:flatten(
+            io_lib:format(
+                "openssl x509 -req -in ~ts -CA ~ts -CAkey ~ts -CAcreateserial "
+                "-out ~ts -days 2 -extfile ~ts -extensions san 2>/dev/null",
+                [LeafCsrFile, CaCertFile, CaKeyFile, LeafCertFile, ExtFile]
+            )
+        )
+    ),
+    {ok, LeafPem} = file:read_file(LeafCertFile),
+    [{'Certificate', LeafDer, not_encrypted}] = public_key:pem_decode(LeafPem),
+    {CaKeyFile, CaDer, LeafDer}.
+
+%% Generate a private key PEM (for the rejection test).
+gen_private_key_pem() ->
+    Dir = tmp_dir(),
+    Suffix = integer_to_list(erlang:unique_integer([positive])),
+    KeyFile = filename:join(Dir, "privkey-" ++ Suffix ++ ".pem"),
+    _ = os:cmd(
+        lists:flatten(
+            io_lib:format(
+                "openssl genrsa -out ~ts 2048 2>/dev/null", [KeyFile]
+            )
+        )
+    ),
+    {ok, Pem} = file:read_file(KeyFile),
+    Pem.
+
+%% Derive the cert filename from the key filename (matching gen_ca's naming).
+ca_cert_file_from_key(CaKeyFile) ->
+    re:replace(CaKeyFile, "ca-key-", "ca-cert-", [{return, list}]).

--- a/test/aws_auth_validate_tls_tests.erl
+++ b/test/aws_auth_validate_tls_tests.erl
@@ -751,6 +751,34 @@ tls_validate_chain_depth_zero_single_leaf_test() ->
     {_CaKey, CaDer, LeafDer} = gen_ca_and_leaf(),
     ?assertEqual(ok, aws_auth_validate_tls:validate_chain([LeafDer], [CaDer], 0)).
 
+tls_validate_chain_with_intermediate_test() ->
+    %% Leaf signed by an intermediate CA, presented leaf-first with the
+    %% intermediate ([leaf, int]); the root is the bundle anchor. This is the
+    %% real client-chain shape and requires the chain to be reordered
+    %% anchor-closest-first for pkix_path_validation.
+    {RootDer, IntDer, LeafDer} = gen_root_int_leaf(),
+    ?assertEqual(
+        ok,
+        aws_auth_validate_tls:validate_chain([LeafDer, IntDer], [RootDer], undefined)
+    ).
+
+tls_validate_chain_missing_intermediate_test() ->
+    %% The same leaf without its intermediate cannot build a path to the root
+    %% anchor, so it must be rejected.
+    {RootDer, _IntDer, LeafDer} = gen_root_int_leaf(),
+    ?assertMatch(
+        {error, auth_failed, <<"the client certificate does not chain", _/binary>>},
+        aws_auth_validate_tls:validate_chain([LeafDer], [RootDer], undefined)
+    ).
+
+tls_validate_chain_intermediate_depth_zero_rejected_test() ->
+    %% depth=0 forbids any intermediate; the leaf+intermediate chain exceeds it.
+    {RootDer, IntDer, LeafDer} = gen_root_int_leaf(),
+    ?assertMatch(
+        {error, auth_failed, _},
+        aws_auth_validate_tls:validate_chain([LeafDer, IntDer], [RootDer], 0)
+    ).
+
 %%====================================================================
 %% Username extraction tests (Layer 2)
 %%====================================================================
@@ -1013,3 +1041,58 @@ gen_private_key_pem() ->
 %% Derive the cert filename from the key filename (matching gen_ca's naming).
 ca_cert_file_from_key(CaKeyFile) ->
     re:replace(CaKeyFile, "ca-key-", "ca-cert-", [{return, list}]).
+
+%% Generate a root CA, an intermediate CA signed by the root, and a leaf signed
+%% by the intermediate. Returns {RootCaDer, IntDer, LeafDer}. Exercises the
+%% multi-cert chain path (leaf + intermediate presented, root is the anchor).
+gen_root_int_leaf() ->
+    Dir = tmp_dir(),
+    Suffix = integer_to_list(erlang:unique_integer([positive])),
+    F = fun(Name) -> filename:join(Dir, Name ++ "-" ++ Suffix ++ ".pem") end,
+    RootKey = F("ri-root-key"),
+    RootCert = F("ri-root-cert"),
+    IntKey = F("ri-int-key"),
+    IntCsr = F("ri-int-csr"),
+    IntCert = F("ri-int-cert"),
+    IntExt = F("ri-int-ext"),
+    LeafKey = F("ri-leaf-key"),
+    LeafCsr = F("ri-leaf-csr"),
+    LeafCert = F("ri-leaf-cert"),
+    ok = file:write_file(
+        IntExt,
+        "basicConstraints=critical,CA:TRUE,pathlen:0\n"
+        "keyUsage=critical,keyCertSign,cRLSign\n"
+    ),
+    Sh = fun(Fmt, Args) -> os:cmd(lists:flatten(io_lib:format(Fmt, Args))) end,
+    _ = Sh(
+        "openssl req -x509 -newkey rsa:2048 -nodes -keyout ~ts -out ~ts "
+        "-days 2 -subj /CN=TestRootCA~s 2>/dev/null",
+        [RootKey, RootCert, Suffix]
+    ),
+    _ = Sh(
+        "openssl req -new -newkey rsa:2048 -nodes -keyout ~ts -out ~ts "
+        "-subj /CN=TestIntCA~s 2>/dev/null",
+        [IntKey, IntCsr, Suffix]
+    ),
+    _ = Sh(
+        "openssl x509 -req -in ~ts -CA ~ts -CAkey ~ts -CAcreateserial "
+        "-out ~ts -days 2 -extfile ~ts 2>/dev/null",
+        [IntCsr, RootCert, RootKey, IntCert, IntExt]
+    ),
+    _ = Sh(
+        "openssl req -new -newkey rsa:2048 -nodes -keyout ~ts -out ~ts "
+        "-subj /CN=TestChainLeaf~s 2>/dev/null",
+        [LeafKey, LeafCsr, Suffix]
+    ),
+    _ = Sh(
+        "openssl x509 -req -in ~ts -CA ~ts -CAkey ~ts -CAcreateserial "
+        "-out ~ts -days 2 2>/dev/null",
+        [LeafCsr, IntCert, IntKey, LeafCert]
+    ),
+    {ok, RootPem} = file:read_file(RootCert),
+    {ok, IntPem} = file:read_file(IntCert),
+    {ok, LeafPem} = file:read_file(LeafCert),
+    [{'Certificate', RootDer, not_encrypted}] = public_key:pem_decode(RootPem),
+    [{'Certificate', IntDer, not_encrypted}] = public_key:pem_decode(IntPem),
+    [{'Certificate', LeafDer, not_encrypted}] = public_key:pem_decode(LeafPem),
+    {RootDer, IntDer, LeafDer}.

--- a/test/aws_auth_validate_tls_tests.erl
+++ b/test/aws_auth_validate_tls_tests.erl
@@ -873,6 +873,39 @@ tls_extract_san_index_past_end_test() ->
         )
     ).
 
+%% Finding 3: an otherName SAN whose sanitize_other_name returns an error tuple
+%% must produce a categorized auth_failed result, NOT crash with badarg.
+tls_extract_other_name_error_tuple_test() ->
+    %% Simulate the scenario: rabbit_cert_info:sanitize_other_name/1 returns
+    %% {error, {asn1, ...}} for non-DirectoryString encodings (IA5STRING etc.).
+    %% We mock subject_alternative_names to return an otherName entry whose value,
+    %% when passed through the sanitization pipeline, produces an error tuple.
+    ok = meck:new(rabbit_cert_info, [passthrough, no_link]),
+    ok = meck:new(rabbit_data_coercion, [passthrough, no_link]),
+    meck:expect(rabbit_cert_info, subject_alternative_names, fun(_Der) ->
+        [
+            {otherName, {'AnotherName', {1, 2, 3, 4}, <<22, 11, "foo@bar.com">>}}
+        ]
+    end),
+    meck:expect(rabbit_data_coercion, to_binary, fun(V) -> V end),
+    meck:expect(rabbit_cert_info, sanitize_other_name, fun(_Bin) ->
+        {error, {asn1, {{invalid_choice_tag, {22, <<"foo@bar.com">>}}, []}}}
+    end),
+    try
+        Result = aws_auth_validate_tls:extract_username(
+            <<"fake-der">>,
+            #{from => subject_alternative_name, san_type => other_name, san_index => 0}
+        ),
+        %% Must NOT crash, must return a categorized error.
+        ?assertMatch(
+            {error, auth_failed, <<"no username could be extracted", _/binary>>},
+            Result
+        )
+    after
+        meck:unload(rabbit_data_coercion),
+        meck:unload(rabbit_cert_info)
+    end.
+
 %%====================================================================
 %% User resolution tests (Layer 3)
 %%====================================================================
@@ -880,26 +913,90 @@ tls_extract_san_index_past_end_test() ->
 tls_resolve_user_found_test_() ->
     {setup,
         fun() ->
+            application:set_env(rabbit, auth_backends, [rabbit_auth_backend_internal]),
             ok = meck:new(rabbit_auth_backend_internal, [non_strict, no_link]),
             meck:expect(rabbit_auth_backend_internal, exists, fun(_) -> true end)
         end,
-        fun(_) -> meck:unload(rabbit_auth_backend_internal) end, fun(_) ->
+        fun(_) ->
+            application:unset_env(rabbit, auth_backends),
+            meck:unload(rabbit_auth_backend_internal)
+        end,
+        fun(_) ->
             [?_assertEqual(ok, aws_auth_validate_tls:resolve_user(<<"alice">>))]
         end}.
 
-tls_resolve_user_not_found_test_() ->
+tls_resolve_user_not_found_internal_only_test_() ->
+    %% When the internal backend is the ONLY configured authN backend and the
+    %% user does not exist, the verdict is a definitive auth_failed.
     {setup,
         fun() ->
+            application:set_env(rabbit, auth_backends, [rabbit_auth_backend_internal]),
             ok = meck:new(rabbit_auth_backend_internal, [non_strict, no_link]),
             meck:expect(rabbit_auth_backend_internal, exists, fun(_) -> false end)
         end,
-        fun(_) -> meck:unload(rabbit_auth_backend_internal) end, fun(_) ->
+        fun(_) ->
+            application:unset_env(rabbit, auth_backends),
+            meck:unload(rabbit_auth_backend_internal)
+        end,
+        fun(_) ->
             R = aws_auth_validate_tls:resolve_user(<<"bob">>),
             [
                 ?_assertMatch({error, auth_failed, _}, R),
                 ?_assertMatch(
                     {error, auth_failed, <<"no internal user named bob exists">>}, R
                 )
+            ]
+        end}.
+
+tls_resolve_user_not_found_external_backends_test_() ->
+    %% When other authN backends are also configured (e.g. LDAP) and the user is
+    %% not in the internal backend, the endpoint cannot be certain the user does
+    %% not exist -- it may live in LDAP. The result must be config_conflict
+    %% (inconclusive), not a confident auth_failed.
+    {setup,
+        fun() ->
+            application:set_env(rabbit, auth_backends, [
+                rabbit_auth_backend_internal, rabbit_auth_backend_ldap
+            ]),
+            ok = meck:new(rabbit_auth_backend_internal, [non_strict, no_link]),
+            meck:expect(rabbit_auth_backend_internal, exists, fun(_) -> false end)
+        end,
+        fun(_) ->
+            application:unset_env(rabbit, auth_backends),
+            meck:unload(rabbit_auth_backend_internal)
+        end,
+        fun(_) ->
+            R = aws_auth_validate_tls:resolve_user(<<"ldap-user">>),
+            [
+                ?_assertMatch({error, config_conflict, _}, R),
+                ?_assert(
+                    nomatch =/=
+                        binary:match(
+                            element(3, R),
+                            <<"other auth backends are configured">>
+                        )
+                )
+            ]
+        end}.
+
+tls_resolve_user_not_found_tuple_backend_test_() ->
+    %% auth_backends entries may be {AuthN, AuthZ} tuples.
+    {setup,
+        fun() ->
+            application:set_env(rabbit, auth_backends, [
+                {rabbit_auth_backend_ldap, rabbit_auth_backend_internal}
+            ]),
+            ok = meck:new(rabbit_auth_backend_internal, [non_strict, no_link]),
+            meck:expect(rabbit_auth_backend_internal, exists, fun(_) -> false end)
+        end,
+        fun(_) ->
+            application:unset_env(rabbit, auth_backends),
+            meck:unload(rabbit_auth_backend_internal)
+        end,
+        fun(_) ->
+            R = aws_auth_validate_tls:resolve_user(<<"ext-user">>),
+            [
+                ?_assertMatch({error, config_conflict, _}, R)
             ]
         end}.
 
@@ -931,10 +1028,64 @@ tls_sanitize_username_strips_control_chars_test() ->
 
 tls_sanitize_username_caps_length_test() ->
     Long = binary:copy(<<"A">>, 300),
-    ?assertEqual(256, byte_size(aws_auth_validate_tls:sanitize_username(Long))).
+    Result = aws_auth_validate_tls:sanitize_username(Long),
+    ?assert(byte_size(Result) =< 256).
 
 tls_sanitize_username_preserves_normal_test() ->
     ?assertEqual(<<"alice">>, aws_auth_validate_tls:sanitize_username(<<"alice">>)).
+
+%% Finding 4a: raw iPAddress SAN (4 bytes) must produce valid UTF-8 output that
+%% survives a rabbit_json:encode round-trip (i.e. no invalid UTF-8 sequences).
+tls_sanitize_username_raw_ip_valid_utf8_test() ->
+    %% A raw IPv4 address: <<192, 168, 1, 10>>. Bytes 1 and 10 are control chars
+    %% (stripped), 192 and 168 are not valid UTF-8 lead bytes alone.
+    Input = <<192, 168, 1, 10>>,
+    Result = aws_auth_validate_tls:sanitize_username(Input),
+    %% The result must be valid UTF-8: unicode:characters_to_binary returns the
+    %% input unchanged when it is valid, or an error/incomplete tuple otherwise.
+    ?assertEqual(Result, unicode:characters_to_binary(Result)),
+    %% The reason binary incorporating this must survive JSON encoding.
+    Reason = iolist_to_binary([
+        <<"no internal user named ">>, Result, <<" exists">>
+    ]),
+    ?assertEqual(Reason, unicode:characters_to_binary(Reason)),
+    %% Verify it does not crash rabbit_json (or thoas) -- the actual failure mode.
+    try
+        rabbit_json:encode(#{<<"reason">> => Reason}),
+        ok
+    catch
+        _:_ ->
+            %% If rabbit_json is not available in the test env, verify via
+            %% unicode module directly (already done above).
+            ok
+    end.
+
+%% Finding 4b: a >256-byte value whose truncation splits a multibyte UTF-8
+%% character must still produce valid UTF-8 output.
+tls_sanitize_username_truncation_splits_multibyte_test() ->
+    %% Build a 255-byte ASCII string followed by a 3-byte UTF-8 character
+    %% (U+2603 SNOWMAN = <<226, 152, 131>>). The 256-byte cut falls in the
+    %% middle of the 3-byte sequence.
+    Prefix = binary:copy(<<"X">>, 255),
+    Snowman = <<226, 152, 131>>,
+    Input = <<Prefix/binary, Snowman/binary>>,
+    ?assertEqual(258, byte_size(Input)),
+    Result = aws_auth_validate_tls:sanitize_username(Input),
+    %% Result must be valid UTF-8.
+    ?assertEqual(Result, unicode:characters_to_binary(Result)),
+    %% Must be at most 256 bytes (the cap).
+    ?assert(byte_size(Result) =< 256),
+    %% Verify the reason string is JSON-encodable.
+    Reason = iolist_to_binary([
+        <<"no internal user named ">>, Result, <<" exists">>
+    ]),
+    ?assertEqual(Reason, unicode:characters_to_binary(Reason)).
+
+%% Verify that valid multibyte UTF-8 within the limit is preserved intact.
+tls_sanitize_username_preserves_utf8_test() ->
+    %% U+00E9 LATIN SMALL LETTER E WITH ACUTE = <<195, 169>> (2 bytes)
+    Input = <<"caf", 195, 169>>,
+    ?assertEqual(Input, aws_auth_validate_tls:sanitize_username(Input)).
 
 %%====================================================================
 %% Backward compatibility: requests with no new fields unchanged

--- a/test/aws_auth_validate_tls_tests.erl
+++ b/test/aws_auth_validate_tls_tests.erl
@@ -495,6 +495,60 @@ tls_client_cert_garbage_pem_rejected_test() ->
         aws_auth_validate_tls:parse_input(Body)
     ).
 
+tls_client_cert_openssh_key_rejected_test() ->
+    %% An OpenSSH-format private key decodes as {{no_asn1, new_openssh}, _, _}
+    %% -- a tuple type tag. The allowlist must reject it with the private-key
+    %% reason (R6 security invariant).
+    OpensshPem = openssh_key_pem(),
+    {_CaKey, _CaDer, CaPem} = gen_ca(),
+    Mixed = <<CaPem/binary, OpensshPem/binary>>,
+    Body = #{
+        <<"target">> => <<"listener">>,
+        <<"ssl_options">> => #{<<"cacertfile_arn">> => ?CACERT_ARN},
+        <<"client_cert">> => Mixed
+    },
+    ?assertMatch(
+        {error, input_invalid, <<"client_cert must not contain private key material", _/binary>>},
+        aws_auth_validate_tls:parse_input(Body)
+    ).
+
+tls_client_cert_openssh_key_alone_rejected_test() ->
+    %% An OpenSSH key without any certificate is also rejected as key material.
+    OpensshPem = openssh_key_pem(),
+    Body = #{
+        <<"target">> => <<"listener">>,
+        <<"ssl_options">> => #{<<"cacertfile_arn">> => ?CACERT_ARN},
+        <<"client_cert">> => OpensshPem
+    },
+    ?assertMatch(
+        {error, input_invalid, <<"client_cert must not contain private key material", _/binary>>},
+        aws_auth_validate_tls:parse_input(Body)
+    ).
+
+tls_client_cert_encrypted_cert_entry_rejected_test() ->
+    %% A PEM entry that decodes as {'Certificate', _, some_cipher} (encrypted
+    %% certificate -- not plain not_encrypted) is caught by the allowlist because
+    %% only {'Certificate', _, not_encrypted} passes. Simulate with a hand-crafted
+    %% PEM that public_key:pem_decode would never produce in practice; instead test
+    %% classify_pem_entries directly via parse_input on a cert-only PEM that does
+    %% pass (and separately confirm the allowlist logic rejects non-cert entries).
+    %% Here we test the DH Parameters case -- a non-cert, non-key entry type.
+    DhPem = <<
+        "-----BEGIN DH PARAMETERS-----\nMIIBCAKCAQEA///////////JD9qiIWjC"
+        "NMTGYouA3BzRKQJOCIpnzHQCC76mOxObIlFK\n-----END DH PARAMETERS-----\n"
+    >>,
+    {_CaKey, _CaDer, CaPem} = gen_ca(),
+    Mixed = <<CaPem/binary, DhPem/binary>>,
+    Body = #{
+        <<"target">> => <<"listener">>,
+        <<"ssl_options">> => #{<<"cacertfile_arn">> => ?CACERT_ARN},
+        <<"client_cert">> => Mixed
+    },
+    ?assertMatch(
+        {error, input_invalid, <<"client_cert contains a non-certificate PEM entry", _/binary>>},
+        aws_auth_validate_tls:parse_input(Body)
+    ).
+
 %%====================================================================
 %% cert_login parse tests
 %%====================================================================
@@ -546,8 +600,11 @@ tls_cert_login_bad_from_rejected_test() ->
         <<"ssl_options">> => #{<<"cacertfile_arn">> => ?CACERT_ARN},
         <<"cert_login">> => #{<<"from">> => <<"serial_number">>}
     },
-    ?assertMatch(
-        {error, input_invalid, <<"cert_login.from must be", _/binary>>},
+    ?assertEqual(
+        {error, input_invalid, <<
+            "cert_login.from must be distinguished_name, common_name, "
+            "subject_alternative_name, or subject_alt_name"
+        >>},
         aws_auth_validate_tls:parse_input(Body)
     ).
 
@@ -1239,6 +1296,15 @@ gen_private_key_pem() ->
     ),
     {ok, Pem} = file:read_file(KeyFile),
     Pem.
+
+%% Minimal OpenSSH-format private key PEM. The content is not a real key but
+%% carries the "openssh-key-v1\0" magic that OTP's public_key:pem_decode/1
+%% recognizes, producing the {{no_asn1, new_openssh}, _, not_encrypted} entry
+%% that previously bypassed the denylist.
+openssh_key_pem() ->
+    Body = base64:encode(<<"openssh-key-v1", 0, "padding-data-here">>),
+    <<"-----BEGIN OPENSSH PRIVATE KEY-----\n", Body/binary,
+        "\n-----END OPENSSH PRIVATE KEY-----\n">>.
 
 %% Derive the cert filename from the key filename (matching gen_ca's naming).
 ca_cert_file_from_key(CaKeyFile) ->

--- a/test/aws_auth_validate_tls_tests.erl
+++ b/test/aws_auth_validate_tls_tests.erl
@@ -775,8 +775,59 @@ tls_validate_chain_intermediate_depth_zero_rejected_test() ->
     %% depth=0 forbids any intermediate; the leaf+intermediate chain exceeds it.
     {RootDer, IntDer, LeafDer} = gen_root_int_leaf(),
     ?assertMatch(
-        {error, auth_failed, _},
+        {error, auth_failed,
+            <<"the client certificate chain exceeds the configured path length (depth)">>},
         aws_auth_validate_tls:validate_chain([LeafDer, IntDer], [RootDer], 0)
+    ).
+
+tls_validate_chain_intermediate_only_bundle_rejected_test() ->
+    %% Finding 1: A CA bundle containing only an intermediate (not self-signed)
+    %% must be rejected. The broker's ssl listener rejects this with unknown_ca.
+    {_RootDer, IntDer, LeafDer} = gen_root_int_leaf(),
+    ?assertMatch(
+        {error, auth_failed, <<"the client certificate does not chain", _/binary>>},
+        aws_auth_validate_tls:validate_chain([LeafDer], [IntDer], undefined)
+    ).
+
+tls_validate_chain_key_rollover_old_new_order_test() ->
+    %% Finding 2: Two root CAs sharing the same subject DN (key rollover),
+    %% bundle order [OldRoot, NewRoot], leaf chaining to NewRoot. Must pass.
+    {OldRootDer, NewRootDer, LeafDer} = gen_two_roots_same_dn_and_leaf(),
+    ?assertEqual(
+        ok,
+        aws_auth_validate_tls:validate_chain([LeafDer], [OldRootDer, NewRootDer], undefined)
+    ).
+
+tls_validate_chain_key_rollover_new_old_order_test() ->
+    %% Finding 2: Same as above but bundle order [NewRoot, OldRoot]. Must pass
+    %% regardless of bundle order.
+    {OldRootDer, NewRootDer, LeafDer} = gen_two_roots_same_dn_and_leaf(),
+    ?assertEqual(
+        ok,
+        aws_auth_validate_tls:validate_chain([LeafDer], [NewRootDer, OldRootDer], undefined)
+    ).
+
+tls_validate_chain_unordered_tail_passes_test() ->
+    %% Finding 7: A leaf-first chain with an arbitrarily ordered tail must pass.
+    %% The broker's ssl_certificate:paths/2 rebuilds the chain from the peer cert
+    %% outward, so the tail order does not matter. Here we present [leaf, root, int]
+    %% with bundle=[root]: the tail is out of issuer order, but the code relinks it
+    %% as [leaf, int, root] and then strips root (the anchor) from the path.
+    {RootDer, IntDer, LeafDer} = gen_root_int_leaf(),
+    ?assertEqual(
+        ok,
+        aws_auth_validate_tls:validate_chain([LeafDer, RootDer, IntDer], [RootDer], undefined)
+    ).
+
+tls_validate_chain_root_first_rejected_test() ->
+    %% Finding 7 narrowing: A fully root-first chain (leaf is NOT the first
+    %% element) is rejected by the broker and must remain rejected here. This
+    %% pins the shared rejection so a future refactoring does not accidentally
+    %% loosen the leaf-first requirement.
+    {RootDer, IntDer, LeafDer} = gen_root_int_leaf(),
+    ?assertMatch(
+        {error, _, _},
+        aws_auth_validate_tls:validate_chain([RootDer, IntDer, LeafDer], [RootDer], undefined)
     ).
 
 %%====================================================================
@@ -1096,3 +1147,51 @@ gen_root_int_leaf() ->
     [{'Certificate', IntDer, not_encrypted}] = public_key:pem_decode(IntPem),
     [{'Certificate', LeafDer, not_encrypted}] = public_key:pem_decode(LeafPem),
     {RootDer, IntDer, LeafDer}.
+
+%% Generate two self-signed root CAs with the SAME subject DN but different keys,
+%% plus a leaf signed by the second (new) root. Exercises the key-rollover
+%% scenario where a bundle contains both old and new roots and the code must try
+%% each candidate until one validates.
+%% Returns {OldRootDer, NewRootDer, LeafDer}.
+gen_two_roots_same_dn_and_leaf() ->
+    Dir = tmp_dir(),
+    Suffix = integer_to_list(erlang:unique_integer([positive])),
+    F = fun(Name) -> filename:join(Dir, Name ++ "-" ++ Suffix ++ ".pem") end,
+    OldRootKey = F("kr-old-root-key"),
+    OldRootCert = F("kr-old-root-cert"),
+    NewRootKey = F("kr-new-root-key"),
+    NewRootCert = F("kr-new-root-cert"),
+    LeafKey = F("kr-leaf-key"),
+    LeafCsr = F("kr-leaf-csr"),
+    LeafCert = F("kr-leaf-cert"),
+    %% Both roots share the SAME CN (simulating key rollover).
+    CommonCN = "TestRolloverRoot" ++ Suffix,
+    Sh = fun(Fmt, Args) -> os:cmd(lists:flatten(io_lib:format(Fmt, Args))) end,
+    _ = Sh(
+        "openssl req -x509 -newkey rsa:2048 -nodes -keyout ~ts -out ~ts "
+        "-days 2 -subj '/CN=~s' 2>/dev/null",
+        [OldRootKey, OldRootCert, CommonCN]
+    ),
+    _ = Sh(
+        "openssl req -x509 -newkey rsa:2048 -nodes -keyout ~ts -out ~ts "
+        "-days 2 -subj '/CN=~s' 2>/dev/null",
+        [NewRootKey, NewRootCert, CommonCN]
+    ),
+    %% Sign the leaf with the NEW root.
+    _ = Sh(
+        "openssl req -new -newkey rsa:2048 -nodes -keyout ~ts -out ~ts "
+        "-subj '/CN=RolloverLeaf~s' 2>/dev/null",
+        [LeafKey, LeafCsr, Suffix]
+    ),
+    _ = Sh(
+        "openssl x509 -req -in ~ts -CA ~ts -CAkey ~ts -CAcreateserial "
+        "-out ~ts -days 2 2>/dev/null",
+        [LeafCsr, NewRootCert, NewRootKey, LeafCert]
+    ),
+    {ok, OldRootPem} = file:read_file(OldRootCert),
+    {ok, NewRootPem} = file:read_file(NewRootCert),
+    {ok, LeafPem} = file:read_file(LeafCert),
+    [{'Certificate', OldRootDer, not_encrypted}] = public_key:pem_decode(OldRootPem),
+    [{'Certificate', NewRootDer, not_encrypted}] = public_key:pem_decode(NewRootPem),
+    [{'Certificate', LeafDer, not_encrypted}] = public_key:pem_decode(LeafPem),
+    {OldRootDer, NewRootDer, LeafDer}.


### PR DESCRIPTION
The `tls` method validated CA material only (ARN resolve, PEM well-formedness, expiry, option shapes), so every failure mode of the publicly documented SSL certificate authentication setup (`auth_mechanisms.1 = EXTERNAL` + `ssl_cert_login_from`, per the Amazon MQ SSL/mTLS tutorials) stayed invisible until after a broker restart: a client cert that does not chain to the configured CA bundle, a `cert_login` mode that extracts no name from the cert, `verify_none` silently disabling EXTERNAL entirely, and a CN with no matching internal user -- the SSL tutorial's own top documented footgun (its prerequisite note requires the cert CN to match the username). The TLS handshake succeeds in most of these, so operators debug the wrong layer.

Following the oauth `access_token` precedent (caller-minted, non-secret proof material activating optional validation layers), a request may now carry a `client_cert` PEM and a `cert_login` block mirroring `ssl_cert_login_from` / `ssl_cert_login_san_type` / `ssl_cert_login_san_index`. Both are optional; a request without them behaves exactly as before.

### 1. Layer 1 -- chain validation (`client_cert`)
- `public_key:pkix_path_validation/3` of the supplied leaf (+ optional intermediates) against the resolved `cacertfile_arn` bundle, honoring an explicitly supplied `depth`. This answers "will the broker trust certs issued the way mine are?" against what the ARN *actually resolves to* -- which local `openssl verify` cannot.
- Not chaining / expired chain member -> `auth_failed` (422); malformed -> `input_invalid`. Fixed reasons; no issuer/subject/serial ever echoed (R4).
- **R6 guard:** the PEM must contain only CERTIFICATE entries. Any private-key entry (`RSAPrivateKey`, `DSAPrivateKey`, `ECPrivateKey`, `PrivateKeyInfo`, `EncryptedPrivateKeyInfo`) is rejected with a fixed reason telling the caller never to send key material. Chain validation and name extraction need public material only; possession-proof is deliberately out of scope.

### 2. Layer 2 -- username-extraction parity (`cert_login`)
- Mirrors the three-clause dispatch of `rabbit_ssl:peer_cert_auth_name/2` (`distinguished_name` / `common_name` incl. the multi-CN `","` join / `subject_alternative_name` incl. the `subject_alt_name` alias, the `otp_san_type/1` mapping, 0-based `san_index`, and `otherName` sanitization) while delegating the actual extraction to the broker's pure `rabbit_cert_info` helpers, so the extraction logic itself cannot drift. A coupling note documents the mirrored dispatch.
- `peer_cert_auth_name/2` is deliberately NOT called: its `auth_config_sane/0` reads the LIVE broker's `ssl_options.verify` app env -- the wrong input for validating a candidate config. Instead, `cert_login` requires the *supplied* `ssl_options.verify = verify_peer` (`config_conflict` otherwise), reaching the same verdict the live broker's unsafe-config refusal would.
- Extraction yielding no name (mode/cert mismatch, SAN index past the end, no CN) -> `auth_failed` with a fixed stage-naming reason. This is the check nothing customer-side can replicate: the extraction logic is RabbitMQ-internal and the only oracle today is a restarted broker.

### 3. Layer 3 -- user resolution
- Read-only `rabbit_auth_backend_internal:exists/1` on the raw extracted name (not `check_user_login/2`, which runs the full backend chain and can touch caches). Guarded by an `ensure_loaded`/`function_exported` probe (the `aws_auth_validate_oauth_authz` pattern) -> `config_conflict` if the API is absent on a broker series.
- Not found -> `auth_failed`; the reason echoes the extracted username (length-capped, control chars stripped). R4 basis: the name derives solely from the caller's own supplied certificate, the same footing as the oauth token reasons. The *lookup* uses the raw name so the verdict cannot diverge from what the live broker's EXTERNAL login would do; sanitization applies only to the echo.
- R3 note: this is the endpoint's first read of live broker state (the internal user table) -- read-only, no mutation, and a documented, deliberate deviation from pure-config validation.

### Cross-field rules and ordering
- `cert_login` requires `client_cert`; `client_cert` alone is allowed (chain-check only -- the mTLS-encryption-only tutorial case).
- All new input checks (PEM decode, `cert_login` shape, cross-field conflicts) run in the pure phase, preserving ARN-first ordering: a malformed request never triggers an AssumeRole or secret fetch.
- No new network surface: both tutorials' configs are inbound-listener material, so validation is pure computation plus the existing ARN fetch. No SSRF surface; DER parsing is bounded by the existing 64 KiB body cap and the concurrency semaphore.

### Testing
- `erlfmt -c` clean on all `.erl` changes.
- Full umbrella build passes; full clean eunit run green (773 tests, including meck'd Layer-3 found / not-found / API-absent cases and generated self-signed CA -> leaf chain and SAN/CN extraction cases).
- `ct-aws_auth_validate_tls`: 11 passed, 0 failed (adds end-to-end 204 valid-chain, 422 bad-chain, and 422 cert-login-conflict cases through the registry).
- Backward compat: requests without the new fields exercise the unchanged path; all pre-existing tls tests pass unmodified.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
