### PR TITLE
Fix `aws.prefer_imdsv2` cuttlefish key collision with the rabbitmq_aws library

### DIFF
--- a/AGENTS-aws_lib.md
+++ b/AGENTS-aws_lib.md
@@ -102,7 +102,7 @@ make t=aws_lib_tests eunit
 
 ## Configuration
 
-Application env `aws_prefer_imdsv2` (default: `true`) controls whether IMDSv2 is attempted before IMDSv1. Also exposed via Cuttlefish schema at `priv/schema/aws_lib.schema` as `aws.prefer_imdsv2` for RabbitMQ integration.
+Application env `aws_prefer_imdsv2` (default: `true`) controls whether IMDSv2 is attempted before IMDSv1. Also exposed via Cuttlefish schema at `priv/schema/aws.schema` as `aws.arns.prefer_imdsv2` for RabbitMQ integration (the bare `aws.prefer_imdsv2` key belongs to the `rabbitmq_aws` library).
 
 ## Known Issues
 

--- a/CODEBASE_SUMMARY.md
+++ b/CODEBASE_SUMMARY.md
@@ -146,7 +146,7 @@ The plugin uses Cuttlefish schema (`priv/schema/aws.schema`) to translate `rabbi
 ### Supported Configuration Keys
 
 **Core Settings:**
-- `aws.prefer_imdsv2` - Prefer EC2 IMDSv2 for metadata (default: true)
+- `aws.arns.prefer_imdsv2` - Prefer EC2 IMDSv2 for metadata (default: true)
 - `aws.arns.assume_role_arn` - IAM role to assume before fetching resources
 
 **RabbitMQ Core SSL:**

--- a/README-aws_lib.md
+++ b/README-aws_lib.md
@@ -116,7 +116,7 @@ By default, IMDSv2 (session-authenticated) is preferred. Falls back to IMDSv1 on
 [{aws_lib, [{aws_prefer_imdsv2, true}]}].  %% default
 ```
 
-Also available via Cuttlefish schema (`priv/schema/aws_lib.schema`) as `aws.prefer_imdsv2` for RabbitMQ plugin integration.
+Also available via Cuttlefish schema (`priv/schema/aws.schema`) as `aws.arns.prefer_imdsv2` for RabbitMQ plugin integration. The bare `aws.prefer_imdsv2` key is owned by the `rabbitmq_aws` library, so this plugin scopes its own setting under `aws.arns` to avoid a mapping collision.
 
 ## Build
 

--- a/priv/schema/aws.schema
+++ b/priv/schema/aws.schema
@@ -11,11 +11,16 @@
 %% See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html.
 
 %% NOTE:
-%% This routes through the "aws" application env (key aws_prefer_imdsv2),
-%% which is the single OTP application for this plugin. There is no separate
-%% rabbitmq_aws / aws_lib application to read from.
-%%
-{mapping, "aws.prefer_imdsv2", "aws.aws_prefer_imdsv2",
+%% The key lives under this plugin's own "aws.arns" namespace, NOT the bare
+%% "aws.prefer_imdsv2". The bare key is owned by the rabbitmq_aws library
+%% (used by rabbitmq_peer_discovery_aws), which maps it to
+%% rabbitmq_aws.aws_prefer_imdsv2. Two cuttlefish mappings cannot share one
+%% key, so when both schemas are present -- e.g. the umbrella running the
+%% rabbitmq_aws config_schema suite with this plugin checked out -- the bare
+%% key collides and the suite fails. Using a distinct key keeps this plugin's
+%% setting independent and routes through the "aws" application env (key
+%% aws_prefer_imdsv2), which aws_lib_config reads directly.
+{mapping, "aws.arns.prefer_imdsv2", "aws.aws_prefer_imdsv2",
     [{datatype, {enum, [true, false]}}]}.
 
 %% @doc IAM role ARN to assume before fetching resources from S3

--- a/test/config_schema_SUITE_data/aws.snippets
+++ b/test/config_schema_SUITE_data/aws.snippets
@@ -103,7 +103,7 @@
         [aws_arn_config]},
 
     {aws_prefer_imdsv2,
-        "aws.prefer_imdsv2 = false",
+        "aws.arns.prefer_imdsv2 = false",
         [{aws, [{aws_prefer_imdsv2, false}]}],
         [aws_arn_config]},
 


### PR DESCRIPTION
Fixes #166.

## Problem

Both this plugin and the `rabbitmq_aws` library mapped the cuttlefish key
`aws.prefer_imdsv2`, to different targets. Two mappings cannot own one key, so with
this plugin checked out in the umbrella the library's own suite fails:

```
config_schema_SUITE > run_snippets
    #1. {error, {{config_mismatch,
             {"rabbitmq_aws_prefer_imdsv2_false", "aws.prefer_imdsv2 = false", []},
             [{rabbitmq_aws,[{aws_prefer_imdsv2,false}]}],
             [{aws,[{aws_prefer_imdsv2,false}]}]}, ...
```

On 0.3.0 the plugin duplicated what `rabbitmq_aws` had, so there was no conflict.

## Change

Rename this plugin's key to **`aws.arns.prefer_imdsv2`**, inside the `aws.arns`
namespace the plugin already owns, and keep it mapped to this plugin's own
`aws.aws_prefer_imdsv2` app env. The bare `aws.prefer_imdsv2` key is ceded to the
library. The consumer in `aws_lib_config:instance_metadata_request_headers/1` is
unchanged -- it still reads `application:get_env(aws, aws_prefer_imdsv2)`.

## Why this shape

The key stays mapped to the plugin's **own** application env, so it resolves in a
standalone plugin build with no dependency on `rabbitmq_aws`:

```
aws.arns.prefer_imdsv2 = false  ->  [{aws,[{aws_prefer_imdsv2,false}]}]
```

The alternative -- keeping the bare `aws.prefer_imdsv2` key but retargeting it to
`rabbitmq_aws.aws_prefer_imdsv2` to match the library -- would require adding the
**entire `rabbitmq_aws` library to this plugin's `DEPS`** just to name its
application env. `rabbitmq_aws` is not currently a dependency (only
`rabbitmq_peer_discovery_aws` depends on it), and pulling it in solely to reuse an
env key is not ideal: it couples this plugin to a library whose stated purpose is
serving peer discovery, and cuttlefish still hard-fails at boot if that schema is
absent. Renaming avoids the dependency entirely.

Renaming is a **breaking config change** for operators who set `aws.prefer_imdsv2`
today: they must switch to `aws.arns.prefer_imdsv2`. Given the setting is niche
(IMDSv2 is already preferred by default) and the collision has to be resolved
somehow, I judged this cleaner than a new cross-package dependency, but I am happy
to switch to the DEPS approach if maintainers prefer keeping the key name stable.

## Verification

- Library `config_schema` suite against unmodified `main` -> **FAILS** with the
  `config_mismatch` above.
- This plugin's `config_schema_SUITE` with the renamed key -> **PASSES**.
- Standalone cuttlefish resolution with only this plugin's schema loaded:
  `aws.arns.prefer_imdsv2 = false` -> `[{aws,[{aws_prefer_imdsv2,false}]}]` (this is
  the case the earlier retarget approach failed in CI -- it now resolves without
  `rabbitmq_aws` present).
- eunit **814 passed, 0 failed** (matches the `main` baseline).