### PR TITLE
Auth Validation: Name the failing fields in ARN resolution errors

### DIFF
--- a/src/aws_auth_validate_http.erl
+++ b/src/aws_auth_validate_http.erl
@@ -728,29 +728,22 @@ build_client_ssl_opts(#{ssl_options := Map} = Params) ->
     %% instance role. Default to `none' (never a usable state) if the key is
     %% somehow absent, preserving the fail-closed contract.
     State = maps:get(aws_state, Params, none),
-    case
-        aws_auth_validate_ssl:resolve_cacerts(maps:get(<<"cacertfile_arn">>, Map, undefined), State)
-    of
+    %% Resolves the CA bundle and the mTLS pair together so a response can name
+    %% every ARN field that failed, not just the first.
+    case aws_auth_validate_ssl:resolve_ssl_material(Map, State) of
         {error, _, _} = Err ->
             Err;
-        {ok, CacertOpts} ->
-            case aws_auth_validate_ssl:resolve_client_cert(Map, State) of
-                {error, _, _} = Err ->
-                    Err;
-                {ok, ClientOpts} ->
-                    Opts =
-                        CacertOpts ++ ClientOpts ++
-                            aws_auth_validate_ssl:translate_ssl_opts(Map, <<"sni">>),
-                    %% Whether the caller set verify explicitly governs the
-                    %% no-trust-anchor policy (fail vs silent default).
-                    VerifyExplicit = maps:is_key(<<"verify">>, Map),
-                    %% Mirror rabbit_auth_backend_http: the RFC 6125 https match
-                    %% fun is applied ONLY when ssl_hostname_verification =
-                    %% wildcard; unset is strict OTP matching. Defaulting to
-                    %% wildcard here would pass a cert the live broker rejects.
-                    HostnameCheck = aws_auth_validate_ssl:hostname_check_mode(Map),
-                    aws_auth_validate_ssl:apply_verify_default(Opts, VerifyExplicit, HostnameCheck)
-            end
+        {ok, MaterialOpts} ->
+            Opts = MaterialOpts ++ aws_auth_validate_ssl:translate_ssl_opts(Map, <<"sni">>),
+            %% Whether the caller set verify explicitly governs the
+            %% no-trust-anchor policy (fail vs silent default).
+            VerifyExplicit = maps:is_key(<<"verify">>, Map),
+            %% Mirror rabbit_auth_backend_http: the RFC 6125 https match
+            %% fun is applied ONLY when ssl_hostname_verification =
+            %% wildcard; unset is strict OTP matching. Defaulting to
+            %% wildcard here would pass a cert the live broker rejects.
+            HostnameCheck = aws_auth_validate_ssl:hostname_check_mode(Map),
+            aws_auth_validate_ssl:apply_verify_default(Opts, VerifyExplicit, HostnameCheck)
     end.
 
 connection_timeout_ms() ->

--- a/src/aws_auth_validate_ldap.erl
+++ b/src/aws_auth_validate_ldap.erl
@@ -137,7 +137,10 @@
     <<"ssl_options.hostname_verification must be wildcard or none">>
 ).
 -define(REASON_BAD_SSL_CACERT_ARN, <<"ssl_options.cacertfile_arn must be a non-empty string">>).
--define(REASON_CACERT_ARN_RESOLVE, <<"failed to resolve ssl_options.cacertfile_arn">>).
+%% ARN-RESOLUTION failures no longer have a per-field macro here: the failing
+%% fields are collected across both ARNs and rendered by
+%% aws_auth_validate_ssl:arn_resolve_reason/1 so one response can name them all.
+%% The PEM macro below is for CONTENT failures, where the ARN did resolve.
 -define(REASON_CACERT_PEM_INVALID,
     <<"ssl_options.cacertfile_arn did not resolve to a valid PEM certificate">>
 ).
@@ -145,7 +148,6 @@
 -define(REASON_CONNECTION, <<"could not connect to LDAP server">>).
 -define(REASON_TLS_HANDSHAKE, <<"TLS handshake failed">>).
 -define(REASON_AUTH, <<"LDAP simple bind rejected the supplied credentials">>).
--define(REASON_ARN_RESOLVE, <<"failed to resolve ARN">>).
 -define(REASON_ASSUME_ROLE, <<"failed to assume the configured role">>).
 -define(REASON_NO_ASSUME_ROLE, <<
     "auth validation requires an assume_role to be configured; "
@@ -207,14 +209,9 @@ validate(Body) when is_map(Body) ->
                         {error, _, _} = Err ->
                             Err;
                         {ok, Params0} ->
-                            case resolve_password(Body, Params0) of
-                                {error, _, _} = Err ->
-                                    Err;
-                                {ok, Params1} ->
-                                    case resolve_cacert(Params1) of
-                                        {error, _, _} = Err -> Err;
-                                        {ok, Params2} -> do_ldap_validate(Params2)
-                                    end
+                            case resolve_arn_material(Body, Params0) of
+                                {error, _, _} = Err -> Err;
+                                {ok, Params2} -> do_ldap_validate(Params2)
                             end
                     end
             end
@@ -332,16 +329,63 @@ parse_user_dn(Body, Acc) ->
 %% fetch. The resolved password is added to the params map and never logged
 %% or returned. Validated for shape here (rather than in parse_input) so the
 %% network call stays out of the pure pipeline.
+%% An ARN-resolution failure returns the field-tagged {arn_failed, Fields} form
+%% so resolve_arn_material/2 can aggregate it with the cacert ARN's outcome and
+%% name every failing field in one response. A SHAPE failure is unrelated to
+%% resolution and still short-circuits with its own reason.
 resolve_password(Body, #{aws_state := State} = Params) ->
     case maps:get(<<"password_arn">>, Body, undefined) of
         Arn when is_binary(Arn), byte_size(Arn) > 0 ->
             case resolve_arn(Arn, State) of
                 {ok, Password} -> {ok, Params#{password => Password}};
-                {error, _} -> {error, input_invalid, ?REASON_ARN_RESOLVE}
+                {error, _} -> {arn_failed, [<<"password_arn">>]}
             end;
         _ ->
             {error, input_invalid, ?REASON_BAD_PASSWORD_ARN}
     end.
+
+%% Resolve both ARN-backed inputs -- the bind password and (when TLS is in use)
+%% the CA bundle -- attempting BOTH so a request with two broken ARNs names both
+%% fields instead of sending the operator round the loop twice.
+%%
+%% Only resolution failures aggregate. A shape error or a PEM-content error is
+%% reported as-is: in the content case the ARN did resolve, so naming it would
+%% misdescribe the failure.
+resolve_arn_material(Body, Params) ->
+    case resolve_password(Body, Params) of
+        {error, _, _} = ShapeErr ->
+            %% A SHAPE error (password_arn missing/empty) is pure-input invalid,
+            %% so stop here rather than aggregating. Continuing would fetch the
+            %% cacert ARN for a request we have already rejected, breaking the
+            %% ARN-first ordering invariant that a malformed request triggers no
+            %% secret fetch.
+            ShapeErr;
+        PasswordRes ->
+            %% Resolve the cacert ARN against the incoming Params; the password
+            %% branch's map is merged in below. Runs even when the password ARN
+            %% failed to RESOLVE, so both failing fields can be named at once.
+            aggregate_arn_results(PasswordRes, resolve_cacert(Params))
+    end.
+
+aggregate_arn_results(PasswordRes, CacertRes) ->
+    case arn_failed_fields(PasswordRes) ++ arn_failed_fields(CacertRes) of
+        [_ | _] = Failed ->
+            {error, input_invalid, aws_auth_validate_ssl:arn_resolve_reason(Failed)};
+        [] ->
+            case {PasswordRes, CacertRes} of
+                {{error, _, _} = Err, _} ->
+                    Err;
+                {_, {error, _, _} = Err} ->
+                    Err;
+                {{ok, WithPassword}, {ok, WithCacert}} ->
+                    %% Both succeeded: keep the password from one branch and the
+                    %% decoded cacerts (under ssl_options) from the other.
+                    {ok, maps:merge(WithPassword, maps:with([ssl_options], WithCacert))}
+            end
+    end.
+
+arn_failed_fields({arn_failed, Fields}) -> Fields;
+arn_failed_fields(_Other) -> [].
 
 %% Resolve the CA-cert ARN (when ssl_options.cacertfile_arn is set) in the
 %% network phase, alongside the password ARN and after all pure validation.
@@ -379,7 +423,7 @@ resolve_cacert(#{ssl_options := SslOpts, aws_state := State} = Params) ->
                         _:_ -> {error, input_invalid, ?REASON_CACERT_PEM_INVALID}
                     end;
                 {error, _} ->
-                    {error, input_invalid, ?REASON_CACERT_ARN_RESOLVE}
+                    {arn_failed, [<<"ssl_options.cacertfile_arn">>]}
             end
     end.
 

--- a/src/aws_auth_validate_ldap.erl
+++ b/src/aws_auth_validate_ldap.erl
@@ -372,9 +372,11 @@ aggregate_arn_results(PasswordRes, CacertRes) ->
         [_ | _] = Failed ->
             {error, input_invalid, aws_auth_validate_ssl:arn_resolve_reason(Failed)};
         [] ->
+            %% PasswordRes cannot be an error here: resolve_arn_material/2
+            %% short-circuits the only shape error before this point, leaving
+            %% {ok,_} once its ARN did not fail to resolve. Only the cacert
+            %% branch can still carry a CONTENT error (an invalid PEM).
             case {PasswordRes, CacertRes} of
-                {{error, _, _} = Err, _} ->
-                    Err;
                 {_, {error, _, _} = Err} ->
                     Err;
                 {{ok, WithPassword}, {ok, WithCacert}} ->

--- a/src/aws_auth_validate_oauth.erl
+++ b/src/aws_auth_validate_oauth.erl
@@ -1168,27 +1168,20 @@ build_client_ssl_opts(#{ssl_options := Map} = Params) ->
     %% every ARN fetch here. A request that references no ARN carries a default
     %% state that is never used to resolve one.
     State = maps:get(aws_state, Params, none),
-    case
-        aws_auth_validate_ssl:resolve_cacerts(maps:get(<<"cacertfile_arn">>, Map, undefined), State)
-    of
+    %% Resolves the CA bundle and the mTLS pair together so a response can name
+    %% every ARN field that failed, not just the first.
+    case aws_auth_validate_ssl:resolve_ssl_material(Map, State) of
         {error, _, _} = Err ->
             Err;
-        {ok, CacertOpts} ->
-            case aws_auth_validate_ssl:resolve_client_cert(Map, State) of
-                {error, _, _} = Err ->
-                    Err;
-                {ok, ClientOpts} ->
-                    Opts =
-                        CacertOpts ++ ClientOpts ++
-                            aws_auth_validate_ssl:translate_ssl_opts(Map, <<"sni">>),
-                    VerifyExplicit = maps:is_key(<<"verify">>, Map),
-                    %% Mirror oauth2_client: hostname_verification defaults to
-                    %% none (strict); the RFC 6125 https match fun is applied only
-                    %% on wildcard. Defaulting to wildcard would pass an IdP cert
-                    %% the live broker rejects.
-                    HostnameCheck = aws_auth_validate_ssl:hostname_check_mode(Map),
-                    aws_auth_validate_ssl:apply_verify_default(Opts, VerifyExplicit, HostnameCheck)
-            end
+        {ok, MaterialOpts} ->
+            Opts = MaterialOpts ++ aws_auth_validate_ssl:translate_ssl_opts(Map, <<"sni">>),
+            VerifyExplicit = maps:is_key(<<"verify">>, Map),
+            %% Mirror oauth2_client: hostname_verification defaults to
+            %% none (strict); the RFC 6125 https match fun is applied only
+            %% on wildcard. Defaulting to wildcard would pass an IdP cert
+            %% the live broker rejects.
+            HostnameCheck = aws_auth_validate_ssl:hostname_check_mode(Map),
+            aws_auth_validate_ssl:apply_verify_default(Opts, VerifyExplicit, HostnameCheck)
     end.
 
 connection_timeout_ms() ->

--- a/src/aws_auth_validate_ssl.erl
+++ b/src/aws_auth_validate_ssl.erl
@@ -292,13 +292,13 @@ nonempty_or(V, ReasonKey, Opts) ->
 %% Resolve ssl_options.cacertfile_arn to the raw-DER cacerts ssl option (or [] if
 %% absent / no cert entries).
 %%
-%% A resolve failure returns the `arn_resolve_failed' sentinel rather than a
-%% finished reason string: only the caller knows which request field this ARN
-%% came from, and resolve_ssl_material/2 aggregates that attribution across all
-%% the ARNs in one request. resolve_arn_reason/1 turns the sentinel into a
-%% caller-facing binary for the single-ARN callers.
+%% A resolve failure returns the field-tagged {arn_failed, Fields} form rather
+%% than a finished reason string, so resolve_ssl_material/2 can aggregate the
+%% attribution across every ARN in the request and name them all in one
+%% response. This mirrors resolve_client_cert/2, which reports its own two
+%% fields the same way.
 -spec resolve_cacerts(term(), aws_lib:aws_state()) ->
-    {ok, list()} | {error, aws_auth_validate_backend:error_category(), binary() | atom()}.
+    {ok, list()} | {arn_failed, [binary()]}.
 resolve_cacerts(undefined, _State) ->
     {ok, []};
 resolve_cacerts(Arn, State) when is_binary(Arn) ->
@@ -309,7 +309,7 @@ resolve_cacerts(Arn, State) when is_binary(Arn) ->
                 Certs -> {ok, [{cacerts, Certs}]}
             end;
         {error, _} ->
-            {error, input_invalid, arn_resolve_failed}
+            {arn_failed, [<<"ssl_options.cacertfile_arn">>]}
     end.
 
 %% Resolve every ARN the request references under ssl_options, attempting ALL of
@@ -328,14 +328,10 @@ resolve_cacerts(Arn, State) when is_binary(Arn) ->
 -spec resolve_ssl_material(map(), aws_lib:aws_state() | none) ->
     {ok, list()} | {error, aws_auth_validate_backend:error_category(), binary()}.
 resolve_ssl_material(Map, State) ->
-    CacertRes =
-        case resolve_cacerts(maps:get(<<"cacertfile_arn">>, Map, undefined), State) of
-            {error, input_invalid, arn_resolve_failed} ->
-                {arn_failed, [<<"ssl_options.cacertfile_arn">>]};
-            Other ->
-                Other
-        end,
-    Results = [CacertRes, resolve_client_cert(Map, State)],
+    Results = [
+        resolve_cacerts(maps:get(<<"cacertfile_arn">>, Map, undefined), State),
+        resolve_client_cert(Map, State)
+    ],
     case [Fields || {arn_failed, Fields} <- Results] of
         [_ | _] = Failed ->
             {error, input_invalid, arn_resolve_reason(lists:append(Failed))};
@@ -659,9 +655,10 @@ connection_timeout_ms(#{default := Default, max := Max}) ->
 reason(Key, #{reasons := Reasons}) ->
     maps:get(Key, Reasons).
 
-%% The generic ARN-resolve reason. Retained for the PEM-decode paths, where the
-%% ARN itself resolved fine and the failure is about the CONTENT, so naming the
-%% field would misdescribe what went wrong.
+%% The generic ARN-resolve reason, used when no field attribution is available.
+%% Every current caller supplies at least one field, so this is reached only via
+%% arn_resolve_reason([]) -- kept so an empty list cannot render as a reason with
+%% a dangling "for: " and no fields.
 generic_arn_resolve() ->
     <<"failed to resolve ARN">>.
 

--- a/src/aws_auth_validate_ssl.erl
+++ b/src/aws_auth_validate_ssl.erl
@@ -41,6 +41,8 @@
     %% TLS-material resolution + translation (network phase)
     resolve_cacerts/2,
     resolve_client_cert/2,
+    resolve_ssl_material/2,
+    arn_resolve_reason/1,
     decode_pem_cacerts/1,
     decode_client_cert/1,
     decode_client_key/1,
@@ -64,6 +66,19 @@
     connection_timeout_ms/1,
     is_nonempty_binary/1
 ]).
+
+%% CONTENT-failure reasons for the mTLS pair: the ARN resolved but the payload
+%% holds no usable material. Distinct from an ARN-RESOLUTION failure (see
+%% arn_resolve_reason/1) so the operator is not sent looking at IAM or the ARN
+%% string when the object exists and is simply the wrong thing. Naming the field
+%% is safe for the same reason it is in arn_resolve_reason/1 -- it echoes a key
+%% the caller sent, never the resolved bytes.
+-define(REASON_CERTFILE_NO_CERT,
+    <<"ssl_options.certfile_arn resolved but contains no certificate">>
+).
+-define(REASON_KEYFILE_NO_KEY,
+    <<"ssl_options.keyfile_arn resolved but contains no usable private key">>
+).
 
 %% Accepted values for `verify' and `versions', shared by all backends.
 -define(SSL_VERIFY_VALUES, [<<"verify_peer">>, <<"verify_none">>]).
@@ -275,9 +290,15 @@ nonempty_or(V, ReasonKey, Opts) ->
 %%--------------------------------------------------------------------
 
 %% Resolve ssl_options.cacertfile_arn to the raw-DER cacerts ssl option (or [] if
-%% absent / no cert entries). Any resolve failure -> input_invalid (fixed reason).
+%% absent / no cert entries).
+%%
+%% A resolve failure returns the `arn_resolve_failed' sentinel rather than a
+%% finished reason string: only the caller knows which request field this ARN
+%% came from, and resolve_ssl_material/2 aggregates that attribution across all
+%% the ARNs in one request. resolve_arn_reason/1 turns the sentinel into a
+%% caller-facing binary for the single-ARN callers.
 -spec resolve_cacerts(term(), aws_lib:aws_state()) ->
-    {ok, list()} | {error, aws_auth_validate_backend:error_category(), binary()}.
+    {ok, list()} | {error, aws_auth_validate_backend:error_category(), binary() | atom()}.
 resolve_cacerts(undefined, _State) ->
     {ok, []};
 resolve_cacerts(Arn, State) when is_binary(Arn) ->
@@ -288,35 +309,78 @@ resolve_cacerts(Arn, State) when is_binary(Arn) ->
                 Certs -> {ok, [{cacerts, Certs}]}
             end;
         {error, _} ->
-            {error, input_invalid, generic_arn_resolve()}
+            {error, input_invalid, arn_resolve_failed}
+    end.
+
+%% Resolve every ARN the request references under ssl_options, attempting ALL of
+%% them so a single response can name every field that failed.
+%%
+%% Short-circuiting on the first failure would force the operator into one round
+%% trip per broken ARN, which is exactly the guess-and-retry loop this endpoint
+%% exists to remove. The cost is bounded: at most three ARNs per request
+%% (cacertfile/certfile/keyfile), already gated by the assume_role guardrail and
+%% the concurrency semaphore.
+%%
+%% Resolution failures are aggregated and attributed to their fields. A CONTENT
+%% failure (the ARN resolved but the payload holds no usable material) is
+%% reported unchanged and takes precedence only when nothing failed to resolve,
+%% since at that point naming the ARN would misdescribe the problem.
+-spec resolve_ssl_material(map(), aws_lib:aws_state() | none) ->
+    {ok, list()} | {error, aws_auth_validate_backend:error_category(), binary()}.
+resolve_ssl_material(Map, State) ->
+    CacertRes =
+        case resolve_cacerts(maps:get(<<"cacertfile_arn">>, Map, undefined), State) of
+            {error, input_invalid, arn_resolve_failed} ->
+                {arn_failed, [<<"ssl_options.cacertfile_arn">>]};
+            Other ->
+                Other
+        end,
+    Results = [CacertRes, resolve_client_cert(Map, State)],
+    case [Fields || {arn_failed, Fields} <- Results] of
+        [_ | _] = Failed ->
+            {error, input_invalid, arn_resolve_reason(lists:append(Failed))};
+        [] ->
+            case [Err || {error, _, _} = Err <- Results] of
+                [Err | _] -> Err;
+                [] -> {ok, lists:append([Opts || {ok, Opts} <- Results])}
+            end
     end.
 
 %% Resolve the client certificate + private key for mutual TLS. parse_ssl_options
 %% already guaranteed both are present or both absent, so here we either resolve
 %% the pair or return no client-auth options.
+%%
+%% Both ARNs are fetched before either is decoded, so a request whose cert AND
+%% key ARNs are both broken names both fields instead of only the cert. Decoding
+%% still happens cert-then-key, since a content error is reported unchanged and
+%% needs no aggregation.
 -spec resolve_client_cert(map(), aws_lib:aws_state()) ->
-    {ok, list()} | {error, aws_auth_validate_backend:error_category(), binary()}.
+    {ok, list()}
+    | {error, aws_auth_validate_backend:error_category(), binary()}
+    | {arn_failed, [binary()]}.
 resolve_client_cert(#{<<"certfile_arn">> := CertArn, <<"keyfile_arn">> := KeyArn}, State) when
     is_binary(CertArn), is_binary(KeyArn)
 ->
-    case resolve_arn(CertArn, State) of
-        {ok, CertPem} ->
+    CertRes = resolve_arn(CertArn, State),
+    KeyRes = resolve_arn(KeyArn, State),
+    Failed =
+        [<<"ssl_options.certfile_arn">> || element(1, CertRes) =:= error] ++
+            [<<"ssl_options.keyfile_arn">> || element(1, KeyRes) =:= error],
+    case Failed of
+        [_ | _] ->
+            {arn_failed, Failed};
+        [] ->
+            {ok, CertPem} = CertRes,
+            {ok, KeyPem} = KeyRes,
             case decode_client_cert(CertPem) of
                 {error, _, _} = Err ->
                     Err;
                 {ok, CertOpt} ->
-                    case resolve_arn(KeyArn, State) of
-                        {ok, KeyPem} ->
-                            case decode_client_key(KeyPem) of
-                                {error, _, _} = Err -> Err;
-                                {ok, KeyOpt} -> {ok, [CertOpt, KeyOpt]}
-                            end;
-                        {error, _} ->
-                            {error, input_invalid, generic_arn_resolve()}
+                    case decode_client_key(KeyPem) of
+                        {error, _, _} = Err -> Err;
+                        {ok, KeyOpt} -> {ok, [CertOpt, KeyOpt]}
                     end
-            end;
-        {error, _} ->
-            {error, input_invalid, generic_arn_resolve()}
+            end
     end;
 resolve_client_cert(_Map, _State) ->
     {ok, []}.
@@ -333,17 +397,19 @@ decode_pem_cacerts(B) when is_binary(B) ->
     end.
 
 %% Decode a client-certificate PEM into an ssl {cert, [DER]} option. A PEM with
-%% no certificate entry is a resolution-shaped failure (fixed ARN category).
+%% no certificate entry is a CONTENT failure: the ARN resolved, the payload is
+%% just unusable, so the reason says so rather than blaming resolution.
 -spec decode_client_cert(binary()) ->
     {ok, {cert, [binary()]}} | {error, aws_auth_validate_backend:error_category(), binary()}.
 decode_client_cert(Pem) when is_binary(Pem) ->
     case [Der || {'Certificate', Der, not_encrypted} <- public_key:pem_decode(Pem)] of
-        [] -> {error, input_invalid, generic_arn_resolve()};
+        [] -> {error, input_invalid, ?REASON_CERTFILE_NO_CERT};
         Ders -> {ok, {cert, Ders}}
     end.
 
 %% Decode a private-key PEM into an ssl {key, {Asn1Type, DER}} option. An
-%% encrypted or absent key is a fixed ARN-category failure.
+%% encrypted or absent key is a CONTENT failure (the ARN resolved), so the reason
+%% names the field and the payload problem rather than blaming resolution.
 -spec decode_client_key(binary()) ->
     {ok, {key, {atom(), binary()}}}
     | {error, aws_auth_validate_backend:error_category(), binary()}.
@@ -357,7 +423,7 @@ decode_client_key(Pem) when is_binary(Pem) ->
     ],
     case KeyEntries of
         [{Type, Der} | _] -> {ok, {key, {Type, Der}}};
-        [] -> {error, input_invalid, generic_arn_resolve()}
+        [] -> {error, input_invalid, ?REASON_KEYFILE_NO_KEY}
     end.
 
 %% Translate the non-cacert ssl_options keys into an ssl proplist. SniKey is the
@@ -593,11 +659,34 @@ connection_timeout_ms(#{default := Default, max := Max}) ->
 reason(Key, #{reasons := Reasons}) ->
     maps:get(Key, Reasons).
 
-%% The generic ARN-resolve reason. resolve_cacerts/2, resolve_client_cert/2, and
-%% the PEM decoders all report the same fixed string across backends (all three
-%% originals used <<"failed to resolve ARN">> in these paths).
+%% The generic ARN-resolve reason. Retained for the PEM-decode paths, where the
+%% ARN itself resolved fine and the failure is about the CONTENT, so naming the
+%% field would misdescribe what went wrong.
 generic_arn_resolve() ->
     <<"failed to resolve ARN">>.
+
+%% Build the ARN-resolution failure reason, naming which request fields failed.
+%%
+%% Naming the FIELD is safe and is the point of the endpoint: a field name is
+%% part of the request the caller just sent us, so it discloses nothing they do
+%% not already know, and it saves them guessing which of several ARNs is broken.
+%% What must never appear is the resolved CONTENT (R6) -- and it cannot, because
+%% only these caller-supplied key paths are interpolated. The underlying AWS
+%% error is also deliberately dropped: it can carry account ids, bucket names,
+%% and IAM role details, so the categories stay fixed (R4) and the distinction
+%% between "does not exist" and "access denied" stays hidden.
+%%
+%% Fields are emitted in the caller-supplied order (each backend passes them in
+%% a fixed order) so the message is deterministic and testable.
+-spec arn_resolve_reason([binary()]) -> binary().
+arn_resolve_reason([]) ->
+    %% No field attribution available -- fall back to the generic wording rather
+    %% than emitting an empty list.
+    generic_arn_resolve();
+arn_resolve_reason(Fields) ->
+    iolist_to_binary([
+        <<"ARN resolution failed for: ">>, lists:join(<<", ">>, Fields)
+    ]).
 
 no_trust_anchor() ->
     <<"verify_peer requested but no CA trust anchor is available; supply cacertfile_arn">>.

--- a/src/aws_auth_validate_tls.erl
+++ b/src/aws_auth_validate_tls.erl
@@ -94,7 +94,12 @@
     <<"ssl_options.fail_if_no_peer_cert must be true or false">>
 ).
 -define(REASON_BAD_SSL_CACERT_ARN, <<"ssl_options.cacertfile_arn must be a non-empty string">>).
--define(REASON_ARN_RESOLVE, <<"failed to resolve ARN">>).
+%% Names the field whose ARN failed to resolve. The field name comes from the
+%% caller's own request, so it leaks nothing; the resolved content and the
+%% underlying AWS error are never included.
+-define(REASON_ARN_RESOLVE,
+    aws_auth_validate_ssl:arn_resolve_reason([<<"ssl_options.cacertfile_arn">>])
+).
 -define(REASON_NO_CERTS, <<"cacertfile ARN did not resolve to any CA certificates">>).
 -define(REASON_BAD_CERT, <<"a certificate in the CA bundle could not be parsed">>).
 -define(REASON_CERT_EXPIRED, <<"the CA bundle contains an expired certificate">>).
@@ -328,6 +333,9 @@ do_tls_validate(#{ssl_options := Map} = Params) ->
                 {ok, CaDers} -> maybe_chain_validate(Params, CaDers)
             end
     end.
+
+%% This backend takes exactly one ARN, so there is never more than one field to
+%% attribute; the shared aggregating resolver is unnecessary here.
 
 %% Decode the CA PEM and check each certificate. Returns {ok, CaDers} on
 %% success so the caller can thread the already-decoded DER list into chain

--- a/test/aws_auth_validate_http_tests.erl
+++ b/test/aws_auth_validate_http_tests.erl
@@ -558,8 +558,87 @@ http_resolve_arn_fails_closed_on_none_sentinel_test_() ->
             },
             Result = aws_auth_validate_http:build_client_ssl_opts(Params),
             [
-                ?_assertEqual({error, input_invalid, <<"failed to resolve ARN">>}, Result),
+                ?_assertEqual(
+                    {error, input_invalid,
+                        <<"ARN resolution failed for: ssl_options.cacertfile_arn">>},
+                    Result
+                ),
                 ?_assertEqual(0, meck:num_calls(aws_arn_util, resolve_arn, '_'))
+            ]
+        end}.
+
+%% All THREE ARN fields failing are named in one response. The point of the
+%% attribution is that an operator with several broken ARNs learns about all of
+%% them in a single call instead of one per round trip, so the resolver must
+%% attempt every ARN rather than stopping at the first failure.
+http_arn_resolve_failure_names_all_failed_fields_test_() ->
+    {setup,
+        fun() ->
+            ok = meck:new(aws_arn_util, [passthrough]),
+            meck:expect(aws_arn_util, resolve_arn, fun(_Arn, State) -> {error, denied, State} end),
+            ok
+        end,
+        fun(_) -> meck:unload(aws_arn_util) end, fun(_) ->
+            Params = #{
+                ssl_options => #{
+                    <<"cacertfile_arn">> => <<"arn:aws:s3:::ca">>,
+                    <<"certfile_arn">> => <<"arn:aws:s3:::cert">>,
+                    <<"keyfile_arn">> => <<"arn:aws:s3:::key">>
+                },
+                aws_state => fake_state
+            },
+            Result = aws_auth_validate_http:build_client_ssl_opts(Params),
+            [
+                ?_assertEqual(
+                    {error, input_invalid, <<
+                        "ARN resolution failed for: ssl_options.cacertfile_arn, "
+                        "ssl_options.certfile_arn, ssl_options.keyfile_arn"
+                    >>},
+                    Result
+                ),
+                %% Every ARN must actually be attempted -- that is what makes the
+                %% full list possible. Short-circuiting would name only the first.
+                ?_assertEqual(3, meck:num_calls(aws_arn_util, resolve_arn, '_'))
+            ]
+        end}.
+
+%% Only the fields that actually failed are named: a request whose CA bundle
+%% resolves but whose mTLS key does not must not blame the CA bundle.
+http_arn_resolve_failure_names_only_failed_fields_test_() ->
+    {setup,
+        fun() ->
+            ok = meck:new(aws_arn_util, [passthrough]),
+            meck:expect(aws_arn_util, resolve_arn, fun(Arn, State) ->
+                case lists:suffix("key", Arn) of
+                    true -> {error, denied, State};
+                    false -> {ok, ?SECRET, State}
+                end
+            end),
+            ok
+        end,
+        fun(_) -> meck:unload(aws_arn_util) end, fun(_) ->
+            Params = #{
+                ssl_options => #{
+                    <<"cacertfile_arn">> => <<"arn:aws:s3:::ca">>,
+                    <<"certfile_arn">> => <<"arn:aws:s3:::cert">>,
+                    <<"keyfile_arn">> => <<"arn:aws:s3:::key">>
+                },
+                aws_state => fake_state
+            },
+            Result = aws_auth_validate_http:build_client_ssl_opts(Params),
+            [
+                ?_assertEqual(
+                    {error, input_invalid,
+                        <<"ARN resolution failed for: ssl_options.keyfile_arn">>},
+                    Result
+                ),
+                %% The resolved material must never appear in the reason (R6).
+                ?_assertNot(
+                    case Result of
+                        {error, _, R} -> binary:match(R, ?SECRET) =/= nomatch;
+                        _ -> false
+                    end
+                )
             ]
         end}.
 

--- a/test/aws_auth_validate_tests.erl
+++ b/test/aws_auth_validate_tests.erl
@@ -996,6 +996,62 @@ cacert_arn_resolution_test_() ->
                     aws_auth_validate_ldap:validate(tls_body(<<"arn:aws:cacert:garbage">>))
                 )
             end},
+            {"both ARNs unresolvable -> one reason naming BOTH fields", fun() ->
+                %% The plural case: an operator with two broken ARNs must learn
+                %% about both in one response instead of fixing one, retrying,
+                %% and discovering the second. Requires the resolver to attempt
+                %% both rather than stopping at the password.
+                meck:expect(aws_arn_util, resolve_arn, fun(_Arn, State) ->
+                    {error, not_found, State}
+                end),
+                ?assertEqual(
+                    {error, input_invalid, <<
+                        "ARN resolution failed for: password_arn, "
+                        "ssl_options.cacertfile_arn"
+                    >>},
+                    aws_auth_validate_ldap:validate(tls_body(<<"arn:aws:cacert:nope">>))
+                )
+            end},
+            {"only the password ARN failing names only that field", fun() ->
+                %% Attribution must be precise: a working CA bundle must not be
+                %% blamed alongside the broken password.
+                meck:expect(aws_arn_util, resolve_arn, fun(Arn, State) ->
+                    case lists:prefix("arn:aws:cacert", Arn) of
+                        true -> {ok, ca_pem_for_test(), State};
+                        false -> {error, not_found, State}
+                    end
+                end),
+                ?assertEqual(
+                    {error, input_invalid, <<"ARN resolution failed for: password_arn">>},
+                    aws_auth_validate_ldap:validate(tls_body(<<"arn:aws:cacert:ok">>))
+                )
+            end},
+            {"a password_arn SHAPE error fetches no ARN at all", fun() ->
+                %% ARN-first ordering: aggregating failures must not cause a
+                %% malformed request to trigger a secret fetch. A missing
+                %% password_arn is pure-input invalid, so neither ARN is fetched
+                %% even though a cacertfile_arn is present.
+                meck:expect(aws_arn_util, resolve_arn, fun(_Arn, State) ->
+                    {ok, <<"pw">>, State}
+                end),
+                Body = maps:remove(<<"password_arn">>, tls_body(<<"arn:aws:cacert:x">>)),
+                Result = aws_auth_validate_ldap:validate(Body),
+                ?assertMatch({error, input_invalid, <<"password_arn must be", _/binary>>}, Result),
+                ?assertEqual(0, meck:num_calls(aws_arn_util, resolve_arn, '_'))
+            end},
+            {"resolved secret never appears in the ARN-failure reason", fun() ->
+                %% R6: field attribution must not become a channel for content.
+                meck:expect(aws_arn_util, resolve_arn, fun(_Arn, State) ->
+                    {error, {access_denied, "arn:aws:iam::999:role/secret-role"}, State}
+                end),
+                {error, input_invalid, Reason} =
+                    aws_auth_validate_ldap:validate(tls_body(<<"arn:aws:cacert:nope">>)),
+                %% The underlying AWS error (which can carry account ids and role
+                %% names) must be dropped, not echoed.
+                ?assertEqual(nomatch, binary:match(Reason, <<"999">>)),
+                ?assertEqual(nomatch, binary:match(Reason, <<"secret-role">>)),
+                ?assertEqual(nomatch, binary:match(Reason, <<"access_denied">>))
+            end},
             {"CA-cert ARN ignored when TLS is off (no resolve, no error)", fun() ->
                 %% With use_ssl/use_starttls both false the CA cert is never
                 %% consumed, so a bogus cacertfile_arn must not trigger a
@@ -1018,6 +1074,25 @@ cacert_arn_resolution_test_() ->
                 ?assertNotMatch({error, input_invalid, _}, Result)
             end}
         ]}.
+
+%% A self-signed CA PEM, so a mocked cacertfile_arn can RESOLVE successfully and
+%% the test isolates password-ARN attribution from a CA content failure.
+ca_pem_for_test() ->
+    Dir = filename:join(["/tmp", "aws-auth-validate-ldap-arn-tests"]),
+    ok = filelib:ensure_dir(filename:join(Dir, "x")),
+    Key = filename:join(Dir, "ca-key.pem"),
+    Cert = filename:join(Dir, "ca-cert.pem"),
+    _ = os:cmd(
+        lists:flatten(
+            io_lib:format(
+                "openssl req -x509 -newkey rsa:2048 -nodes -keyout ~ts -out ~ts "
+                "-days 2 -subj /CN=AwsAuthValidateLdapArnTestCA 2>/dev/null",
+                [Key, Cert]
+            )
+        )
+    ),
+    {ok, Pem} = file:read_file(Cert),
+    Pem.
 
 %% A body with TLS enabled and a caller-supplied CA-cert ARN, otherwise valid.
 tls_body(CacertArn) ->

--- a/test/aws_auth_validate_tls_tests.erl
+++ b/test/aws_auth_validate_tls_tests.erl
@@ -247,15 +247,30 @@ tls_malformed_pem_maps_to_input_invalid_test_() ->
         end
     ).
 
-%% An ARN resolution failure maps to input_invalid.
+%% An ARN resolution failure maps to input_invalid and NAMES the field that
+%% failed, so the operator knows which ARN to fix. This backend takes only
+%% cacertfile_arn, so there is exactly one field to name.
 tls_arn_resolve_failure_test_() ->
     {setup, fun setup_role/0, fun cleanup_role/1, fun(_) ->
         meck:expect(aws_arn_util, resolve_arn, fun(_Arn, State) -> {error, not_found, State} end),
         R = validate_ok_body(),
         [
-            ?_assertEqual({error, input_invalid, <<"failed to resolve ARN">>}, R)
+            ?_assertEqual(
+                {error, input_invalid, <<"ARN resolution failed for: ssl_options.cacertfile_arn">>},
+                R
+            ),
+            %% The resolved content and the underlying AWS error must never be
+            %% echoed, however specific the field attribution gets (R6/R4).
+            ?_assertNot(reason_contains(R, ?SECRET)),
+            ?_assertNot(reason_contains(R, <<"not_found">>))
         ]
     end}.
+
+%% True when the reason binary of an error result contains Needle.
+reason_contains({error, _Category, Reason}, Needle) when is_binary(Reason) ->
+    binary:match(Reason, Needle) =/= nomatch;
+reason_contains(_Other, _Needle) ->
+    false.
 
 %% A valid, in-window CA bundle passes. Generated fresh so it is current.
 tls_valid_ca_returns_ok_test_() ->


### PR DESCRIPTION
_Enhancement to #43_

The generic "failed to resolve ARN" gave an operator with several ARNs in one request no way to tell which one was broken, so they had to bisect by editing ARNs and retrying -- the guess-and-retry loop this endpoint exists to remove. 

Responses now name the fields like:
"ARN resolution failed for: password_arn, ssl_options.cacertfile_arn"

Changes:
  - add aws_auth_validate_ssl:arn_resolve_reason/1 to render the list, falling back to the old wording when no attribution is available
  - resolve ALL referenced ARNs instead of short-circuiting on the first failure, so one response reports every broken field; bounded at three ARNs per request and already gated by the assume_role guardrail and the concurrency semaphore
  - attribute failures structurally ({arn_failed, Fields}) rather than by re-parsing reason strings; add resolve_ssl_material/2 for the shared http/oauth path and aggregate_arn_results/2 for ldap
  - resolve the mTLS cert and key ARNs before decoding either, so a request with both broken names both fields
  - distinguish CONTENT failures from RESOLUTION failures: a certfile or keyfile ARN that resolves but holds no usable material now says so instead of claiming resolution failed
  - qualify nested keys (ssl_options.*) so the operator knows where in the request to look
  - drop the now-dead per-field LDAP resolve macros

Field names come from the caller's own request, so they disclose nothing new. The resolved content and the underlying AWS error are still never included, keeping "does not exist" and "access denied" indistinguishable. A password_arn shape error still short circuits, preserving ARN-first ordering: a malformed request triggers no secret fetch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
