### PR TITLE
Comment cleanup: inline the design-doc requirement IDs

### DIFF
--- a/src/aws_auth_validate_backend.erl
+++ b/src/aws_auth_validate_backend.erl
@@ -23,7 +23,9 @@
     %% config mismatch (token_invalid -- the JWKS the broker fetches will reject
     %% live tokens). Safe to be granular here: unlike the reachability
     %% categories, these describe the caller's own token, not the broker's infra
-    %% or an SSRF target, so they leak nothing R4 is guarding.
+    %% or an SSRF target, so they disclose nothing the fixed-category rule guards
+    %% (that rule prevents echoing raw errors, hostnames, or network details that
+    %% would enable SSRF reconnaissance).
     | token_expired
     | token_invalid.
 

--- a/src/aws_auth_validate_http.erl
+++ b/src/aws_auth_validate_http.erl
@@ -728,29 +728,22 @@ build_client_ssl_opts(#{ssl_options := Map} = Params) ->
     %% instance role. Default to `none' (never a usable state) if the key is
     %% somehow absent, preserving the fail-closed contract.
     State = maps:get(aws_state, Params, none),
-    case
-        aws_auth_validate_ssl:resolve_cacerts(maps:get(<<"cacertfile_arn">>, Map, undefined), State)
-    of
+    %% Resolves the CA bundle and the mTLS pair together so a response can name
+    %% every ARN field that failed, not just the first.
+    case aws_auth_validate_ssl:resolve_ssl_material(Map, State) of
         {error, _, _} = Err ->
             Err;
-        {ok, CacertOpts} ->
-            case aws_auth_validate_ssl:resolve_client_cert(Map, State) of
-                {error, _, _} = Err ->
-                    Err;
-                {ok, ClientOpts} ->
-                    Opts =
-                        CacertOpts ++ ClientOpts ++
-                            aws_auth_validate_ssl:translate_ssl_opts(Map, <<"sni">>),
-                    %% Whether the caller set verify explicitly governs the
-                    %% no-trust-anchor policy (fail vs silent default).
-                    VerifyExplicit = maps:is_key(<<"verify">>, Map),
-                    %% Mirror rabbit_auth_backend_http: the RFC 6125 https match
-                    %% fun is applied ONLY when ssl_hostname_verification =
-                    %% wildcard; unset is strict OTP matching. Defaulting to
-                    %% wildcard here would pass a cert the live broker rejects.
-                    HostnameCheck = aws_auth_validate_ssl:hostname_check_mode(Map),
-                    aws_auth_validate_ssl:apply_verify_default(Opts, VerifyExplicit, HostnameCheck)
-            end
+        {ok, MaterialOpts} ->
+            Opts = MaterialOpts ++ aws_auth_validate_ssl:translate_ssl_opts(Map, <<"sni">>),
+            %% Whether the caller set verify explicitly governs the
+            %% no-trust-anchor policy (fail vs silent default).
+            VerifyExplicit = maps:is_key(<<"verify">>, Map),
+            %% Mirror rabbit_auth_backend_http: the RFC 6125 https match
+            %% fun is applied ONLY when ssl_hostname_verification =
+            %% wildcard; unset is strict OTP matching. Defaulting to
+            %% wildcard here would pass a cert the live broker rejects.
+            HostnameCheck = aws_auth_validate_ssl:hostname_check_mode(Map),
+            aws_auth_validate_ssl:apply_verify_default(Opts, VerifyExplicit, HostnameCheck)
     end.
 
 connection_timeout_ms() ->

--- a/src/aws_auth_validate_http.erl
+++ b/src/aws_auth_validate_http.erl
@@ -40,11 +40,12 @@
 %% well-formed deny still proves the endpoint speaks the auth protocol.
 %%
 %% A future credentialed-probe mode (assert user_path returns `allow' for a
-%% supplied username + password_arn) is intentionally out of scope here; see
-%% http-validation-analysis.md, open question 1.
+%% supplied username + password_arn) is intentionally out of scope for this
+%% initial reachability-only implementation.
 %%
 %% Category mapping (reuses the existing aws_auth_validate_backend categories;
-%% no new category is introduced, per R4 "keep the set small"):
+%% no new category is introduced -- the fixed set is kept small so responses
+%% cannot be used for SSRF reconnaissance or information disclosure):
 %%   * connection_failed (400) -- host unreachable / DNS / connection refused.
 %%   * tls_failed        (400) -- TLS handshake / cert verification failure.
 %%   * auth_failed       (422) -- reached the server but its response is not
@@ -120,8 +121,7 @@
 %% mutual TLS (the broker's auth_http.ssl_options.certfile / .keyfile). The
 %% cert is typically an S3-hosted PEM; the key a Secrets Manager PEM. Both are
 %% resolved like cacertfile_arn and decoded into in-memory ssl {cert,_}/{key,_}
-%% options so an mTLS auth server (which the RabbitMqHttpSampleStack requires)
-%% can be validated.
+%% options so an mTLS auth server can be validated.
 -define(SSL_OPTION_KEYS, [
     <<"cacertfile_arn">>,
     <<"certfile_arn">>,
@@ -132,7 +132,8 @@
     <<"sni">>,
     <<"hostname_verification">>
 ]).
-%% Fixed, hardcoded reason strings (R4): no URL, host, or raw error echoed.
+%% Fixed, hardcoded reason strings -- never echo a URL, host, or raw error,
+%% so the endpoint cannot be used for SSRF reconnaissance.
 -define(REASON_BAD_PATHS, <<"at least user_path must be a non-empty URL string">>).
 -define(REASON_BAD_PATH_VALUE, <<"each path must be a non-empty URL string">>).
 -define(REASON_BAD_URL, <<"a configured path is not a valid http(s) URL">>).
@@ -210,7 +211,7 @@
 %% Per-backend surface passed to the shared aws_auth_validate_ssl helpers: which
 %% ssl_options keys reference an ARN, the full allowed-key set, the customer SNI
 %% key spelling, whether the mTLS client-cert pair is accepted, and this
-%% backend's fixed R4 reason strings (kept here so wording/tests are unchanged).
+%% backend's fixed reason strings (kept here so wording/tests are unchanged).
 ssl_opts() ->
     #{
         arn_keys => [<<"cacertfile_arn">>, <<"certfile_arn">>, <<"keyfile_arn">>],
@@ -308,9 +309,9 @@ validate(Body) when is_map(Body) ->
 %% no AWS call, so it needs no role and gets a default state that is never used
 %% to resolve an ARN -- preserving the credential-free reachability check.
 %% Delegates to the shared aws_auth_validate_ssl helper. The no-ARN branch there
-%% stores the `none' credential sentinel (which resolve_arn/2 refuses), matching
-%% the fail-closed contract PR #116 introduced -- a customer request can never
-%% resolve an ARN under the broker's ambient EC2 instance role.
+%% stores the `none' credential sentinel (which resolve_arn/2 refuses), so a
+%% customer request can never resolve an ARN under the broker's ambient EC2
+%% instance role.
 resolve_request_state(Params) ->
     aws_auth_validate_ssl:resolve_request_state(Params, ssl_opts()).
 
@@ -475,16 +476,18 @@ pin_url(Url, Host) -> aws_auth_validate_net:pin_url(Url, Host).
 %% auth protocol). Only a body matching NEITHER is a failure.
 %%
 %% The whole probe runs inside a try/catch that collapses any raise to
-%% connection_failed, so a resolved secret can never reach a crash report (R6).
+%% connection_failed, so a resolved secret can never reach a crash report.
 %%
 %% All probe requests for THIS validation run on a dedicated, ephemeral httpc
 %% profile that is started here and stopped in the `after' clause. This isolates
 %% each validation's TLS sessions/connections: the shared default profile pools
 %% TLS sessions, so a prior request's authenticated (e.g. mTLS) session could be
 %% reused by a later request -- producing a false success for a config that
-%% would not connect on its own (and a leaked connection across requests, an R3
-%% violation). A fresh profile has no sessions to reuse, and stopping it tears
-%% down anything opened, so each validation is hermetic.
+%% would not connect on its own (and a leaked connection across requests, which
+%% violates the zero-side-effects invariant: each validation must use only
+%% ephemeral connections and never mutate shared state). A fresh profile has no
+%% sessions to reuse, and stopping it tears down anything opened, so each
+%% validation is hermetic.
 do_http_validate(Params) ->
     case aws_auth_validate_httpc:claim_probe_profile(?PROFILE_PREFIX) of
         none ->
@@ -559,7 +562,8 @@ probe_one(Key, Url, #{http_method := Method, timeout := Timeout}, SslOpts, Profi
 
 %% Map an httpc transport error to a fixed category (shared classifier). A
 %% TLS/cert failure -> tls_failed; everything else -> connection_failed. The raw
-%% reason is never echoed (R4).
+%% reason is never echoed -- responses carry only fixed categories and hardcoded
+%% strings to prevent information disclosure.
 classify_http_error(Reason) ->
     aws_auth_validate_ssl:classify_http_error(
         Reason, ?REASON_TLS_HANDSHAKE, ?REASON_CONNECTION
@@ -631,9 +635,10 @@ is_keyword_prefix(Keyword, Resp) ->
 
 %% Build the httpc Request tuple for the configured method. For GET the query
 %% goes in the URL; for POST it is a form-encoded body, matching
-%% rabbit_auth_backend_http's request shape (R12 request-shape parity). The
-%% Host header carries the ORIGINAL hostname (the URL host is the pinned IP), so
-%% the auth server sees the name it expects -- needed for name-based vhosts.
+%% rabbit_auth_backend_http's request shape so the endpoint's decision matches
+%% the live broker's for the same inputs. The Host header carries the ORIGINAL
+%% hostname (the URL host is the pinned IP), so the auth server sees the name it
+%% expects -- needed for name-based vhosts.
 build_request(get, UrlStr, Query, Host) ->
     Sep =
         case Query of

--- a/src/aws_auth_validate_http.erl
+++ b/src/aws_auth_validate_http.erl
@@ -309,9 +309,9 @@ validate(Body) when is_map(Body) ->
 %% no AWS call, so it needs no role and gets a default state that is never used
 %% to resolve an ARN -- preserving the credential-free reachability check.
 %% Delegates to the shared aws_auth_validate_ssl helper. The no-ARN branch there
-%% stores the `none' credential sentinel (which resolve_arn/2 refuses), so a
-%% customer request can never resolve an ARN under the broker's ambient EC2
-%% instance role.
+%% stores the `none' credential sentinel (which resolve_arn/2 refuses), matching
+%% the fail-closed contract PR #116 introduced -- a customer request can never
+%% resolve an ARN under the broker's ambient EC2 instance role.
 resolve_request_state(Params) ->
     aws_auth_validate_ssl:resolve_request_state(Params, ssl_opts()).
 

--- a/src/aws_auth_validate_httpc.erl
+++ b/src/aws_auth_validate_httpc.erl
@@ -9,7 +9,8 @@
 %% This machinery exists ONLY because httpc pools TLS sessions on a global,
 %% named-profile basis: the shared default profile would let a prior request's
 %% authenticated (e.g. mTLS) session be reused by a later request -- a false
-%% success and a cross-request connection leak (R3 violation). Each in-flight
+%% success and a cross-request connection leak (violating the zero-side-effects
+%% invariant that each validation uses only ephemeral connections). Each in-flight
 %% probe therefore OWNS a distinct started profile drawn from a FIXED pool of
 %% ?PROFILE_POOL_SIZE interned atoms (a fresh atom per request would leak the
 %% atom table). A slot is claimed only by successfully starting it, so two

--- a/src/aws_auth_validate_ldap.erl
+++ b/src/aws_auth_validate_ldap.erl
@@ -137,7 +137,10 @@
     <<"ssl_options.hostname_verification must be wildcard or none">>
 ).
 -define(REASON_BAD_SSL_CACERT_ARN, <<"ssl_options.cacertfile_arn must be a non-empty string">>).
--define(REASON_CACERT_ARN_RESOLVE, <<"failed to resolve ssl_options.cacertfile_arn">>).
+%% ARN-RESOLUTION failures no longer have a per-field macro here: the failing
+%% fields are collected across both ARNs and rendered by
+%% aws_auth_validate_ssl:arn_resolve_reason/1 so one response can name them all.
+%% The PEM macro below is for CONTENT failures, where the ARN did resolve.
 -define(REASON_CACERT_PEM_INVALID,
     <<"ssl_options.cacertfile_arn did not resolve to a valid PEM certificate">>
 ).
@@ -145,7 +148,6 @@
 -define(REASON_CONNECTION, <<"could not connect to LDAP server">>).
 -define(REASON_TLS_HANDSHAKE, <<"TLS handshake failed">>).
 -define(REASON_AUTH, <<"LDAP simple bind rejected the supplied credentials">>).
--define(REASON_ARN_RESOLVE, <<"failed to resolve ARN">>).
 -define(REASON_ASSUME_ROLE, <<"failed to assume the configured role">>).
 -define(REASON_NO_ASSUME_ROLE, <<
     "auth validation requires an assume_role to be configured; "
@@ -207,14 +209,9 @@ validate(Body) when is_map(Body) ->
                         {error, _, _} = Err ->
                             Err;
                         {ok, Params0} ->
-                            case resolve_password(Body, Params0) of
-                                {error, _, _} = Err ->
-                                    Err;
-                                {ok, Params1} ->
-                                    case resolve_cacert(Params1) of
-                                        {error, _, _} = Err -> Err;
-                                        {ok, Params2} -> do_ldap_validate(Params2)
-                                    end
+                            case resolve_arn_material(Body, Params0) of
+                                {error, _, _} = Err -> Err;
+                                {ok, Params2} -> do_ldap_validate(Params2)
                             end
                     end
             end
@@ -332,16 +329,63 @@ parse_user_dn(Body, Acc) ->
 %% fetch. The resolved password is added to the params map and never logged
 %% or returned. Validated for shape here (rather than in parse_input) so the
 %% network call stays out of the pure pipeline.
+%% An ARN-resolution failure returns the field-tagged {arn_failed, Fields} form
+%% so resolve_arn_material/2 can aggregate it with the cacert ARN's outcome and
+%% name every failing field in one response. A SHAPE failure is unrelated to
+%% resolution and still short-circuits with its own reason.
 resolve_password(Body, #{aws_state := State} = Params) ->
     case maps:get(<<"password_arn">>, Body, undefined) of
         Arn when is_binary(Arn), byte_size(Arn) > 0 ->
             case resolve_arn(Arn, State) of
                 {ok, Password} -> {ok, Params#{password => Password}};
-                {error, _} -> {error, input_invalid, ?REASON_ARN_RESOLVE}
+                {error, _} -> {arn_failed, [<<"password_arn">>]}
             end;
         _ ->
             {error, input_invalid, ?REASON_BAD_PASSWORD_ARN}
     end.
+
+%% Resolve both ARN-backed inputs -- the bind password and (when TLS is in use)
+%% the CA bundle -- attempting BOTH so a request with two broken ARNs names both
+%% fields instead of sending the operator round the loop twice.
+%%
+%% Only resolution failures aggregate. A shape error or a PEM-content error is
+%% reported as-is: in the content case the ARN did resolve, so naming it would
+%% misdescribe the failure.
+resolve_arn_material(Body, Params) ->
+    case resolve_password(Body, Params) of
+        {error, _, _} = ShapeErr ->
+            %% A SHAPE error (password_arn missing/empty) is pure-input invalid,
+            %% so stop here rather than aggregating. Continuing would fetch the
+            %% cacert ARN for a request we have already rejected, breaking the
+            %% ARN-first ordering invariant that a malformed request triggers no
+            %% secret fetch.
+            ShapeErr;
+        PasswordRes ->
+            %% Resolve the cacert ARN against the incoming Params; the password
+            %% branch's map is merged in below. Runs even when the password ARN
+            %% failed to RESOLVE, so both failing fields can be named at once.
+            aggregate_arn_results(PasswordRes, resolve_cacert(Params))
+    end.
+
+aggregate_arn_results(PasswordRes, CacertRes) ->
+    case arn_failed_fields(PasswordRes) ++ arn_failed_fields(CacertRes) of
+        [_ | _] = Failed ->
+            {error, input_invalid, aws_auth_validate_ssl:arn_resolve_reason(Failed)};
+        [] ->
+            case {PasswordRes, CacertRes} of
+                {{error, _, _} = Err, _} ->
+                    Err;
+                {_, {error, _, _} = Err} ->
+                    Err;
+                {{ok, WithPassword}, {ok, WithCacert}} ->
+                    %% Both succeeded: keep the password from one branch and the
+                    %% decoded cacerts (under ssl_options) from the other.
+                    {ok, maps:merge(WithPassword, maps:with([ssl_options], WithCacert))}
+            end
+    end.
+
+arn_failed_fields({arn_failed, Fields}) -> Fields;
+arn_failed_fields(_Other) -> [].
 
 %% Resolve the CA-cert ARN (when ssl_options.cacertfile_arn is set) in the
 %% network phase, alongside the password ARN and after all pure validation.
@@ -379,7 +423,7 @@ resolve_cacert(#{ssl_options := SslOpts, aws_state := State} = Params) ->
                         _:_ -> {error, input_invalid, ?REASON_CACERT_PEM_INVALID}
                     end;
                 {error, _} ->
-                    {error, input_invalid, ?REASON_CACERT_ARN_RESOLVE}
+                    {arn_failed, [<<"ssl_options.cacertfile_arn">>]}
             end
     end.
 

--- a/src/aws_auth_validate_ldap.erl
+++ b/src/aws_auth_validate_ldap.erl
@@ -632,7 +632,7 @@ is_denied_ip(IP) ->
 %% BROADER than the http/oauth infra-only denylist in aws_auth_validate_net: LDAP
 %% denies ALL RFC1918/CGNAT/reserved space, not just broker infra. Sharing the
 %% classifier while keeping a distinct list means a future range or segment-math
-%% fix cannot silently apply to only one backend. Mirrors #153, one layer up.
+%% fix cannot silently apply to only one backend.
 %%   100.64.0.0/10 (RFC 6598) is carrier-grade NAT shared address space; it can
 %%     route to provider/internal infrastructure, so it is denied too.
 %%   240.0.0.0/4 is reserved/Class E, including 255.255.255.255 limited broadcast.
@@ -671,17 +671,18 @@ check_config_conflicts(_) ->
 %% LDAP execution
 %%--------------------------------------------------------------------
 
-%% SECURITY (R6): the resolved bind password is passed to eldap:simple_bind/3
-%% as a direct argument. If anything in the connect/bind/post-bind section
-%% *raises* (rather than returning {error, _}), the exception's stacktrace
-%% would carry the live argument terms -- including this function's Params map,
-%% which holds the plaintext password -- into a Cowboy crash report. To
-%% guarantee the password can never reach a log or crash dump, the entire body
-%% is destructured into a separate worker (do_ldap_bind/1) whose only job is to
-%% return a fixed-category result, and any escaping exception is caught here and
-%% collapsed to the fixed connection_failed category. We deliberately discard
-%% the caught class/reason/stacktrace (binding them to throwaway names that are
-%% never logged or returned) so no fragment of the bind arguments survives.
+%% SECURITY: no credential leakage. The resolved bind password is passed to
+%% eldap:simple_bind/3 as a direct argument. If anything in the connect/bind/
+%% post-bind section *raises* (rather than returning {error, _}), the
+%% exception's stacktrace would carry the live argument terms -- including this
+%% function's Params map, which holds the plaintext password -- into a Cowboy
+%% crash report. To guarantee the password can never reach a log or crash dump,
+%% the entire body is destructured into a separate worker (do_ldap_bind/1) whose
+%% only job is to return a fixed-category result, and any escaping exception is
+%% caught here and collapsed to the fixed connection_failed category. We
+%% deliberately discard the caught class/reason/stacktrace (binding them to
+%% throwaway names that are never logged or returned) so no fragment of the bind
+%% arguments survives.
 %% Note: a raise in a post-bind probe (e.g. eldap:search/2 in object_exists/2)
 %% is therefore reported as connection_failed rather than its more specific
 %% category. This is a deliberate, safe degradation -- those probes already map
@@ -726,7 +727,7 @@ do_ldap_connect(
             {error, connection_failed, ?REASON_CONNECTION};
         {ok, Handle} ->
             try
-                %% SSRF (R4): close the DNS-rebinding window. parse_servers/2's
+                %% SSRF defense: close the DNS-rebinding window. parse_servers/2's
                 %% is_allowed_server/1 vetted a resolved IP, but eldap re-resolved
                 %% the hostname for this connection, so the peer we are actually
                 %% attached to may differ (DNS rebinding). Re-check the *real*
@@ -1010,7 +1011,8 @@ eval_dn_probe(DN, Probe) ->
 %% (default "member") against the resolved user DN. A match means the user is a
 %% member. Distinct from object_exists/2, which only proves the group EXISTS;
 %% reusing that here would wrongly pass a real-but-non-member group. Any
-%% non-{ok,_} collapses to false (never raises -- R6).
+%% non-{ok,_} collapses to false (never raises -- so a resolved secret cannot
+%% reach a crash report).
 eval_membership(_Handle, _DN, _Desc, undefined) ->
     %% No resolved principal in scope for this sub-result; degrade.
     skip;
@@ -1154,8 +1156,9 @@ build_tls_opts(true, SslOpts) ->
 
 %% Resolve an ARN using the request's threaded aws_state() (shared helper). The
 %% state is built once per request by resolve_request_state/1 under the
-%% operator-configured assume_role. R6: the resolved secret is neither logged nor
-%% returned; R3: this runs only after the pure validation pipeline.
+%% operator-configured assume_role. The resolved secret is neither logged nor
+%% returned (no credential leakage); this runs only after the pure validation
+%% pipeline (zero side effects -- no secret fetch for a malformed request).
 resolve_arn(Arn, State) when is_binary(Arn) ->
     aws_auth_validate_ssl:resolve_arn(Arn, State).
 

--- a/src/aws_auth_validate_ldap.erl
+++ b/src/aws_auth_validate_ldap.erl
@@ -634,7 +634,7 @@ is_denied_ip(IP) ->
 %% BROADER than the http/oauth infra-only denylist in aws_auth_validate_net: LDAP
 %% denies ALL RFC1918/CGNAT/reserved space, not just broker infra. Sharing the
 %% classifier while keeping a distinct list means a future range or segment-math
-%% fix cannot silently apply to only one backend.
+%% fix cannot silently apply to only one backend. Mirrors #153, one layer up.
 %%   100.64.0.0/10 (RFC 6598) is carrier-grade NAT shared address space; it can
 %%     route to provider/internal infrastructure, so it is denied too.
 %%   240.0.0.0/4 is reserved/Class E, including 255.255.255.255 limited broadcast.

--- a/src/aws_auth_validate_ldap_query.erl
+++ b/src/aws_auth_validate_ldap_query.erl
@@ -9,9 +9,9 @@
 %% This intentionally mirrors the grammar accepted by
 %% rabbit_auth_backend_ldap_util:parse_query/1 (erl_scan + erl_parse:parse_term
 %% over the same accepted-term allowlist) so that a query the broker would
-%% accept is accepted here and vice-versa (design requirement R12: the
-%% validation endpoint must not diverge from rabbit_auth_backend_ldap). A
-%% parity test in aws_auth_validate_tests guards against drift.
+%% accept is accepted here and vice-versa -- the endpoint's parse decision must
+%% match the live broker's for the same input. A parity test in
+%% aws_auth_validate_tests guards against drift.
 %%
 %% Three deliberate differences from the upstream helper:
 %%   1. It returns {ok, Query} | {error, Reason} instead of throwing via

--- a/src/aws_auth_validate_mgmt.erl
+++ b/src/aws_auth_validate_mgmt.erl
@@ -145,18 +145,19 @@ with_semaphore(T0, SourceIP, User, Method, BodyMap, Req, Context) ->
             reply_error(503, capacity_exhausted, <<"Service at capacity">>, Req, Context);
         {ok, Ref} ->
             try
-                %% Defense in depth for R6: a backend must always *return* a
-                %% fixed-category result, but if one ever raises, the escaping
-                %% exception would carry BodyMap (and any future secret it
-                %% holds) into a Cowboy crash report. Catch here, discarding the
-                %% class/reason/stacktrace so no request term is logged.
+                %% Defense in depth -- no credential leakage: a backend must
+                %% always *return* a fixed-category result, but if one ever
+                %% raises, the escaping exception would carry BodyMap (and any
+                %% future secret it holds) into a Cowboy crash report. Catch
+                %% here, discarding the class/reason/stacktrace so no request
+                %% term is logged.
                 %%
                 %% A raise here is OUR fault, not the caller's: a real
                 %% unreachable server is *returned* as connection_failed by the
-                %% backend (which has its own R6 try/catch), so reaching this
-                %% clause means an unexpected internal error. Report it as a 500
-                %% rather than a 400 connection_failed, which would wrongly tell
-                %% the caller their LDAP server is unreachable.
+                %% backend (which has its own no-credential-leakage try/catch),
+                %% so reaching this clause means an unexpected internal error.
+                %% Report it as a 500 rather than a 400 connection_failed, which
+                %% would wrongly tell the caller their LDAP server is unreachable.
                 Result = aws_auth_validate_registry:dispatch(Method, BodyMap),
                 audit(Method, SourceIP, User, result_category(Result), T0),
                 respond(Result, Req, Context)
@@ -325,7 +326,8 @@ sanitize_byte(B) ->
 %% an OPTIONS preflight is let through unauthenticated (user=undefined), but the
 %% feature toggle short-circuits OPTIONS before any audit, so a `<<"unknown">>'
 %% here only ever reflects an unexpected shape, never a real unaudited PUT. Only
-%% the username is logged -- never tags, target host, URL, or DN (R4/R6).
+%% the username is logged -- never tags, target host, URL, or DN (to prevent
+%% information disclosure and ensure resolved secrets never reach logs).
 username(#context{user = #user{username = Name}}) when is_binary(Name) ->
     Name;
 username(_) ->

--- a/src/aws_auth_validate_net.erl
+++ b/src/aws_auth_validate_net.erl
@@ -13,7 +13,7 @@
 %% The validator issues outbound requests to customer-supplied URLs from the
 %% broker's network position -- a textbook SSRF / confused-deputy surface.
 %% Defense is two-phase and IDENTICAL for http and oauth; only the scheme
-%% allowlist (oauth is https-only; http allows http+https) and the fixed R4
+%% allowlist (oauth is https-only; http allows http+https) and the fixed
 %% reason strings differ, so those are parameters (a policy() map):
 %%
 %%   * PURE phase (url_allowed/2): scheme allowlist + literal-IP classification

--- a/src/aws_auth_validate_oauth.erl
+++ b/src/aws_auth_validate_oauth.erl
@@ -1168,27 +1168,20 @@ build_client_ssl_opts(#{ssl_options := Map} = Params) ->
     %% every ARN fetch here. A request that references no ARN carries a default
     %% state that is never used to resolve one.
     State = maps:get(aws_state, Params, none),
-    case
-        aws_auth_validate_ssl:resolve_cacerts(maps:get(<<"cacertfile_arn">>, Map, undefined), State)
-    of
+    %% Resolves the CA bundle and the mTLS pair together so a response can name
+    %% every ARN field that failed, not just the first.
+    case aws_auth_validate_ssl:resolve_ssl_material(Map, State) of
         {error, _, _} = Err ->
             Err;
-        {ok, CacertOpts} ->
-            case aws_auth_validate_ssl:resolve_client_cert(Map, State) of
-                {error, _, _} = Err ->
-                    Err;
-                {ok, ClientOpts} ->
-                    Opts =
-                        CacertOpts ++ ClientOpts ++
-                            aws_auth_validate_ssl:translate_ssl_opts(Map, <<"sni">>),
-                    VerifyExplicit = maps:is_key(<<"verify">>, Map),
-                    %% Mirror oauth2_client: hostname_verification defaults to
-                    %% none (strict); the RFC 6125 https match fun is applied only
-                    %% on wildcard. Defaulting to wildcard would pass an IdP cert
-                    %% the live broker rejects.
-                    HostnameCheck = aws_auth_validate_ssl:hostname_check_mode(Map),
-                    aws_auth_validate_ssl:apply_verify_default(Opts, VerifyExplicit, HostnameCheck)
-            end
+        {ok, MaterialOpts} ->
+            Opts = MaterialOpts ++ aws_auth_validate_ssl:translate_ssl_opts(Map, <<"sni">>),
+            VerifyExplicit = maps:is_key(<<"verify">>, Map),
+            %% Mirror oauth2_client: hostname_verification defaults to
+            %% none (strict); the RFC 6125 https match fun is applied only
+            %% on wildcard. Defaulting to wildcard would pass an IdP cert
+            %% the live broker rejects.
+            HostnameCheck = aws_auth_validate_ssl:hostname_check_mode(Map),
+            aws_auth_validate_ssl:apply_verify_default(Opts, VerifyExplicit, HostnameCheck)
     end.
 
 connection_timeout_ms() ->

--- a/src/aws_auth_validate_oauth.erl
+++ b/src/aws_auth_validate_oauth.erl
@@ -76,7 +76,8 @@
 %%                               re-mint the token and retry.
 %%   token_invalid / token_expired are safe to distinguish (unlike the coarse
 %%   reachability categories) because they describe the caller's own token, not
-%%   the broker's infra or an SSRF target, so they leak nothing R4 guards.
+%%   the broker's infra or an SSRF target, so they disclose nothing the
+%%   fixed-category rule guards against (SSRF reconnaissance / info disclosure).
 -module(aws_auth_validate_oauth).
 
 -behaviour(aws_auth_validate_backend).
@@ -142,7 +143,8 @@
     <<"hostname_verification">>
 ]).
 
-%% Fixed, hardcoded reason strings (R4): no URL, host, or raw error echoed.
+%% Fixed, hardcoded reason strings -- never echo a URL, host, or raw error,
+%% so the endpoint cannot be used for SSRF reconnaissance.
 -define(REASON_MISSING_URL, <<"at least one of jwks_uri or issuer must be present">>).
 -define(REASON_BAD_URL, <<"a configured URL is not a valid https URL">>).
 -define(REASON_URL_NOT_ALLOWED, <<"a configured URL targets a disallowed address">>).
@@ -170,8 +172,8 @@
 -define(REASON_ENDPOINT, <<"endpoint did not return a valid JWKS document">>).
 -define(REASON_DISCOVERY, <<"issuer discovery did not return a valid OpenID configuration">>).
 %% Customer-supplied access-token verification (optional, activates when
-%% access_token is present). Fixed R4 reasons: no token content, claim value,
-%% or key material echoed. Pure-phase shape problems are input_invalid (400);
+%% access_token is present). Fixed reason strings: no token content, claim value,
+%% or key material is ever echoed. Pure-phase shape problems are input_invalid (400);
 %% verification outcomes use the token_invalid / token_expired categories (422)
 %% so an operator can tell a real config mismatch (token_invalid: bad signature
 %% or no matching JWKS key -- the broker will reject live tokens) from a
@@ -256,7 +258,7 @@
 
 %% Per-backend surface passed to the shared aws_auth_validate_ssl helpers.
 %% Identical shape to the HTTP backend's (both accept the mTLS pair and use the
-%% <<"sni">> key); only this backend's fixed R4 reason strings differ, kept here.
+%% <<"sni">> key); only this backend's fixed reason strings differ, kept here.
 ssl_opts() ->
     #{
         arn_keys => [<<"cacertfile_arn">>, <<"certfile_arn">>, <<"keyfile_arn">>],
@@ -739,8 +741,9 @@ in_cidr(IP, Cidr) -> aws_auth_validate_net:in_cidr(IP, Cidr).
 %%--------------------------------------------------------------------
 %%
 %% The whole network section runs inside a try/catch collapsing any raise to
-%% connection_failed, so a resolved secret can never reach a crash report (R6).
-%% All probe requests run on a dedicated ephemeral httpc profile (R3).
+%% connection_failed, so a resolved secret can never reach a crash report.
+%% All probe requests run on a dedicated ephemeral httpc profile (zero side
+%% effects -- each validation uses only ephemeral connections).
 
 do_oauth_validate(Params) ->
     case aws_auth_validate_httpc:claim_probe_profile(?PROFILE_PREFIX) of
@@ -818,11 +821,12 @@ maybe_verify_token(#{token := #{raw := Raw, header := Header}} = Params, Keys) -
 %%   4. if a resource_server_id was supplied, require it in the token `aud'
 %%      (unless the broker's verify_aud is disabled).
 %% Failures map to fixed categories (no claim value, key material, or token
-%% content echoed -- R6): a bad signature or no matching JWKS key -> token_invalid
-%% (a real config mismatch the broker would also reject); an expired token ->
-%% token_expired (transient, just re-mint); an audience mismatch stays
-%% auth_failed. verify_token/3 takes the pre-decoded header so the -ifdef(TEST)
-%% export can exercise it directly.
+%% content is ever echoed -- a resolved secret must never reach a response or
+%% log): a bad signature or no matching JWKS key -> token_invalid (a real config
+%% mismatch the broker would also reject); an expired token -> token_expired
+%% (transient, just re-mint); an audience mismatch stays auth_failed.
+%% verify_token/3 takes the pre-decoded header so the -ifdef(TEST) export can
+%% exercise it directly.
 -ifdef(TEST).
 %% Test-only wrapper preserving the historical verify_token/3 contract (returns
 %% `ok' on success). Production code calls verify_token_claims/3 directly (it
@@ -883,7 +887,8 @@ select_jwk(Kid, Keys) when is_binary(Kid) ->
 %% jose_jwt:verify_strict/3 refuses any token whose alg is not the allowed one,
 %% and jose_jwk:from_map/1 builds the public key from the JWKS entry. Any raise
 %% (malformed key material, unsupported curve) is caught and treated as a
-%% signature failure -- never a crash report (R6). Returns the decoded claims.
+%% signature failure -- never a crash report, so key material cannot leak.
+%% Returns the decoded claims.
 verify_signature(Alg, JwkMap, Raw) ->
     try
         JWK = jose_jwk:from_map(JwkMap),
@@ -1134,7 +1139,8 @@ strip_trailing_slash(S) ->
 %%--------------------------------------------------------------------
 
 %% Shared classifier: TLS/cert failure -> tls_failed, else connection_failed.
-%% The raw reason is never echoed (R4).
+%% The raw reason is never echoed -- responses carry only fixed categories to
+%% prevent SSRF reconnaissance.
 classify_http_error(Reason) ->
     aws_auth_validate_ssl:classify_http_error(
         Reason, ?REASON_TLS_HANDSHAKE, ?REASON_CONNECTION

--- a/src/aws_auth_validate_oauth_authz.erl
+++ b/src/aws_auth_validate_oauth_authz.erl
@@ -49,7 +49,7 @@
 %%       expansion
 %%   * rabbit_oauth2_scope:{vhost,resource,topic}_access/*  -- the final match
 %%
-%% R3 (zero side effects): every function above is side-effect-free; the config
+%% Zero side effects: every function above is side-effect-free; the config
 %% comes from the record argument, so this reads nothing from broker state and
 %% mutates nothing. We construct the #resource_server{} from CUSTOMER-SUPPLIED
 %% fields, so we are validating the customer's config, not the broker's live one.
@@ -100,8 +100,8 @@
 -define(SCOPE_MOD, rabbit_oauth2_scope).
 -define(RS_MOD, rabbit_oauth2_resource_server).
 
-%% Fixed reasons. NOTE on granularity vs R4: R4's fixed-category rule guards
-%% against leaking BROKER INFRASTRUCTURE or an SSRF target (hostnames, IPs, raw
+%% Fixed reasons. NOTE on granularity: the fixed-category rule guards against
+%% leaking BROKER INFRASTRUCTURE or an SSRF target (hostnames, IPs, raw
 %% network/LDAP errors) that an attacker does not already know. The authz
 %% failure reasons below are categorically different: they describe only the
 %% CALLER'S OWN token and the CALLER'S OWN supplied authorization config (both
@@ -111,8 +111,8 @@
 %% contract but differentiate the human-readable message, which is what actually
 %% lets a customer self-diagnose the "my token is broken (it isn't)" case. The
 %% messages carry NO scope values or claim content -- they name the failing
-%% STAGE, not the data -- so no token material is echoed, and (per the design
-%% decision) the message is not audit-logged regardless.
+%% STAGE, not the data -- so no token material is echoed, and the message is not
+%% audit-logged regardless.
 -define(REASON_AUTHZ_UNAVAILABLE, <<
     "authorization evaluation requires the rabbitmq_auth_backend_oauth2 plugin "
     "to be loaded on this broker; it is not"
@@ -249,7 +249,7 @@ evaluator_compiled_in() ->
 %%       where Msg distinguishes: no effective scopes after prefix/alias
 %%       filtering, scopes present but none match, or too-many-scopes. The
 %%       CATEGORY stays authz_unverified in every failing case; only the message
-%%       differs (see the reason macros above for the R4 rationale).
+%%       differs (see the reason macros above for the granularity rationale).
 -spec maybe_check(map(), map()) -> aws_auth_validate_backend:result().
 maybe_check(#{authz_check := none}, _Claims) ->
     ok;

--- a/src/aws_auth_validate_ssl.erl
+++ b/src/aws_auth_validate_ssl.erl
@@ -670,11 +670,13 @@ generic_arn_resolve() ->
 %% Naming the FIELD is safe and is the point of the endpoint: a field name is
 %% part of the request the caller just sent us, so it discloses nothing they do
 %% not already know, and it saves them guessing which of several ARNs is broken.
-%% What must never appear is the resolved CONTENT (R6) -- and it cannot, because
-%% only these caller-supplied key paths are interpolated. The underlying AWS
-%% error is also deliberately dropped: it can carry account ids, bucket names,
-%% and IAM role details, so the categories stay fixed (R4) and the distinction
-%% between "does not exist" and "access denied" stays hidden.
+%% What must never appear is the resolved CONTENT -- a resolved secret (password,
+%% PEM, token) must never appear in a response, log, or crash report. The
+%% underlying AWS error is also deliberately dropped: it can carry account ids,
+%% bucket names, and IAM role details, so the categories stay fixed (responses
+%% use only a fixed set of categories and hardcoded reason strings to prevent
+%% SSRF reconnaissance) and the distinction between "does not exist" and "access
+%% denied" stays hidden.
 %%
 %% Fields are emitted in the caller-supplied order (each backend passes them in
 %% a fixed order) so the message is deterministic and testable.

--- a/src/aws_auth_validate_ssl.erl
+++ b/src/aws_auth_validate_ssl.erl
@@ -41,6 +41,8 @@
     %% TLS-material resolution + translation (network phase)
     resolve_cacerts/2,
     resolve_client_cert/2,
+    resolve_ssl_material/2,
+    arn_resolve_reason/1,
     decode_pem_cacerts/1,
     decode_client_cert/1,
     decode_client_key/1,
@@ -64,6 +66,19 @@
     connection_timeout_ms/1,
     is_nonempty_binary/1
 ]).
+
+%% CONTENT-failure reasons for the mTLS pair: the ARN resolved but the payload
+%% holds no usable material. Distinct from an ARN-RESOLUTION failure (see
+%% arn_resolve_reason/1) so the operator is not sent looking at IAM or the ARN
+%% string when the object exists and is simply the wrong thing. Naming the field
+%% is safe for the same reason it is in arn_resolve_reason/1 -- it echoes a key
+%% the caller sent, never the resolved bytes.
+-define(REASON_CERTFILE_NO_CERT,
+    <<"ssl_options.certfile_arn resolved but contains no certificate">>
+).
+-define(REASON_KEYFILE_NO_KEY,
+    <<"ssl_options.keyfile_arn resolved but contains no usable private key">>
+).
 
 %% Accepted values for `verify' and `versions', shared by all backends.
 -define(SSL_VERIFY_VALUES, [<<"verify_peer">>, <<"verify_none">>]).
@@ -275,9 +290,15 @@ nonempty_or(V, ReasonKey, Opts) ->
 %%--------------------------------------------------------------------
 
 %% Resolve ssl_options.cacertfile_arn to the raw-DER cacerts ssl option (or [] if
-%% absent / no cert entries). Any resolve failure -> input_invalid (fixed reason).
+%% absent / no cert entries).
+%%
+%% A resolve failure returns the `arn_resolve_failed' sentinel rather than a
+%% finished reason string: only the caller knows which request field this ARN
+%% came from, and resolve_ssl_material/2 aggregates that attribution across all
+%% the ARNs in one request. resolve_arn_reason/1 turns the sentinel into a
+%% caller-facing binary for the single-ARN callers.
 -spec resolve_cacerts(term(), aws_lib:aws_state()) ->
-    {ok, list()} | {error, aws_auth_validate_backend:error_category(), binary()}.
+    {ok, list()} | {error, aws_auth_validate_backend:error_category(), binary() | atom()}.
 resolve_cacerts(undefined, _State) ->
     {ok, []};
 resolve_cacerts(Arn, State) when is_binary(Arn) ->
@@ -288,35 +309,78 @@ resolve_cacerts(Arn, State) when is_binary(Arn) ->
                 Certs -> {ok, [{cacerts, Certs}]}
             end;
         {error, _} ->
-            {error, input_invalid, generic_arn_resolve()}
+            {error, input_invalid, arn_resolve_failed}
+    end.
+
+%% Resolve every ARN the request references under ssl_options, attempting ALL of
+%% them so a single response can name every field that failed.
+%%
+%% Short-circuiting on the first failure would force the operator into one round
+%% trip per broken ARN, which is exactly the guess-and-retry loop this endpoint
+%% exists to remove. The cost is bounded: at most three ARNs per request
+%% (cacertfile/certfile/keyfile), already gated by the assume_role guardrail and
+%% the concurrency semaphore.
+%%
+%% Resolution failures are aggregated and attributed to their fields. A CONTENT
+%% failure (the ARN resolved but the payload holds no usable material) is
+%% reported unchanged and takes precedence only when nothing failed to resolve,
+%% since at that point naming the ARN would misdescribe the problem.
+-spec resolve_ssl_material(map(), aws_lib:aws_state() | none) ->
+    {ok, list()} | {error, aws_auth_validate_backend:error_category(), binary()}.
+resolve_ssl_material(Map, State) ->
+    CacertRes =
+        case resolve_cacerts(maps:get(<<"cacertfile_arn">>, Map, undefined), State) of
+            {error, input_invalid, arn_resolve_failed} ->
+                {arn_failed, [<<"ssl_options.cacertfile_arn">>]};
+            Other ->
+                Other
+        end,
+    Results = [CacertRes, resolve_client_cert(Map, State)],
+    case [Fields || {arn_failed, Fields} <- Results] of
+        [_ | _] = Failed ->
+            {error, input_invalid, arn_resolve_reason(lists:append(Failed))};
+        [] ->
+            case [Err || {error, _, _} = Err <- Results] of
+                [Err | _] -> Err;
+                [] -> {ok, lists:append([Opts || {ok, Opts} <- Results])}
+            end
     end.
 
 %% Resolve the client certificate + private key for mutual TLS. parse_ssl_options
 %% already guaranteed both are present or both absent, so here we either resolve
 %% the pair or return no client-auth options.
+%%
+%% Both ARNs are fetched before either is decoded, so a request whose cert AND
+%% key ARNs are both broken names both fields instead of only the cert. Decoding
+%% still happens cert-then-key, since a content error is reported unchanged and
+%% needs no aggregation.
 -spec resolve_client_cert(map(), aws_lib:aws_state()) ->
-    {ok, list()} | {error, aws_auth_validate_backend:error_category(), binary()}.
+    {ok, list()}
+    | {error, aws_auth_validate_backend:error_category(), binary()}
+    | {arn_failed, [binary()]}.
 resolve_client_cert(#{<<"certfile_arn">> := CertArn, <<"keyfile_arn">> := KeyArn}, State) when
     is_binary(CertArn), is_binary(KeyArn)
 ->
-    case resolve_arn(CertArn, State) of
-        {ok, CertPem} ->
+    CertRes = resolve_arn(CertArn, State),
+    KeyRes = resolve_arn(KeyArn, State),
+    Failed =
+        [<<"ssl_options.certfile_arn">> || element(1, CertRes) =:= error] ++
+            [<<"ssl_options.keyfile_arn">> || element(1, KeyRes) =:= error],
+    case Failed of
+        [_ | _] ->
+            {arn_failed, Failed};
+        [] ->
+            {ok, CertPem} = CertRes,
+            {ok, KeyPem} = KeyRes,
             case decode_client_cert(CertPem) of
                 {error, _, _} = Err ->
                     Err;
                 {ok, CertOpt} ->
-                    case resolve_arn(KeyArn, State) of
-                        {ok, KeyPem} ->
-                            case decode_client_key(KeyPem) of
-                                {error, _, _} = Err -> Err;
-                                {ok, KeyOpt} -> {ok, [CertOpt, KeyOpt]}
-                            end;
-                        {error, _} ->
-                            {error, input_invalid, generic_arn_resolve()}
+                    case decode_client_key(KeyPem) of
+                        {error, _, _} = Err -> Err;
+                        {ok, KeyOpt} -> {ok, [CertOpt, KeyOpt]}
                     end
-            end;
-        {error, _} ->
-            {error, input_invalid, generic_arn_resolve()}
+            end
     end;
 resolve_client_cert(_Map, _State) ->
     {ok, []}.
@@ -333,17 +397,19 @@ decode_pem_cacerts(B) when is_binary(B) ->
     end.
 
 %% Decode a client-certificate PEM into an ssl {cert, [DER]} option. A PEM with
-%% no certificate entry is a resolution-shaped failure (fixed ARN category).
+%% no certificate entry is a CONTENT failure: the ARN resolved, the payload is
+%% just unusable, so the reason says so rather than blaming resolution.
 -spec decode_client_cert(binary()) ->
     {ok, {cert, [binary()]}} | {error, aws_auth_validate_backend:error_category(), binary()}.
 decode_client_cert(Pem) when is_binary(Pem) ->
     case [Der || {'Certificate', Der, not_encrypted} <- public_key:pem_decode(Pem)] of
-        [] -> {error, input_invalid, generic_arn_resolve()};
+        [] -> {error, input_invalid, ?REASON_CERTFILE_NO_CERT};
         Ders -> {ok, {cert, Ders}}
     end.
 
 %% Decode a private-key PEM into an ssl {key, {Asn1Type, DER}} option. An
-%% encrypted or absent key is a fixed ARN-category failure.
+%% encrypted or absent key is a CONTENT failure (the ARN resolved), so the reason
+%% names the field and the payload problem rather than blaming resolution.
 -spec decode_client_key(binary()) ->
     {ok, {key, {atom(), binary()}}}
     | {error, aws_auth_validate_backend:error_category(), binary()}.
@@ -357,7 +423,7 @@ decode_client_key(Pem) when is_binary(Pem) ->
     ],
     case KeyEntries of
         [{Type, Der} | _] -> {ok, {key, {Type, Der}}};
-        [] -> {error, input_invalid, generic_arn_resolve()}
+        [] -> {error, input_invalid, ?REASON_KEYFILE_NO_KEY}
     end.
 
 %% Translate the non-cacert ssl_options keys into an ssl proplist. SniKey is the
@@ -593,11 +659,34 @@ connection_timeout_ms(#{default := Default, max := Max}) ->
 reason(Key, #{reasons := Reasons}) ->
     maps:get(Key, Reasons).
 
-%% The generic ARN-resolve reason. resolve_cacerts/2, resolve_client_cert/2, and
-%% the PEM decoders all report the same fixed string across backends (all three
-%% originals used <<"failed to resolve ARN">> in these paths).
+%% The generic ARN-resolve reason. Retained for the PEM-decode paths, where the
+%% ARN itself resolved fine and the failure is about the CONTENT, so naming the
+%% field would misdescribe what went wrong.
 generic_arn_resolve() ->
     <<"failed to resolve ARN">>.
+
+%% Build the ARN-resolution failure reason, naming which request fields failed.
+%%
+%% Naming the FIELD is safe and is the point of the endpoint: a field name is
+%% part of the request the caller just sent us, so it discloses nothing they do
+%% not already know, and it saves them guessing which of several ARNs is broken.
+%% What must never appear is the resolved CONTENT (R6) -- and it cannot, because
+%% only these caller-supplied key paths are interpolated. The underlying AWS
+%% error is also deliberately dropped: it can carry account ids, bucket names,
+%% and IAM role details, so the categories stay fixed (R4) and the distinction
+%% between "does not exist" and "access denied" stays hidden.
+%%
+%% Fields are emitted in the caller-supplied order (each backend passes them in
+%% a fixed order) so the message is deterministic and testable.
+-spec arn_resolve_reason([binary()]) -> binary().
+arn_resolve_reason([]) ->
+    %% No field attribution available -- fall back to the generic wording rather
+    %% than emitting an empty list.
+    generic_arn_resolve();
+arn_resolve_reason(Fields) ->
+    iolist_to_binary([
+        <<"ARN resolution failed for: ">>, lists:join(<<", ">>, Fields)
+    ]).
 
 no_trust_anchor() ->
     <<"verify_peer requested but no CA trust anchor is available; supply cacertfile_arn">>.

--- a/src/aws_auth_validate_tls.erl
+++ b/src/aws_auth_validate_tls.erl
@@ -450,7 +450,8 @@ to_str(T) when is_list(T) -> T.
 %%--------------------------------------------------------------------
 
 %% client_cert is optional; when present it must be a non-empty binary holding
-%% only certificate PEM entries (no private key material -- R6).
+%% only certificate PEM entries (no private key material, so no credential can
+%% leak through this field).
 parse_client_cert(Body, Acc) ->
     case maps:get(<<"client_cert">>, Body, undefined) of
         undefined ->
@@ -966,9 +967,10 @@ maybe_sanitize_other_name(_Type, Value) ->
 %% The broker's live EXTERNAL login calls rabbit_access_control:check_user_login/2,
 %% which walks ALL configured auth_backends (each entry may be a bare module or a
 %% {AuthN, AuthZ} tuple). We can only query rabbit_auth_backend_internal (a local
-%% mnesia/khepri read -- no I/O, no state mutation, R3-safe). If other backends
-%% are also configured, a not-found in the internal backend does NOT mean the user
-%% does not exist -- the broker may authenticate it via LDAP, HTTP, or OAuth.
+%% mnesia/khepri read -- no I/O, no state mutation, so it preserves the
+%% zero-side-effects invariant). If other backends are also configured, a
+%% not-found in the internal backend does NOT mean the user does not exist --
+%% the broker may authenticate it via LDAP, HTTP, or OAuth.
 %%
 %% Strategy:
 %%   - internal backend unavailable -> config_conflict (cannot check at all).
@@ -1023,9 +1025,10 @@ module_ready(Mod) ->
 
 %% Cap username length and strip control characters, ensuring the result is
 %% valid UTF-8 (required for JSON-safe reason binaries in the response). The
-%% username derives from the caller's own supplied certificate (R4 basis for
-%% echoing it), but we bound it against degenerate inputs. Non-UTF-8 bytes
-%% (e.g. raw iPAddress SANs) are hex-escaped so the reason is always encodable.
+%% username derives from the caller's own supplied certificate, not from broker
+%% infrastructure, which is why echoing it does not breach the fixed-category
+%% rule, but we bound it against degenerate inputs. Non-UTF-8 bytes (e.g. raw
+%% iPAddress SANs) are hex-escaped so the reason is always encodable.
 %%
 %% NOTE: iPAddress SANs are kept as raw bytes for the user LOOKUP (matching
 %% upstream rabbit_ssl/rabbit_cert_info behavior, which passes the raw value

--- a/src/aws_auth_validate_tls.erl
+++ b/src/aws_auth_validate_tls.erl
@@ -81,7 +81,12 @@
     <<"ssl_options.fail_if_no_peer_cert must be true or false">>
 ).
 -define(REASON_BAD_SSL_CACERT_ARN, <<"ssl_options.cacertfile_arn must be a non-empty string">>).
--define(REASON_ARN_RESOLVE, <<"failed to resolve ARN">>).
+%% Names the field whose ARN failed to resolve. The field name comes from the
+%% caller's own request, so it leaks nothing; the resolved content and the
+%% underlying AWS error are never included.
+-define(REASON_ARN_RESOLVE,
+    aws_auth_validate_ssl:arn_resolve_reason([<<"ssl_options.cacertfile_arn">>])
+).
 -define(REASON_NO_CERTS, <<"cacertfile ARN did not resolve to any CA certificates">>).
 -define(REASON_BAD_CERT, <<"a certificate in the CA bundle could not be parsed">>).
 -define(REASON_CERT_EXPIRED, <<"the CA bundle contains an expired certificate">>).
@@ -206,6 +211,9 @@ do_tls_validate(#{ssl_options := Map} = Params) ->
         {ok, Pem} ->
             decode_and_check(Pem)
     end.
+
+%% This backend takes exactly one ARN, so there is never more than one field to
+%% attribute; the shared aggregating resolver is unnecessary here.
 
 %% Decode the CA PEM and check each certificate. The decode is wrapped because
 %% public_key:pem_decode/1 raises (rather than returning `skip') on a

--- a/test/aws_auth_validate_http_tests.erl
+++ b/test/aws_auth_validate_http_tests.erl
@@ -558,8 +558,87 @@ http_resolve_arn_fails_closed_on_none_sentinel_test_() ->
             },
             Result = aws_auth_validate_http:build_client_ssl_opts(Params),
             [
-                ?_assertEqual({error, input_invalid, <<"failed to resolve ARN">>}, Result),
+                ?_assertEqual(
+                    {error, input_invalid,
+                        <<"ARN resolution failed for: ssl_options.cacertfile_arn">>},
+                    Result
+                ),
                 ?_assertEqual(0, meck:num_calls(aws_arn_util, resolve_arn, '_'))
+            ]
+        end}.
+
+%% All THREE ARN fields failing are named in one response. The point of the
+%% attribution is that an operator with several broken ARNs learns about all of
+%% them in a single call instead of one per round trip, so the resolver must
+%% attempt every ARN rather than stopping at the first failure.
+http_arn_resolve_failure_names_all_failed_fields_test_() ->
+    {setup,
+        fun() ->
+            ok = meck:new(aws_arn_util, [passthrough]),
+            meck:expect(aws_arn_util, resolve_arn, fun(_Arn, State) -> {error, denied, State} end),
+            ok
+        end,
+        fun(_) -> meck:unload(aws_arn_util) end, fun(_) ->
+            Params = #{
+                ssl_options => #{
+                    <<"cacertfile_arn">> => <<"arn:aws:s3:::ca">>,
+                    <<"certfile_arn">> => <<"arn:aws:s3:::cert">>,
+                    <<"keyfile_arn">> => <<"arn:aws:s3:::key">>
+                },
+                aws_state => fake_state
+            },
+            Result = aws_auth_validate_http:build_client_ssl_opts(Params),
+            [
+                ?_assertEqual(
+                    {error, input_invalid, <<
+                        "ARN resolution failed for: ssl_options.cacertfile_arn, "
+                        "ssl_options.certfile_arn, ssl_options.keyfile_arn"
+                    >>},
+                    Result
+                ),
+                %% Every ARN must actually be attempted -- that is what makes the
+                %% full list possible. Short-circuiting would name only the first.
+                ?_assertEqual(3, meck:num_calls(aws_arn_util, resolve_arn, '_'))
+            ]
+        end}.
+
+%% Only the fields that actually failed are named: a request whose CA bundle
+%% resolves but whose mTLS key does not must not blame the CA bundle.
+http_arn_resolve_failure_names_only_failed_fields_test_() ->
+    {setup,
+        fun() ->
+            ok = meck:new(aws_arn_util, [passthrough]),
+            meck:expect(aws_arn_util, resolve_arn, fun(Arn, State) ->
+                case lists:suffix("key", Arn) of
+                    true -> {error, denied, State};
+                    false -> {ok, ?SECRET, State}
+                end
+            end),
+            ok
+        end,
+        fun(_) -> meck:unload(aws_arn_util) end, fun(_) ->
+            Params = #{
+                ssl_options => #{
+                    <<"cacertfile_arn">> => <<"arn:aws:s3:::ca">>,
+                    <<"certfile_arn">> => <<"arn:aws:s3:::cert">>,
+                    <<"keyfile_arn">> => <<"arn:aws:s3:::key">>
+                },
+                aws_state => fake_state
+            },
+            Result = aws_auth_validate_http:build_client_ssl_opts(Params),
+            [
+                ?_assertEqual(
+                    {error, input_invalid,
+                        <<"ARN resolution failed for: ssl_options.keyfile_arn">>},
+                    Result
+                ),
+                %% The resolved material must never appear in the reason (R6).
+                ?_assertNot(
+                    case Result of
+                        {error, _, R} -> binary:match(R, ?SECRET) =/= nomatch;
+                        _ -> false
+                    end
+                )
             ]
         end}.
 

--- a/test/aws_auth_validate_http_tests.erl
+++ b/test/aws_auth_validate_http_tests.erl
@@ -5,7 +5,7 @@
 
 %% Unit tests for aws_auth_validate_http: pure input validation (every
 %% ?REASON_*), the SSRF literal-IP classifier reached through validate/1,
-%% ARN-first ordering + R6 no-leak (resolve_arn mocked), and the behaviour
+%% ARN-first ordering + no-secret-leakage (resolve_arn mocked), and the behaviour
 %% callbacks. The live (m)TLS probe path runs in aws_auth_validate_mgmt_SUITE /
 %% an HTTP integration suite. Internal helpers (classify_ip/1, in_cidr/2,
 %% resolve_and_pin/1, classify_http_error/1, is_tls_error/1 etc.) are exported
@@ -19,8 +19,9 @@
 %% aws_lib:aws_state() record literal). Mirror that: include eunit only.
 
 %% A unique sentinel standing in for a resolved ARN secret (CA/client-cert/key
-%% material). If it appears in a rendered result term, R6 is violated. Mirrors
-%% the ?SECRET macro and string_find/2 helper in aws_auth_validate_tests.erl.
+%% material). If it appears in a rendered result term, the no-credential-leakage
+%% invariant is violated. Mirrors the ?SECRET macro and string_find/2 helper in
+%% aws_auth_validate_tests.erl.
 %% Binary (not list) to match aws_arn_util:resolve_arn/2's return type.
 -define(SECRET, <<"S3cr3t-Sentinel-Cert-Material-DO-NOT-LEAK">>).
 
@@ -632,7 +633,7 @@ http_arn_resolve_failure_names_only_failed_fields_test_() ->
                         <<"ARN resolution failed for: ssl_options.keyfile_arn">>},
                     Result
                 ),
-                %% The resolved material must never appear in the reason (R6).
+                %% The resolved material must never appear in the reason.
                 ?_assertNot(
                     case Result of
                         {error, _, R} -> binary:match(R, ?SECRET) =/= nomatch;
@@ -671,7 +672,7 @@ http_arn_request_without_role_is_config_conflict_test_() ->
         end}.
 
 %%--------------------------------------------------------------------
-%% R6: a resolved secret (CA/cert/key PEM) must never reach a result term,
+%% A resolved secret (CA/cert/key PEM) must never reach a result term,
 %% log, or crash report -- even when the probe raises with the secret in scope.
 %% Mirrors ldap_bind_raise_does_not_leak_password_test_.
 %%--------------------------------------------------------------------

--- a/test/aws_auth_validate_ldap_SUITE.erl
+++ b/test/aws_auth_validate_ldap_SUITE.erl
@@ -31,7 +31,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 %% Directory layout we seed (mirrors the backend dep's base DN so the
-%% R12 parity comparison is against a realistic tree).
+%% decision-parity comparison is against a realistic tree).
 -define(BASE_DN, "dc=rabbitmq,dc=com").
 -define(ADMIN_DN, "cn=admin,dc=rabbitmq,dc=com").
 -define(ADMIN_PW, "admin").
@@ -356,7 +356,7 @@ username_runtime_placeholder_degrades_returns_ok(Config) ->
     },
     ?assertEqual(ok, validate(Config, Body)).
 
-%% R11/R12 membership parity: the endpoint's in_group decision for a resolved
+%% Membership decision parity: the endpoint's in_group decision for a resolved
 %% principal must match a direct eldap equalityMatch(member, userDN) search --
 %% the same primitive rabbit_auth_backend_ldap:in_group/3 runs. Check both the
 %% positive (admins) and negative (others) group for alice.
@@ -419,7 +419,7 @@ direct_member(Port, GroupDn, UserDn) ->
     Result.
 
 %%--------------------------------------------------------------------
-%% R12: parity with the broker's bind path
+%% Decision parity with the broker's bind path
 %%--------------------------------------------------------------------
 
 %% For the same (server, port, DN, password), the endpoint's validate

--- a/test/aws_auth_validate_mgmt_SUITE.erl
+++ b/test/aws_auth_validate_mgmt_SUITE.erl
@@ -205,9 +205,9 @@ init_per_testcase(success_returns_204 = TC, Config) ->
     rabbit_ct_helpers:testcase_started(Config, TC);
 init_per_testcase(backend_raise_returns_500_without_leak = TC, Config) ->
     %% Drive the registry dispatch to RAISE with a secret-bearing term, so the
-    %% handler's with_semaphore/6 defence-in-depth catch (the R6 crash-dump guard)
-    %% is exercised through the real Cowboy pipeline. The mock runs ON THE BROKER
-    %% NODE so the handler sees it.
+    %% handler's with_semaphore/6 defence-in-depth catch (the crash-dump leakage
+    %% guard) is exercised through the real Cowboy pipeline. The mock runs ON THE
+    %% BROKER NODE so the handler sees it.
     ok = rabbit_ct_broker_helpers:rpc(
         Config, 0, ?MODULE, mock_dispatch_raise, [?LEAK_SENTINEL]
     ),
@@ -404,12 +404,12 @@ method_disabled_returns_404(Config) ->
     {ok, {{_, Code, _}, _, _}} = put_request(Config, ?API, Body),
     ?assertEqual(404, Code).
 
-%% R5/R6 (crash-dump leakage): the handler's with_semaphore/6 wraps the backend
-%% dispatch in a try/catch whose sole purpose is to keep an escaping exception --
-%% which would carry the request BodyMap (and any resolved secret) into a Cowboy
-%% crash report -- from ever surfacing. Nothing exercised that catch before: the
-%% success/error paths all RETURN a value, so the class:reason:stack discard was
-%% asserted nowhere.
+%% No credential leakage (crash-dump path): the handler's with_semaphore/6 wraps
+%% the backend dispatch in a try/catch whose sole purpose is to keep an escaping
+%% exception -- which would carry the request BodyMap (and any resolved secret)
+%% into a Cowboy crash report -- from ever surfacing. Nothing exercised that catch
+%% before: the success/error paths all RETURN a value, so the class:reason:stack
+%% discard was asserted nowhere.
 %%
 %% Here we force dispatch to RAISE with a secret-bearing term (the worst case for
 %% a crash-report leak) and drive a real PUT through the handler. We assert:
@@ -419,7 +419,7 @@ method_disabled_returns_404(Config) ->
 %%      body -- it is a fixed category + message only.
 %% The submitted-password no-leak on the response is covered by
 %% password_not_in_response; this is specifically the RAISE path through the
-%% handler boundary that the design doc flagged as unproven.
+%% handler boundary that was previously unproven.
 backend_raise_returns_500_without_leak(Config) ->
     Body = (base_body())#{<<"password">> => ?LEAK_SENTINEL},
     {ok, {{_, Code, _}, _Headers, ResBody}} = put_request(Config, ?API, Body),
@@ -466,11 +466,11 @@ custom_tag_insufficient_returns_401(Config) ->
     ?assertEqual(401, Code),
     ?assertMatch(#{<<"error">> := <<"insufficient_user_tag">>}, decode(ResBody)).
 
-%% R2 confirmatory test: the authorize_tag/3 `user = undefined' clause
-%% (aws_auth_validate_mgmt.erl) lets a request through WITHOUT a user, on the
-%% documented assumption that only an unauthenticated OPTIONS preflight can reach
-%% it (rabbit_mgmt_util short-circuits OPTIONS to {true, _, undefined} before
-%% authenticating). The safety of the whole custom-tag branch rests on that
+%% Authorization gate confirmatory test: the authorize_tag/3 `user = undefined'
+%% clause (aws_auth_validate_mgmt.erl) lets a request through WITHOUT a user, on
+%% the documented assumption that only an unauthenticated OPTIONS preflight can
+%% reach it (rabbit_mgmt_util short-circuits OPTIONS to {true, _, undefined}
+%% before authenticating). The safety of the whole custom-tag branch rests on that
 %% clause being UNREACHABLE by a state-changing PUT. This asserts the invariant:
 %% an UNAUTHENTICATED PUT (no auth header) is stopped with 401 by is_authorized/2
 %% BEFORE authorize_tag/3 is reached -- it must never dispatch. If a future
@@ -570,7 +570,7 @@ oauth_success_returns_204(Config) ->
 
 %% The 204 response must carry no secret material. We submit a body that
 %% contains a plausible secret field and verify it does not appear in the
-%% response (R6).
+%% response.
 oauth_response_no_secret(Config) ->
     Secret = <<"oauth-client-secret-DO-NOT-LEAK-1234">>,
     Body = (oauth_body())#{<<"client_secret">> => Secret},
@@ -655,7 +655,7 @@ oauth_authz_denies_returns_422(Config) ->
     {ok, {{_, Code, _}, _Headers, ResBody}} = put_request(Config, ?OAUTH_API, Body),
     ?assertEqual(422, Code),
     ?assertMatch(#{<<"error">> := <<"authz_unverified">>}, decode(ResBody)),
-    %% R6/R4: the caller's token must never appear in the response body.
+    %% The caller's token must never appear in the response body.
     ?assertEqual(nomatch, binary:match(iolist_to_binary(ResBody), Token)).
 
 %%--------------------------------------------------------------------

--- a/test/aws_auth_validate_oauth_SUITE.erl
+++ b/test/aws_auth_validate_oauth_SUITE.erl
@@ -232,9 +232,9 @@ custom_ca_verify_peer_returns_ok(Config) ->
         meck:unload(aws_arn_util)
     end.
 
-%% R4/R6: a fixed-category error response must not echo the target host, port,
-%% or URL. Drive an auth_failed (a 404 JWKS) and assert the rendered result
-%% contains neither the loopback address nor the stub port.
+%% Fixed-category responses must not echo the target host, port, or URL (doing so
+%% would enable SSRF reconnaissance). Drive an auth_failed (a 404 JWKS) and assert
+%% the rendered result contains neither the loopback address nor the stub port.
 error_reason_leaks_no_target_detail(Config) ->
     Port = ?config(self_port, Config),
     Url = self_url(Config, "/notfound"),

--- a/test/aws_auth_validate_oauth_tests.erl
+++ b/test/aws_auth_validate_oauth_tests.erl
@@ -419,7 +419,7 @@ oidc_discovery_jwks_uri_ssrf_denied_test_() ->
     end}.
 
 %%--------------------------------------------------------------------
-%% R6: no secret leakage in error results
+%% No secret leakage in error results
 %%--------------------------------------------------------------------
 
 %% A network-phase error must never include resolved secret material.
@@ -846,7 +846,7 @@ access_token_end_to_end_expired_test_() ->
         [?_assertMatch({error, token_expired, _}, aws_auth_validate_oauth:validate(Body))]
     end}.
 
-%% R6: a valid supplied token's claims must not leak into the rendered result.
+%% A valid supplied token's claims must not leak into the rendered result.
 access_token_no_leak_test_() ->
     {setup, fun setup_httpc_mock/0, fun teardown_httpc_mock/1, fun(_) ->
         #{jwk_pub := PubJwk, sign := Sign} = rsa_signer(<<"k1">>),

--- a/test/aws_auth_validate_shared_tests.erl
+++ b/test/aws_auth_validate_shared_tests.erl
@@ -333,10 +333,10 @@ scheme_policy_divergence_test() ->
     ?assertEqual(ok, aws_auth_validate_oauth:url_allowed(HttpsUrl)).
 
 %%--------------------------------------------------------------------
-%% aws_auth_validate_ssl:apply_verify_default/2 (R7): verify_peer is never
-%% SILENTLY downgraded. This is the false-positive the whole endpoint exists to
-%% prevent -- an operator who wrote verify_peer must not be told "reachable" by a
-%% probe that quietly fell back to verify_none. These pin every branch of the
+%% aws_auth_validate_ssl:apply_verify_default/2: verify_peer is never SILENTLY
+%% downgraded to verify_none. An explicitly requested verify_peer with no trust
+%% anchor must FAIL rather than pass, because silently downgrading would report a
+%% config as certificate-verified when it is not. These pin every branch of the
 %% policy directly, deterministically, without needing a live TLS server (the
 %% http/oauth/tls SUITEs cover it end to end but skip when no server is present).
 %%
@@ -362,9 +362,8 @@ with_empty_os_store(Fun) ->
         end,
         fun(_) -> meck:unload(public_key) end, Fun}.
 
-%% LOAD-BEARING R7 assertion: an EXPLICIT verify_peer with no trust anchor MUST
-%% fail closed with tls_failed -- it must never be silently downgraded to
-%% verify_none.
+%% LOAD-BEARING assertion: an EXPLICIT verify_peer with no trust anchor MUST fail
+%% closed with tls_failed -- it must never be silently downgraded to verify_none.
 apply_verify_default_explicit_verify_peer_without_anchor_fails_test_() ->
     with_empty_os_store(fun() ->
         Result = aws_auth_validate_ssl:apply_verify_default([{verify, verify_peer}], true),

--- a/test/aws_auth_validate_tests.erl
+++ b/test/aws_auth_validate_tests.erl
@@ -996,6 +996,62 @@ cacert_arn_resolution_test_() ->
                     aws_auth_validate_ldap:validate(tls_body(<<"arn:aws:cacert:garbage">>))
                 )
             end},
+            {"both ARNs unresolvable -> one reason naming BOTH fields", fun() ->
+                %% The plural case: an operator with two broken ARNs must learn
+                %% about both in one response instead of fixing one, retrying,
+                %% and discovering the second. Requires the resolver to attempt
+                %% both rather than stopping at the password.
+                meck:expect(aws_arn_util, resolve_arn, fun(_Arn, State) ->
+                    {error, not_found, State}
+                end),
+                ?assertEqual(
+                    {error, input_invalid, <<
+                        "ARN resolution failed for: password_arn, "
+                        "ssl_options.cacertfile_arn"
+                    >>},
+                    aws_auth_validate_ldap:validate(tls_body(<<"arn:aws:cacert:nope">>))
+                )
+            end},
+            {"only the password ARN failing names only that field", fun() ->
+                %% Attribution must be precise: a working CA bundle must not be
+                %% blamed alongside the broken password.
+                meck:expect(aws_arn_util, resolve_arn, fun(Arn, State) ->
+                    case lists:prefix("arn:aws:cacert", Arn) of
+                        true -> {ok, ca_pem_for_test(), State};
+                        false -> {error, not_found, State}
+                    end
+                end),
+                ?assertEqual(
+                    {error, input_invalid, <<"ARN resolution failed for: password_arn">>},
+                    aws_auth_validate_ldap:validate(tls_body(<<"arn:aws:cacert:ok">>))
+                )
+            end},
+            {"a password_arn SHAPE error fetches no ARN at all", fun() ->
+                %% ARN-first ordering: aggregating failures must not cause a
+                %% malformed request to trigger a secret fetch. A missing
+                %% password_arn is pure-input invalid, so neither ARN is fetched
+                %% even though a cacertfile_arn is present.
+                meck:expect(aws_arn_util, resolve_arn, fun(_Arn, State) ->
+                    {ok, <<"pw">>, State}
+                end),
+                Body = maps:remove(<<"password_arn">>, tls_body(<<"arn:aws:cacert:x">>)),
+                Result = aws_auth_validate_ldap:validate(Body),
+                ?assertMatch({error, input_invalid, <<"password_arn must be", _/binary>>}, Result),
+                ?assertEqual(0, meck:num_calls(aws_arn_util, resolve_arn, '_'))
+            end},
+            {"resolved secret never appears in the ARN-failure reason", fun() ->
+                %% R6: field attribution must not become a channel for content.
+                meck:expect(aws_arn_util, resolve_arn, fun(_Arn, State) ->
+                    {error, {access_denied, "arn:aws:iam::999:role/secret-role"}, State}
+                end),
+                {error, input_invalid, Reason} =
+                    aws_auth_validate_ldap:validate(tls_body(<<"arn:aws:cacert:nope">>)),
+                %% The underlying AWS error (which can carry account ids and role
+                %% names) must be dropped, not echoed.
+                ?assertEqual(nomatch, binary:match(Reason, <<"999">>)),
+                ?assertEqual(nomatch, binary:match(Reason, <<"secret-role">>)),
+                ?assertEqual(nomatch, binary:match(Reason, <<"access_denied">>))
+            end},
             {"CA-cert ARN ignored when TLS is off (no resolve, no error)", fun() ->
                 %% With use_ssl/use_starttls both false the CA cert is never
                 %% consumed, so a bogus cacertfile_arn must not trigger a
@@ -1018,6 +1074,25 @@ cacert_arn_resolution_test_() ->
                 ?assertNotMatch({error, input_invalid, _}, Result)
             end}
         ]}.
+
+%% A self-signed CA PEM, so a mocked cacertfile_arn can RESOLVE successfully and
+%% the test isolates password-ARN attribution from a CA content failure.
+ca_pem_for_test() ->
+    Dir = filename:join(["/tmp", "aws-auth-validate-ldap-arn-tests"]),
+    ok = filelib:ensure_dir(filename:join(Dir, "x")),
+    Key = filename:join(Dir, "ca-key.pem"),
+    Cert = filename:join(Dir, "ca-cert.pem"),
+    _ = os:cmd(
+        lists:flatten(
+            io_lib:format(
+                "openssl req -x509 -newkey rsa:2048 -nodes -keyout ~ts -out ~ts "
+                "-days 2 -subj /CN=AwsAuthValidateLdapArnTestCA 2>/dev/null",
+                [Key, Cert]
+            )
+        )
+    ),
+    {ok, Pem} = file:read_file(Cert),
+    Pem.
 
 %% A body with TLS enabled and a caller-supplied CA-cert ARN, otherwise valid.
 tls_body(CacertArn) ->

--- a/test/aws_auth_validate_tests.erl
+++ b/test/aws_auth_validate_tests.erl
@@ -860,11 +860,12 @@ assume_role_configured_failure_returns_input_invalid() ->
     ?assertEqual(0, meck:num_calls(aws_arn_util, resolve_arn, '_')).
 
 %%--------------------------------------------------------------------
-%% R6: password must never reach a crash report / log, even on a raise
+%% The resolved password must never reach a crash report or log, even on a raise
 %%--------------------------------------------------------------------
 
 %% A unique, recognisable sentinel standing in for the resolved bind password.
-%% If it appears anywhere in a crash report or log line, R6 is violated.
+%% If it appears anywhere in a crash report or log line, the no-credential-leakage
+%% invariant is violated.
 -define(SECRET, "S3cr3t-Sentinel-Passw0rd-DO-NOT-LEAK").
 
 %% do_ldap_validate/1 is not exported, so reach it via validate/1's public
@@ -1040,7 +1041,7 @@ cacert_arn_resolution_test_() ->
                 ?assertEqual(0, meck:num_calls(aws_arn_util, resolve_arn, '_'))
             end},
             {"resolved secret never appears in the ARN-failure reason", fun() ->
-                %% R6: field attribution must not become a channel for content.
+                %% Field attribution must not become a channel for secret content.
                 meck:expect(aws_arn_util, resolve_arn, fun(_Arn, State) ->
                     {error, {access_denied, "arn:aws:iam::999:role/secret-role"}, State}
                 end),
@@ -1317,8 +1318,8 @@ fill_does_not_affect_literal_dns_test() ->
 value_str({string, S}) -> S;
 value_str(S) when is_list(S) -> S.
 
-%% Parity of fill/2 with the broker's fill machinery (design req R12). Our DN
-%% sinks must match rabbit_ldap_rfc4514:fill_dn/2 and our value sinks must match
+%% Parity of fill/2 with the broker's fill machinery. Our DN sinks must match
+%% rabbit_ldap_rfc4514:fill_dn/2 and our value sinks must match
 %% rabbit_auth_backend_ldap_util:fill/2. Skips unless both upstream modules are
 %% loadable (same matrix concern as the parser parity test).
 fill_parity_test_() ->
@@ -1385,7 +1386,7 @@ fill_upstream_usable() ->
         erlang:function_exported(rabbit_ldap_rfc4514, fill_dn, 2) andalso
         erlang:function_exported(rabbit_auth_backend_ldap_util, fill, 2).
 
-%% Parity with rabbit_auth_backend_ldap_util:parse_query/1 (design req R12).
+%% Parity with rabbit_auth_backend_ldap_util:parse_query/1.
 %% The broker's parser throws via cuttlefish:invalid/2 on rejection; ours
 %% returns {error, _}. Assert both classify each corpus entry the same way.
 %%

--- a/test/aws_auth_validate_tls_tests.erl
+++ b/test/aws_auth_validate_tls_tests.erl
@@ -246,15 +246,30 @@ tls_malformed_pem_maps_to_input_invalid_test_() ->
         end
     ).
 
-%% An ARN resolution failure maps to input_invalid.
+%% An ARN resolution failure maps to input_invalid and NAMES the field that
+%% failed, so the operator knows which ARN to fix. This backend takes only
+%% cacertfile_arn, so there is exactly one field to name.
 tls_arn_resolve_failure_test_() ->
     {setup, fun setup_role/0, fun cleanup_role/1, fun(_) ->
         meck:expect(aws_arn_util, resolve_arn, fun(_Arn, State) -> {error, not_found, State} end),
         R = validate_ok_body(),
         [
-            ?_assertEqual({error, input_invalid, <<"failed to resolve ARN">>}, R)
+            ?_assertEqual(
+                {error, input_invalid, <<"ARN resolution failed for: ssl_options.cacertfile_arn">>},
+                R
+            ),
+            %% The resolved content and the underlying AWS error must never be
+            %% echoed, however specific the field attribution gets (R6/R4).
+            ?_assertNot(reason_contains(R, ?SECRET)),
+            ?_assertNot(reason_contains(R, <<"not_found">>))
         ]
     end}.
+
+%% True when the reason binary of an error result contains Needle.
+reason_contains({error, _Category, Reason}, Needle) when is_binary(Reason) ->
+    binary:match(Reason, Needle) =/= nomatch;
+reason_contains(_Other, _Needle) ->
+    false.
 
 %% A valid, in-window CA bundle passes. Generated fresh so it is current.
 tls_valid_ca_returns_ok_test_() ->

--- a/test/aws_auth_validate_tls_tests.erl
+++ b/test/aws_auth_validate_tls_tests.erl
@@ -259,7 +259,7 @@ tls_arn_resolve_failure_test_() ->
                 R
             ),
             %% The resolved content and the underlying AWS error must never be
-            %% echoed, however specific the field attribution gets (R6/R4).
+            %% echoed, however specific the field attribution gets.
             ?_assertNot(reason_contains(R, ?SECRET)),
             ?_assertNot(reason_contains(R, <<"not_found">>))
         ]

--- a/test/aws_auth_validate_tls_tests.erl
+++ b/test/aws_auth_validate_tls_tests.erl
@@ -461,7 +461,8 @@ tls_client_cert_not_binary_rejected_test_() ->
     ].
 
 tls_client_cert_private_key_rejected_test() ->
-    %% A PEM containing a private key must be rejected (R6).
+    %% A PEM containing a private key must be rejected: no credential material
+    %% may be accepted through this field.
     KeyPem = gen_private_key_pem(),
     Body = #{
         <<"target">> => <<"listener">>,
@@ -513,7 +514,7 @@ tls_client_cert_garbage_pem_rejected_test() ->
 tls_client_cert_openssh_key_rejected_test() ->
     %% An OpenSSH-format private key decodes as {{no_asn1, new_openssh}, _, _}
     %% -- a tuple type tag. The allowlist must reject it with the private-key
-    %% reason (R6 security invariant).
+    %% reason (the no-credential-leakage invariant).
     OpensshPem = openssh_key_pem(),
     {_CaKey, _CaDer, CaPem} = gen_ca(),
     Mixed = <<CaPem/binary, OpensshPem/binary>>,

--- a/test/aws_lib_config_tests.erl
+++ b/test/aws_lib_config_tests.erl
@@ -513,12 +513,12 @@ ini_split_line_test_() ->
 ini_parse_line_parts_does_not_crash_on_value_with_equals_test_() ->
     [
         {"a credential_process value with '=' parses as a single string value", fun() ->
-            Line = <<"credential_process = ada credentials print --account=591164066752">>,
+            Line = <<"credential_process = cred-helper print --account=123456789012">>,
             {NewSection, none} = aws_lib_config:ini_parse_line(
                 [], none, Line
             ),
             ?assertEqual(
-                "ada credentials print --account=591164066752",
+                "cred-helper print --account=123456789012",
                 proplists:get_value(credential_process, NewSection)
             )
         end}


### PR DESCRIPTION
> [!NOTE]
> This description was drafted by Claude (Anthropic's Claude Code) under the direction of @lukebakken, who reviewed it before posting.

Lands after #167. Cleans up comments across the auth validation endpoint code, replacing internal design-doc requirement IDs (R3/R4/R6, etc.) with inline rationale so the reasoning is legible to any contributor, and restoring two same-repo GitHub references (#116, #153) that resolve for any reader.

Also updates an aws_lib_config test fixture to use AWS documentation example account IDs. Comments only, apart from that fixture change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
