### PR TITLE
`aws_lib`: Remove the unused two-step connection API

### DIFF
--- a/AGENTS-aws_lib.md
+++ b/AGENTS-aws_lib.md
@@ -40,9 +40,8 @@ Checked in order by `aws_lib_config:credentials/1`:
 
 ### HTTP Client
 
-Uses Gun (HTTP/1.1 and HTTP/2). Two usage patterns:
-- **One-shot:** `request/6-8` opens connection, makes request, closes connection
-- **Pooled:** `open_connection/2` + `direct_request/7` + `close_connection/1`
+Uses Gun (HTTP/1.1 and HTTP/2). One-shot request lifecycle:
+- `request/6-8` opens connection, makes request, closes connection
 
 ### Retry Logic
 
@@ -52,7 +51,7 @@ Uses Gun (HTTP/1.1 and HTTP/2). Two usage patterns:
 
 | Module | Purpose |
 |--------|---------|
-| `aws_lib` | Main API: state management, request lifecycle, retries, connection pooling, EBS volume discovery |
+| `aws_lib` | Main API: state management, request lifecycle, retries, EBS volume discovery |
 | `aws_lib_config` | Credential/region loading from env, files, and IMDS; INI parsing; IMDSv2 token management |
 | `aws_lib_sign` | AWS Signature Version 4: canonical request, signing key derivation, authorization header |
 | `aws_lib_ops` | Higher-level EC2 operations: create/delete EBS snapshots |

--- a/README-aws_lib.md
+++ b/README-aws_lib.md
@@ -69,14 +69,6 @@ RequestHeaders = [{"Content-Type", "application/x-amz-json-1.0"},
 | `aws_lib:api_get_request/3` | GET with automatic retries |
 | `aws_lib:api_post_request/5` | POST with automatic retries |
 
-### Connection Pooling
-
-| Function | Description |
-|----------|-------------|
-| `aws_lib:open_connection/2-3` | Open a reusable connection to a service |
-| `aws_lib:direct_request/7` | Make request on an existing connection |
-| `aws_lib:close_connection/1` | Close a connection |
-
 ### EC2 Operations
 
 | Function | Description |

--- a/src/aws_lib.erl
+++ b/src/aws_lib.erl
@@ -28,9 +28,6 @@
     local_time/0,
     api_get_request/3,
     api_post_request/5,
-    open_connection/2, open_connection/3,
-    close_connection/1,
-    direct_request/7,
     endpoint/4,
     sign_headers/10,
     instance_volumes/1,
@@ -49,7 +46,6 @@
 -include_lib("kernel/include/logger.hrl").
 
 -opaque aws_state() :: #aws_state{}.
--type connection_handle() :: {aws_lib_httpc:conn(), string()}.
 
 %%====================================================================
 %% State construction and accessors
@@ -190,125 +186,6 @@ put(Service, Path, Body, Headers, Options, State) ->
 %% @end
 refresh_credentials(State) ->
     do_refresh_credentials(State).
-
-%%====================================================================
-%% New Concurrent API Functions
-%%====================================================================
-
-%% Open a connection and return handle for direct use
--spec open_connection(
-    Service :: string(),
-    State :: aws_state()
-) -> {ok, connection_handle(), aws_state()} | {error, term()}.
-open_connection(Service, State) ->
-    open_connection(Service, [], State).
-
--spec open_connection(
-    Service :: string(),
-    Options :: list(),
-    State :: aws_state()
-) -> {ok, connection_handle(), aws_state()} | {error, term()}.
-open_connection(Service, Options, State0) ->
-    % Get region from state or use default
-    Region =
-        case State0#aws_state.config of
-            #aws_config{region = R} when R =/= undefined -> R;
-            _ -> ?DEFAULT_REGION
-        end,
-
-    % Update state with region if it was default
-    State1 =
-        case State0#aws_state.config of
-            undefined ->
-                State0#aws_state{config = #aws_config{region = Region}};
-            #aws_config{region = undefined} = C ->
-                State0#aws_state{config = C#aws_config{region = Region}};
-            _ ->
-                State0
-        end,
-
-    Host = endpoint_host(Region, Service),
-    Port = 443,
-    %% The legacy two-step API always targets the real AWS endpoint over TLS; it
-    %% does not honour the endpoint-url override (see endpoint/4).
-    case aws_lib_httpc:open(Host, Port, gun_open_opts(tls, Options)) of
-        {ok, Conn} ->
-            {ok, {Conn, Service}, State1};
-        {error, _Reason} = Error ->
-            Error
-    end.
-
-%% Close a direct connection
--spec close_connection(Handle :: connection_handle()) -> ok.
-close_connection({Conn, _Service}) ->
-    aws_lib_httpc:close(Conn).
-
--spec direct_request(
-    Handle :: connection_handle(),
-    Method :: method(),
-    Path :: path(),
-    Body :: body(),
-    Headers :: headers(),
-    Options :: list(),
-    State :: aws_state()
-) -> {ok, {headers(), term()}, aws_state()} | {error, term()}.
-direct_request({GunPid, Service}, Method, Path, Body, Headers, Options, State0) ->
-    % Ensure we have credentials
-    State1 =
-        case has_credentials(State0) of
-            false ->
-                case refresh_credentials(State0) of
-                    {ok, S} -> S;
-                    {error, _} -> State0
-                end;
-            true ->
-                State0
-        end,
-
-    case State1#aws_state.credentials of
-        #aws_credentials{
-            access_key = AccessKey,
-            secret_key = SecretKey,
-            security_token = SecurityToken
-        } ->
-            % Get region
-            Region =
-                case State1#aws_state.config of
-                    #aws_config{region = R} when R =/= undefined -> R;
-                    _ -> ?DEFAULT_REGION
-                end,
-
-            Host = endpoint_host(Region, Service),
-            URI = create_uri(Host, Path),
-            BodyHash = proplists:get_value(payload_hash, Options),
-            case
-                sign_headers(
-                    AccessKey,
-                    SecretKey,
-                    SecurityToken,
-                    Region,
-                    Service,
-                    Method,
-                    URI,
-                    Headers,
-                    Body,
-                    BodyHash
-                )
-            of
-                {ok, SignedHeaders} ->
-                    Options1 = ensure_timeout_option(Options, State1),
-                    case direct_gun_request(GunPid, Method, Path, SignedHeaders, Body, Options1) of
-                        {ok, Response} ->
-                            {ok, Response, State1};
-                        Error ->
-                            Error
-                    end;
-                {error, _} = Error ->
-                    Error
-            end;
-        undefined ->
-            {error, no_credentials}
-    end.
 
 -spec sign_headers(
     AccessKey :: access_key(),
@@ -1105,30 +982,6 @@ gun_open_opts(Transport, Options) when Transport =:= tls; Transport =:= tcp ->
         connect_timeout => proplists:get_value(connect_timeout, Options, infinity),
         timeout => proplists:get_value(timeout, Options, ?DEFAULT_API_TIMEOUT)
     }.
-
-create_uri(Host, Path) when is_list(Path) ->
-    "https://" ++ Host ++ Path;
-create_uri(Host, {Bucket, Key}) ->
-    "https://" ++ Bucket ++ "." ++ Host ++ "/" ++ Key.
-
--spec direct_gun_request(
-    Conn :: aws_lib_httpc:conn(),
-    Method :: method(),
-    Path :: path() | {term(), path()},
-    Headers :: headers(),
-    Body :: body(),
-    Options :: list()
-) -> result().
-%% Issue a request on an already-open connection (the two-step API). The Gun
-%% lifecycle lives in aws_lib_httpc; this resolves the request timeout and
-%% shapes the result. A {_, Path} tuple (S3 bucket/key) is normalized to an
-%% absolute path first.
-direct_gun_request(Conn, Method, {_, Path}, Headers, Body, Options) ->
-    direct_gun_request(Conn, Method, [$/ | Path], Headers, Body, Options);
-direct_gun_request(Conn, Method, Path, Headers, Body, Options) ->
-    Timeout = proplists:get_value(timeout, Options, ?DEFAULT_API_TIMEOUT),
-    Response = aws_lib_httpc:request(Conn, Method, Path, Headers, Body, Timeout),
-    aws_lib_response:format_response(Response).
 
 -spec parse_volumes_response(term()) -> {'ok', volumes_list()} | {'error', 'parse_error'}.
 %% @doc Parse the DescribeVolumes XML response into a list of volume information.


### PR DESCRIPTION
Fixes #108.

## Change

Removes the two-step connection API from `aws_lib`, which had no callers anywhere:

- `open_connection/2`, `open_connection/3`
- `direct_request/7`
- `close_connection/1`
- the `connection_handle()` type, now unused
- `create_uri/2` and `direct_gun_request/6`, reachable only from the above

147 lines from `src/aws_lib.erl`, plus the doc references in `AGENTS-aws_lib.md`
and `README-aws_lib.md`.

Per the issue's sequencing note and @lukebakken's comment: this is the speculative,
untested, retry-bypassing version. If the reuse work later wants a
hold-a-connection-across-requests primitive, it should be designed and tested
deliberately there rather than adopted from here.

## Evidence the removal is safe

- No callers in `src/` or `test/`, and none in the sibling worktrees.
- No dynamic references (`apply/3`, atom-form calls, meck expectations,
  `-ifdef(TEST)` exports).
- `aws_lib_httpc:open/3` and `close/1` retain other callers, so they are not
  orphaned by this.
- The surviving reuse machinery is untouched and confirmed intact:
  `enable_connection_reuse/1`, `close_reuse_connection/1`, `seed_conn_from_state/1`,
  `finish_conn/2`, `perform_request_reuse/8`.

## Verification

- eunit: **814 passed, 0 failed** (matches the `main` baseline)
- `erlang:function_exported/3` returns `false` for the removed functions;
  `aws_lib:module_info(exports)` no longer lists them; calling one raises `undef`
- the surviving request path still works end to end against a local HTTP listener,
  including the `enable_connection_reuse/1` path
- no new dialyzer warnings (the ~30-warning backlog in #8 is pre-existing and
  untouched here)