### PR TITLE
`aws_lib`: Support IAM Roles Anywhere via `credential_process`

### DIFF
--- a/src/aws_lib_config.erl
+++ b/src/aws_lib_config.erl
@@ -22,7 +22,8 @@
     load_imdsv2_token/0,
     instance_metadata_request_headers/1,
     region/1,
-    endpoint_url/1
+    endpoint_url/1,
+    parse_iso8601_timestamp/1
 ]).
 
 %% Export all for unit tests
@@ -111,9 +112,15 @@ credentials(Config) ->
 %%      indicating the credentials are locally configured, and are not
 %%      temporary.
 %%
-%%      If no credentials could be resolved up until this point, there will be
-%%      an attempt to contact a local EC2 instance metadata service for
-%%      credentials.
+%%      If no credentials are found in the configuration or shared credentials
+%%      files, and the profile's config file section specifies a
+%%      ``credential_process`` key, the external helper command will be invoked.
+%%      If it succeeds, those credentials are returned. If it is configured but
+%%      fails, an error is returned without consulting the instance metadata
+%%      service.
+%%
+%%      If ``credential_process`` is not configured, there will be an attempt
+%%      to contact a local EC2 instance metadata service for credentials.
 %%
 %%      When the EC2 instance metadata server is checked for but does not exist,
 %%      the operation will timeout in ``?DEFAULT_IMDS_TIMEOUT``ms.
@@ -602,51 +609,56 @@ lookup_credentials_from_config(_, AccessKey, SecretKey, SessionToken, Config) ->
     Credentials :: list(),
     Config :: aws_config()
 ) ->
-    {ok, aws_credentials(), aws_config()} | error().
+    {ok, aws_credentials(), aws_config()} | {error, term()}.
 %% @doc Check to see if the shared credentials file exists and if it does,
-%%      invoke ``lookup_credentials_from_shared_creds_section/2`` to attempt to
-%%      get the credentials values out of it. If the file does not exist,
-%%      attempt to lookup the values from the EC2 instance metadata service.
+%%      invoke ``lookup_credentials_from_section/3`` to attempt to get the
+%%      credentials values out of it. If the file does not exist, attempt to
+%%      lookup values via credential_process (if configured in the profile's
+%%      config file section) or the EC2 instance metadata service.
 %% @end
-lookup_credentials_from_file(_, {error, _}, Config) ->
-    lookup_credentials_from_instance_metadata(Config);
+lookup_credentials_from_file(Profile, {error, _}, Config) ->
+    lookup_credentials_from_credential_process(Profile, Config);
 lookup_credentials_from_file(Profile, Credentials, Config) ->
     Section = proplists:get_value(Profile, Credentials),
-    lookup_credentials_from_section(Section, Config).
+    lookup_credentials_from_section(Profile, Section, Config).
 
 -spec lookup_credentials_from_section(
+    Profile :: string(),
     Credentials :: list() | undefined,
     Config :: aws_config()
 ) ->
-    {ok, aws_credentials(), aws_config()} | error().
+    {ok, aws_credentials(), aws_config()} | {error, term()}.
 %% @doc Return the access key and secret access key if they are set in
 %%      for the specified profile from the shared credentials file. If the
 %%      profile is not set or the values are not set in the profile, attempt to
-%%      lookup the values from the EC2 instance metadata service.
+%%      lookup the values via credential_process or the EC2 instance metadata
+%%      service.
 %% @end
-lookup_credentials_from_section(undefined, Config) ->
-    lookup_credentials_from_instance_metadata(Config);
-lookup_credentials_from_section(Credentials, Config) ->
+lookup_credentials_from_section(Profile, undefined, Config) ->
+    lookup_credentials_from_credential_process(Profile, Config);
+lookup_credentials_from_section(Profile, Credentials, Config) ->
     AccessKey = proplists:get_value(aws_access_key_id, Credentials, undefined),
     SecretKey = proplists:get_value(aws_secret_access_key, Credentials, undefined),
     SessionToken = proplists:get_value(aws_session_token, Credentials, undefined),
-    lookup_credentials_from_proplist(AccessKey, SecretKey, SessionToken, Config).
+    lookup_credentials_from_proplist(Profile, AccessKey, SecretKey, SessionToken, Config).
 
 -spec lookup_credentials_from_proplist(
+    Profile :: string(),
     AccessKey :: access_key(),
     SecretAccessKey :: secret_access_key(),
     SessionToken :: security_token(),
     Config :: aws_config()
 ) ->
-    {ok, aws_credentials(), aws_config()} | error().
+    {ok, aws_credentials(), aws_config()} | {error, term()}.
 %% @doc Process the contents of the Credentials proplists checking if the
-%%      access key and secret access key are both set.
+%%      access key and secret access key are both set. If either is undefined,
+%%      falls through to credential_process (if configured) before IMDS.
 %% @end
-lookup_credentials_from_proplist(undefined, _, _, Config) ->
-    lookup_credentials_from_instance_metadata(Config);
-lookup_credentials_from_proplist(_, undefined, _, Config) ->
-    lookup_credentials_from_instance_metadata(Config);
-lookup_credentials_from_proplist(AccessKey, SecretKey, SessionToken, Config) ->
+lookup_credentials_from_proplist(Profile, undefined, _, _, Config) ->
+    lookup_credentials_from_credential_process(Profile, Config);
+lookup_credentials_from_proplist(Profile, _, undefined, _, Config) ->
+    lookup_credentials_from_credential_process(Profile, Config);
+lookup_credentials_from_proplist(_Profile, AccessKey, SecretKey, SessionToken, Config) ->
     Creds = #aws_credentials{
         access_key = AccessKey,
         secret_key = SecretKey,
@@ -654,6 +666,58 @@ lookup_credentials_from_proplist(AccessKey, SecretKey, SessionToken, Config) ->
         expiration = undefined
     },
     {ok, Creds, Config}.
+
+-spec lookup_credentials_from_credential_process(
+    Profile :: string(),
+    Config :: aws_config()
+) ->
+    {ok, aws_credentials(), aws_config()} | {error, term()}.
+%% @doc Check the config file for a credential_process setting in the active
+%%      profile. If present, execute it and return credentials on success or a
+%%      hard error on failure (no fallthrough to IMDS). If absent, fall through
+%%      to the instance metadata service.
+%% @end
+lookup_credentials_from_credential_process(Profile, Config) ->
+    case get_credential_process_command(Profile) of
+        undefined ->
+            lookup_credentials_from_instance_metadata(Config);
+        Command ->
+            case aws_lib_credential_process:execute(Command) of
+                {ok, Creds} ->
+                    {ok, Creds, Config};
+                {error, _} = Error ->
+                    Error
+            end
+    end.
+
+-spec get_credential_process_command(Profile :: string()) -> string() | undefined.
+%% @doc Look up the credential_process key from the config file for the given
+%%      profile. In ~/.aws/config, non-default profiles are stored under
+%%      "[profile <name>]" while the default profile is stored as "[default]".
+%% @end
+get_credential_process_command(Profile) ->
+    case config_file_data() of
+        {error, _} ->
+            undefined;
+        ConfigData ->
+            %% Try the profile section name as-is first (handles "default"),
+            %% then try with "profile " prefix (handles non-default profiles
+            %% in the config file format).
+            Section = proplists:get_value(
+                Profile,
+                ConfigData,
+                proplists:get_value(
+                    "profile " ++ Profile,
+                    ConfigData,
+                    []
+                )
+            ),
+            case proplists:get_value(credential_process, Section) of
+                undefined -> undefined;
+                Value when is_list(Value) -> Value;
+                _ -> undefined
+            end
+    end.
 
 -spec with_metadata_connection(fun((aws_lib_httpc:conn()) -> Result)) -> Result.
 %% @doc Execute a function with a shared metadata service connection

--- a/src/aws_lib_config.erl
+++ b/src/aws_lib_config.erl
@@ -63,9 +63,15 @@
 %%      indicating the credentials are locally configured, and are not
 %%      temporary.
 %%
-%%      If no credentials could be resolved up until this point, there will be
-%%      an attempt to contact a local EC2 instance metadata service for
-%%      credentials.
+%%      If no credentials are found in the configuration or shared credentials
+%%      files, and the profile's config file section specifies a
+%%      ``credential_process`` key, the external helper command will be invoked.
+%%      If it succeeds, those credentials are returned. If it is configured but
+%%      fails, an error is returned without consulting the instance metadata
+%%      service.
+%%
+%%      If ``credential_process`` is not configured, there will be an attempt
+%%      to contact a local EC2 instance metadata service for credentials.
 %%
 %%      When the EC2 instance metadata server is checked for but does not exist,
 %%      the operation will timeout in ``?DEFAULT_IMDS_TIMEOUT``ms.

--- a/src/aws_lib_credential_process.erl
+++ b/src/aws_lib_credential_process.erl
@@ -92,14 +92,15 @@ collect_output(Port, Acc, Deadline) ->
     Remaining = max(0, Deadline - erlang:monotonic_time(millisecond)),
     receive
         {Port, {data, Data}} ->
-            NewAcc = <<Acc/binary, Data/binary>>,
-            case byte_size(NewAcc) > ?MAX_OUTPUT_BYTES of
+            %% Check size BEFORE allocating the combined binary to avoid
+            %% transiently exceeding the cap by one pipe-buffer chunk.
+            case byte_size(Acc) + byte_size(Data) > ?MAX_OUTPUT_BYTES of
                 true ->
                     kill_port(Port),
                     ?LOG_ERROR("credential_process: output exceeded size limit"),
                     {error, {credential_process, output_too_large}};
                 false ->
-                    collect_output(Port, NewAcc, Deadline)
+                    collect_output(Port, <<Acc/binary, Data/binary>>, Deadline)
             end;
         {Port, {exit_status, 0}} ->
             parse_output(Acc);
@@ -113,8 +114,8 @@ collect_output(Port, Acc, Deadline) ->
     end.
 
 -spec kill_port(Port :: port()) -> ok.
-%% @doc Close the port, which sends SIGKILL to the OS process on most
-%%      platforms. Ignores errors if the port is already closed.
+%% @doc Close the port, which sends SIGTERM to the OS process on Unix.
+%%      Ignores errors if the port is already closed.
 %% @end
 kill_port(Port) ->
     try
@@ -216,8 +217,15 @@ parse_expiration(Timestamp) ->
         aws_lib_config:parse_iso8601_timestamp(Timestamp)
     catch
         _:_ ->
-            ?LOG_WARNING("credential_process: could not parse Expiration timestamp"),
-            undefined
+            %% Fail-closed: unparseable expiration is treated as already expired,
+            %% forcing re-invocation of the helper on next credential use. Returning
+            %% undefined here would be fail-open (never expires), which silently
+            %% breaks when the real credentials expire at the provider.
+            ?LOG_WARNING(
+                "credential_process: could not parse Expiration timestamp, "
+                "treating credentials as already expired"
+            ),
+            {{1970, 1, 1}, {0, 0, 0}}
     end.
 
 %%====================================================================

--- a/src/aws_lib_credential_process.erl
+++ b/src/aws_lib_credential_process.erl
@@ -1,0 +1,313 @@
+%% ====================================================================
+%% @doc Execute an external credential_process helper and parse its JSON
+%%      output into an aws_credentials record.
+%%
+%%      This module implements the AWS credential_process contract: it
+%%      executes the command specified by the `credential_process' key in
+%%      ~/.aws/config, collects stdout with bounded size and timeout, then
+%%      parses the JSON output.
+%%
+%%      Security invariants:
+%%      - No shell invocation (open_port with spawn_executable).
+%%      - Output size bounded to 64KB; port killed on overflow.
+%%      - Hard 30-second timeout; port killed on expiry.
+%%      - Credential values never appear in logs or error tuples.
+%% @end
+%% ====================================================================
+-module(aws_lib_credential_process).
+
+-export([execute/1]).
+
+%% Export all for unit tests
+-ifdef(TEST).
+-compile(export_all).
+-endif.
+
+-include("aws_lib.hrl").
+-include_lib("kernel/include/logger.hrl").
+
+%% Maximum output size from the credential helper (64KB).
+-define(MAX_OUTPUT_BYTES, 65536).
+
+%% Hard timeout for the credential helper process (30 seconds).
+-define(PROCESS_TIMEOUT_MS, 30000).
+
+-spec execute(Command :: string()) ->
+    {ok, aws_credentials()} | {error, {credential_process, atom()}}.
+%% @doc Execute the credential_process command, parse its JSON output, and
+%%      return an aws_credentials record on success. The command string is
+%%      parsed into an executable path and argument list without invoking a
+%%      shell. Returns a categorized error on any failure.
+%% @end
+execute(Command) ->
+    case parse_command(Command) of
+        {ok, {Executable, Args}} ->
+            ?LOG_DEBUG("credential_process: invoking helper ~ts", [Executable]),
+            execute_helper(Executable, Args);
+        {error, Reason} ->
+            {error, {credential_process, Reason}}
+    end.
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec execute_helper(Executable :: string(), Args :: [string()]) ->
+    {ok, aws_credentials()} | {error, {credential_process, atom()}}.
+%% @doc Open a port to the helper executable, collect output with bounds,
+%%      and parse the result.
+%% @end
+execute_helper(Executable, Args) ->
+    PortOpts = [
+        {args, Args},
+        binary,
+        exit_status,
+        use_stdio,
+        stderr_to_stdout,
+        hide
+    ],
+    try
+        Port = erlang:open_port({spawn_executable, Executable}, PortOpts),
+        Deadline = erlang:monotonic_time(millisecond) + ?PROCESS_TIMEOUT_MS,
+        collect_output(Port, <<>>, Deadline)
+    catch
+        error:enoent ->
+            ?LOG_ERROR("credential_process: command not found"),
+            {error, {credential_process, command_not_found}};
+        error:eacces ->
+            ?LOG_ERROR("credential_process: permission denied"),
+            {error, {credential_process, command_not_found}};
+        error:Reason ->
+            ?LOG_ERROR("credential_process: port open failed: ~tp", [Reason]),
+            {error, {credential_process, execution_failed}}
+    end.
+
+-spec collect_output(Port :: port(), Acc :: binary(), Deadline :: integer()) ->
+    {ok, aws_credentials()} | {error, {credential_process, atom()}}.
+%% @doc Receive loop for port data. Enforces a wall-clock deadline and output
+%%      size cap, killing the port on either violation. Deadline is an absolute
+%%      monotonic timestamp (milliseconds) computed at invocation start.
+%% @end
+collect_output(Port, Acc, Deadline) ->
+    Remaining = max(0, Deadline - erlang:monotonic_time(millisecond)),
+    receive
+        {Port, {data, Data}} ->
+            NewAcc = <<Acc/binary, Data/binary>>,
+            case byte_size(NewAcc) > ?MAX_OUTPUT_BYTES of
+                true ->
+                    kill_port(Port),
+                    ?LOG_ERROR("credential_process: output exceeded size limit"),
+                    {error, {credential_process, output_too_large}};
+                false ->
+                    collect_output(Port, NewAcc, Deadline)
+            end;
+        {Port, {exit_status, 0}} ->
+            parse_output(Acc);
+        {Port, {exit_status, _NonZero}} ->
+            ?LOG_ERROR("credential_process: helper exited with non-zero status"),
+            {error, {credential_process, execution_failed}}
+    after Remaining ->
+        kill_port(Port),
+        ?LOG_ERROR("credential_process: helper timed out"),
+        {error, {credential_process, timeout}}
+    end.
+
+-spec kill_port(Port :: port()) -> ok.
+%% @doc Close the port, which sends SIGKILL to the OS process on most
+%%      platforms. Ignores errors if the port is already closed.
+%% @end
+kill_port(Port) ->
+    try
+        erlang:port_close(Port)
+    catch
+        error:badarg -> ok
+    end,
+    %% Flush any remaining messages from the port
+    flush_port(Port).
+
+-spec flush_port(Port :: port()) -> ok.
+%% @doc Drain any remaining messages from a closed port.
+%% @end
+flush_port(Port) ->
+    receive
+        {Port, _} -> flush_port(Port)
+    after 0 ->
+        ok
+    end.
+
+-spec parse_output(Output :: binary()) ->
+    {ok, aws_credentials()} | {error, {credential_process, atom()}}.
+%% @doc Decode the JSON output from the credential helper, validate the
+%%      Version field, and extract credential fields.
+%% @end
+parse_output(Output) ->
+    try
+        Parsed = aws_lib_json:decode(Output),
+        validate_and_extract(Parsed)
+    catch
+        _:_ ->
+            ?LOG_ERROR("credential_process: failed to parse JSON output"),
+            {error, {credential_process, invalid_json}}
+    end.
+
+-spec validate_and_extract(Parsed :: list()) ->
+    {ok, aws_credentials()} | {error, {credential_process, atom()}}.
+%% @doc Validate Version == 1 and extract credential fields from the
+%%      parsed proplist.
+%% @end
+validate_and_extract(Parsed) ->
+    case validate_version(Parsed) of
+        ok ->
+            extract_credentials(Parsed);
+        {error, _} = Error ->
+            Error
+    end.
+
+-spec validate_version(Parsed :: list()) ->
+    ok | {error, {credential_process, invalid_version}}.
+%% @doc Validate the Version field is 1 (integer or string "1").
+%% @end
+validate_version(Parsed) ->
+    case proplists:get_value("Version", Parsed) of
+        1 ->
+            ok;
+        "1" ->
+            ok;
+        _ ->
+            ?LOG_ERROR("credential_process: invalid or missing Version field"),
+            {error, {credential_process, invalid_version}}
+    end.
+
+-spec extract_credentials(Parsed :: list()) ->
+    {ok, aws_credentials()} | {error, {credential_process, missing_fields}}.
+%% @doc Extract AccessKeyId, SecretAccessKey, and optional SessionToken
+%%      and Expiration from the parsed output.
+%% @end
+extract_credentials(Parsed) ->
+    AccessKeyId = proplists:get_value("AccessKeyId", Parsed),
+    SecretAccessKey = proplists:get_value("SecretAccessKey", Parsed),
+    case {AccessKeyId, SecretAccessKey} of
+        {undefined, _} ->
+            ?LOG_ERROR("credential_process: missing required fields in output"),
+            {error, {credential_process, missing_fields}};
+        {_, undefined} ->
+            ?LOG_ERROR("credential_process: missing required fields in output"),
+            {error, {credential_process, missing_fields}};
+        {_, _} ->
+            SessionToken = proplists:get_value("SessionToken", Parsed),
+            Expiration = parse_expiration(proplists:get_value("Expiration", Parsed)),
+            Creds = #aws_credentials{
+                access_key = AccessKeyId,
+                secret_key = SecretAccessKey,
+                security_token = SessionToken,
+                expiration = Expiration
+            },
+            {ok, Creds}
+    end.
+
+-spec parse_expiration(Value :: string() | undefined) -> expiration().
+%% @doc Parse the optional Expiration field from ISO8601 format. Returns
+%%      undefined when not present (long-lived credentials).
+%% @end
+parse_expiration(undefined) ->
+    undefined;
+parse_expiration(Timestamp) ->
+    try
+        aws_lib_config:parse_iso8601_timestamp(Timestamp)
+    catch
+        _:_ ->
+            ?LOG_WARNING("credential_process: could not parse Expiration timestamp"),
+            undefined
+    end.
+
+%%====================================================================
+%% Command parsing
+%%====================================================================
+
+-spec parse_command(Command :: string()) ->
+    {ok, {Executable :: string(), Args :: [string()]}} | {error, command_parse_error}.
+%% @doc Parse a command string into an executable path and argument list.
+%%      Handles single and double quoting, and backslash escaping outside
+%%      of quotes. Does NOT invoke a shell -- the result is suitable for
+%%      open_port({spawn_executable, ...}, [{args, ...}]).
+%% @end
+parse_command(Command) ->
+    Stripped = string:strip(Command),
+    case Stripped of
+        "" ->
+            {error, command_parse_error};
+        _ ->
+            case tokenize(Stripped) of
+                {ok, []} ->
+                    {error, command_parse_error};
+                {ok, [Exe | Args]} ->
+                    {ok, {Exe, Args}};
+                {error, _} ->
+                    {error, command_parse_error}
+            end
+    end.
+
+-spec tokenize(Input :: string()) ->
+    {ok, [string()]} | {error, unterminated_quote}.
+%% @doc Split a command string into tokens respecting single quotes, double
+%%      quotes, and backslash escaping.
+%% @end
+tokenize(Input) ->
+    tokenize(Input, [], [], none).
+
+%% State: none -- not inside quotes
+%% State: single -- inside single quotes
+%% State: double -- inside double quotes
+-spec tokenize(
+    Input :: string(),
+    CurrentToken :: string(),
+    Tokens :: [string()],
+    QuoteState :: none | single | double
+) -> {ok, [string()]} | {error, unterminated_quote}.
+%% End of input
+tokenize([], [], Tokens, none) ->
+    {ok, lists:reverse(Tokens)};
+tokenize([], CurrentToken, Tokens, none) ->
+    {ok, lists:reverse([lists:reverse(CurrentToken) | Tokens])};
+tokenize([], _CurrentToken, _Tokens, _QuoteState) ->
+    {error, unterminated_quote};
+%% Backslash escaping outside quotes -- escape the next character
+tokenize([$\\, Next | Rest], CurrentToken, Tokens, none) ->
+    tokenize(Rest, [Next | CurrentToken], Tokens, none);
+%% Trailing backslash at end of input
+tokenize([$\\], CurrentToken, Tokens, none) ->
+    {ok, lists:reverse([lists:reverse(CurrentToken) | Tokens])};
+%% Start single quote
+tokenize([$' | Rest], CurrentToken, Tokens, none) ->
+    tokenize(Rest, CurrentToken, Tokens, single);
+%% End single quote
+tokenize([$' | Rest], CurrentToken, Tokens, single) ->
+    tokenize(Rest, CurrentToken, Tokens, none);
+%% Inside single quotes -- everything is literal
+tokenize([C | Rest], CurrentToken, Tokens, single) ->
+    tokenize(Rest, [C | CurrentToken], Tokens, single);
+%% Start double quote
+tokenize([$" | Rest], CurrentToken, Tokens, none) ->
+    tokenize(Rest, CurrentToken, Tokens, double);
+%% End double quote
+tokenize([$" | Rest], CurrentToken, Tokens, double) ->
+    tokenize(Rest, CurrentToken, Tokens, none);
+%% Backslash inside double quotes -- only escapes specific characters
+tokenize([$\\, C | Rest], CurrentToken, Tokens, double) when
+    C =:= $\\; C =:= $"; C =:= $$; C =:= $`; C =:= $\n
+->
+    tokenize(Rest, [C | CurrentToken], Tokens, double);
+%% Backslash inside double quotes -- literal backslash for other chars
+tokenize([$\\, C | Rest], CurrentToken, Tokens, double) ->
+    tokenize(Rest, [C, $\\ | CurrentToken], Tokens, double);
+%% Inside double quotes -- everything else is literal
+tokenize([C | Rest], CurrentToken, Tokens, double) ->
+    tokenize(Rest, [C | CurrentToken], Tokens, double);
+%% Whitespace outside quotes -- token boundary
+tokenize([C | Rest], [], Tokens, none) when C =:= $\s; C =:= $\t ->
+    tokenize(Rest, [], Tokens, none);
+tokenize([C | Rest], CurrentToken, Tokens, none) when C =:= $\s; C =:= $\t ->
+    tokenize(Rest, [], [lists:reverse(CurrentToken) | Tokens], none);
+%% Regular character outside quotes
+tokenize([C | Rest], CurrentToken, Tokens, none) ->
+    tokenize(Rest, [C | CurrentToken], Tokens, none).

--- a/test/aws_lib_config_tests.erl
+++ b/test/aws_lib_config_tests.erl
@@ -105,7 +105,16 @@ config_file_data_test_() ->
                 ]},
                 {"profile only-key", [{aws_access_key_id, "foo3"}]},
                 {"profile only-secret", [{aws_secret_access_key, "foo4"}]},
-                {"profile bad-entry", [{aws_secret_access, "foo5"}]}
+                {"profile bad-entry", [{aws_secret_access, "foo5"}]},
+                {"profile credential-process", [
+                    {credential_process, "/usr/bin/test-helper --arg1 --arg2"},
+                    {region, "us-east-1"}
+                ]},
+                {"profile credential-process-with-creds", [
+                    {aws_access_key_id, "direct-key"},
+                    {aws_secret_access_key, "direct-secret"},
+                    {credential_process, "/usr/bin/should-not-run"}
+                ]}
             ],
             ?assertEqual(
                 Expectation,
@@ -762,6 +771,87 @@ maybe_imdsv2_token_headers_test_() ->
                 meck:expect(gun, await_body, fun(_, _, _) -> {ok, list_to_binary(IMDSv2Token)} end),
                 {ok, Headers, _S1} = aws_lib_config:maybe_imdsv2_token_headers(S),
                 ?assertEqual([{"X-aws-ec2-metadata-token", IMDSv2Token}], Headers)
+            end}
+        ]
+    }.
+
+credential_process_chain_test_() ->
+    {
+        foreach,
+        fun() ->
+            meck:new(gun, []),
+            meck:new(aws_lib, [passthrough]),
+            meck:new(aws_lib_credential_process, [passthrough]),
+            reset_environment(),
+            application:set_env(aws, aws_prefer_imdsv2, false),
+            [gun, aws_lib, aws_lib_credential_process]
+        end,
+        fun(Mods) ->
+            application:unset_env(aws, aws_prefer_imdsv2),
+            meck:unload(Mods)
+        end,
+        [
+            {"credential_process is invoked when direct creds are absent", fun() ->
+                setup_test_config_env_var(),
+                FakeCreds = #aws_credentials{
+                    access_key = "FROMPROCESS",
+                    secret_key = "SECRETFROMPROCESS",
+                    security_token = "TOKENFROMPROCESS",
+                    expiration = {{2026, 12, 31}, {23, 59, 59}}
+                },
+                meck:expect(aws_lib_credential_process, execute, fun(_) ->
+                    {ok, FakeCreds}
+                end),
+                S = #aws_config{},
+                {ok, Creds, _S1} = aws_lib_config:credentials("credential-process", S),
+                ?assertEqual("FROMPROCESS", Creds#aws_credentials.access_key),
+                ?assertEqual("SECRETFROMPROCESS", Creds#aws_credentials.secret_key),
+                ?assertEqual("TOKENFROMPROCESS", Creds#aws_credentials.security_token),
+                %% Verify execute was called
+                ?assert(meck:called(aws_lib_credential_process, execute, '_'))
+            end},
+            {"direct creds take priority over credential_process", fun() ->
+                setup_test_config_env_var(),
+                meck:expect(aws_lib_credential_process, execute, fun(_) ->
+                    {ok, #aws_credentials{
+                        access_key = "SHOULDNOTUSE",
+                        secret_key = "SHOULDNOTUSE",
+                        security_token = undefined,
+                        expiration = undefined
+                    }}
+                end),
+                S = #aws_config{},
+                %% The "credential-process-with-creds" profile has both direct
+                %% creds and credential_process; direct creds should win.
+                {ok, Creds, _S1} = aws_lib_config:credentials(
+                    "credential-process-with-creds", S
+                ),
+                ?assertEqual("direct-key", Creds#aws_credentials.access_key),
+                ?assertEqual("direct-secret", Creds#aws_credentials.secret_key),
+                %% execute should NOT have been called
+                ?assertNot(meck:called(aws_lib_credential_process, execute, '_'))
+            end},
+            {"credential_process failure does NOT fall through to IMDS", fun() ->
+                setup_test_config_env_var(),
+                meck:expect(aws_lib_credential_process, execute, fun(_) ->
+                    {error, {credential_process, execution_failed}}
+                end),
+                S = #aws_config{},
+                Result = aws_lib_config:credentials("credential-process", S),
+                ?assertEqual({error, {credential_process, execution_failed}}, Result),
+                %% Verify IMDS was NOT attempted (gun:open not called)
+                ?assertNot(meck:called(gun, open, '_'))
+            end},
+            {"falls through to IMDS when credential_process is not configured", fun() ->
+                setup_test_config_env_var(),
+                S = #aws_config{},
+                meck:expect(aws_lib, ensure_imdsv2_token_valid, 1, {ok, undefined, S}),
+                mock_gun_imdsv2_failure(),
+                %% "nonexistent-profile" has no entry in either config or
+                %% credentials file, and no credential_process, so should
+                %% fall through to IMDS (which we mock to fail).
+                Result = aws_lib_config:credentials("nonexistent-profile", S),
+                ?assertEqual({error, undefined}, Result)
             end}
         ]
     }.

--- a/test/aws_lib_credential_process_tests.erl
+++ b/test/aws_lib_credential_process_tests.erl
@@ -1,0 +1,350 @@
+-module(aws_lib_credential_process_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("kernel/include/file.hrl").
+-include("aws_lib.hrl").
+
+%%====================================================================
+%% Command parsing tests
+%%====================================================================
+
+parse_command_test_() ->
+    [
+        {"simple command with no args", fun() ->
+            ?assertEqual(
+                {ok, {"/usr/bin/helper", []}},
+                aws_lib_credential_process:parse_command("/usr/bin/helper")
+            )
+        end},
+        {"command with arguments", fun() ->
+            ?assertEqual(
+                {ok, {"/usr/bin/helper", ["--profile", "default"]}},
+                aws_lib_credential_process:parse_command("/usr/bin/helper --profile default")
+            )
+        end},
+        {"command with single-quoted argument", fun() ->
+            ?assertEqual(
+                {ok, {"/usr/bin/helper", ["hello world"]}},
+                aws_lib_credential_process:parse_command("/usr/bin/helper 'hello world'")
+            )
+        end},
+        {"command with double-quoted argument", fun() ->
+            ?assertEqual(
+                {ok, {"/usr/bin/helper", ["hello world"]}},
+                aws_lib_credential_process:parse_command("/usr/bin/helper \"hello world\"")
+            )
+        end},
+        {"command with backslash escape", fun() ->
+            ?assertEqual(
+                {ok, {"/usr/bin/helper", ["hello world"]}},
+                aws_lib_credential_process:parse_command("/usr/bin/helper hello\\ world")
+            )
+        end},
+        {"command with equals in argument", fun() ->
+            ?assertEqual(
+                {ok, {"/usr/bin/aws", ["sso", "get-credentials", "--account=12345"]}},
+                aws_lib_credential_process:parse_command(
+                    "/usr/bin/aws sso get-credentials --account=12345"
+                )
+            )
+        end},
+        {"empty command returns error", fun() ->
+            ?assertEqual(
+                {error, command_parse_error},
+                aws_lib_credential_process:parse_command("")
+            )
+        end},
+        {"whitespace-only command returns error", fun() ->
+            ?assertEqual(
+                {error, command_parse_error},
+                aws_lib_credential_process:parse_command("   ")
+            )
+        end},
+        {"unterminated single quote returns error", fun() ->
+            ?assertEqual(
+                {error, command_parse_error},
+                aws_lib_credential_process:parse_command("/usr/bin/helper 'unterminated")
+            )
+        end},
+        {"unterminated double quote returns error", fun() ->
+            ?assertEqual(
+                {error, command_parse_error},
+                aws_lib_credential_process:parse_command("/usr/bin/helper \"unterminated")
+            )
+        end},
+        {"command with multiple spaces between args", fun() ->
+            ?assertEqual(
+                {ok, {"/usr/bin/helper", ["--arg1", "--arg2"]}},
+                aws_lib_credential_process:parse_command("/usr/bin/helper   --arg1   --arg2")
+            )
+        end},
+        {"command with leading/trailing whitespace", fun() ->
+            ?assertEqual(
+                {ok, {"/usr/bin/helper", ["--arg"]}},
+                aws_lib_credential_process:parse_command("  /usr/bin/helper --arg  ")
+            )
+        end}
+    ].
+
+%%====================================================================
+%% parse_output tests
+%%====================================================================
+
+parse_output_test_() ->
+    [
+        {"valid full output with all fields", fun() ->
+            Json =
+                <<"{\"Version\": 1, \"AccessKeyId\": \"AKID\", \"SecretAccessKey\": \"SECRET\", \"SessionToken\": \"TOKEN\", \"Expiration\": \"2026-01-15T12:30:00Z\"}">>,
+            {ok, Creds} = aws_lib_credential_process:parse_output(Json),
+            ?assertEqual("AKID", Creds#aws_credentials.access_key),
+            ?assertEqual("SECRET", Creds#aws_credentials.secret_key),
+            ?assertEqual("TOKEN", Creds#aws_credentials.security_token),
+            ?assertEqual({{2026, 1, 15}, {12, 30, 0}}, Creds#aws_credentials.expiration)
+        end},
+        {"valid output without optional fields", fun() ->
+            Json =
+                <<"{\"Version\": 1, \"AccessKeyId\": \"AKID\", \"SecretAccessKey\": \"SECRET\"}">>,
+            {ok, Creds} = aws_lib_credential_process:parse_output(Json),
+            ?assertEqual("AKID", Creds#aws_credentials.access_key),
+            ?assertEqual("SECRET", Creds#aws_credentials.secret_key),
+            ?assertEqual(undefined, Creds#aws_credentials.security_token),
+            ?assertEqual(undefined, Creds#aws_credentials.expiration)
+        end},
+        {"version as string '1' is accepted", fun() ->
+            Json =
+                <<"{\"Version\": \"1\", \"AccessKeyId\": \"AKID\", \"SecretAccessKey\": \"SECRET\"}">>,
+            {ok, Creds} = aws_lib_credential_process:parse_output(Json),
+            ?assertEqual("AKID", Creds#aws_credentials.access_key)
+        end},
+        {"invalid version returns error", fun() ->
+            Json =
+                <<"{\"Version\": 2, \"AccessKeyId\": \"AKID\", \"SecretAccessKey\": \"SECRET\"}">>,
+            ?assertEqual(
+                {error, {credential_process, invalid_version}},
+                aws_lib_credential_process:parse_output(Json)
+            )
+        end},
+        {"missing version returns error", fun() ->
+            Json = <<"{\"AccessKeyId\": \"AKID\", \"SecretAccessKey\": \"SECRET\"}">>,
+            ?assertEqual(
+                {error, {credential_process, invalid_version}},
+                aws_lib_credential_process:parse_output(Json)
+            )
+        end},
+        {"missing AccessKeyId returns error", fun() ->
+            Json = <<"{\"Version\": 1, \"SecretAccessKey\": \"SECRET\"}">>,
+            ?assertEqual(
+                {error, {credential_process, missing_fields}},
+                aws_lib_credential_process:parse_output(Json)
+            )
+        end},
+        {"missing SecretAccessKey returns error", fun() ->
+            Json = <<"{\"Version\": 1, \"AccessKeyId\": \"AKID\"}">>,
+            ?assertEqual(
+                {error, {credential_process, missing_fields}},
+                aws_lib_credential_process:parse_output(Json)
+            )
+        end},
+        {"invalid JSON returns error", fun() ->
+            ?assertEqual(
+                {error, {credential_process, invalid_json}},
+                aws_lib_credential_process:parse_output(<<"not json at all">>)
+            )
+        end},
+        {"empty input returns error", fun() ->
+            %% Empty binary decodes to empty proplist, which fails on
+            %% missing Version field.
+            ?assertEqual(
+                {error, {credential_process, invalid_version}},
+                aws_lib_credential_process:parse_output(<<>>)
+            )
+        end}
+    ].
+
+%%====================================================================
+%% Execute integration tests (using real helper scripts)
+%%====================================================================
+
+execute_test_() ->
+    {foreach, fun setup_helper_scripts/0, fun cleanup_helper_scripts/1, [
+        {"successful execution with full credentials", fun() ->
+            {ok, Creds} = aws_lib_credential_process:execute(
+                helper_script_path("success_full")
+            ),
+            ?assertEqual("AKIAIOSFODNN7EXAMPLE", Creds#aws_credentials.access_key),
+            ?assertEqual(
+                "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", Creds#aws_credentials.secret_key
+            ),
+            ?assertEqual("FwoGZXIvYXdzEBYaDA==", Creds#aws_credentials.security_token),
+            ?assertEqual({{2026, 12, 31}, {23, 59, 59}}, Creds#aws_credentials.expiration)
+        end},
+        {"successful execution without optional fields", fun() ->
+            {ok, Creds} = aws_lib_credential_process:execute(
+                helper_script_path("success_minimal")
+            ),
+            ?assertEqual("AKIAIOSFODNN7EXAMPLE", Creds#aws_credentials.access_key),
+            ?assertEqual(
+                "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", Creds#aws_credentials.secret_key
+            ),
+            ?assertEqual(undefined, Creds#aws_credentials.security_token),
+            ?assertEqual(undefined, Creds#aws_credentials.expiration)
+        end},
+        {"non-zero exit code returns execution_failed", fun() ->
+            ?assertEqual(
+                {error, {credential_process, execution_failed}},
+                aws_lib_credential_process:execute(helper_script_path("exit_nonzero"))
+            )
+        end},
+        {"invalid JSON output returns invalid_json", fun() ->
+            ?assertEqual(
+                {error, {credential_process, invalid_json}},
+                aws_lib_credential_process:execute(helper_script_path("invalid_json"))
+            )
+        end},
+        {"missing required fields returns missing_fields", fun() ->
+            ?assertEqual(
+                {error, {credential_process, missing_fields}},
+                aws_lib_credential_process:execute(helper_script_path("missing_fields"))
+            )
+        end},
+        {"invalid version returns invalid_version", fun() ->
+            ?assertEqual(
+                {error, {credential_process, invalid_version}},
+                aws_lib_credential_process:execute(helper_script_path("invalid_version"))
+            )
+        end},
+        {"command not found returns command_not_found", fun() ->
+            ?assertEqual(
+                {error, {credential_process, command_not_found}},
+                aws_lib_credential_process:execute("/nonexistent/path/to/helper")
+            )
+        end},
+        {"output too large returns output_too_large", fun() ->
+            ?assertEqual(
+                {error, {credential_process, output_too_large}},
+                aws_lib_credential_process:execute(helper_script_path("output_too_large"))
+            )
+        end},
+        {"shell metacharacters are not interpreted", fun() ->
+            %% This command contains shell metacharacters that would be
+            %% dangerous if passed through a shell. With spawn_executable,
+            %% they are treated as literal arguments.
+            ?assertEqual(
+                {error, {credential_process, command_not_found}},
+                aws_lib_credential_process:execute(
+                    "/nonexistent/binary; rm -rf / #"
+                )
+            )
+        end},
+        {"timeout triggers error", fun() ->
+            %% The sleep helper sleeps for 60s, which exceeds the 30s timeout.
+            %% We call collect_output directly with a short deadline for fast
+            %% test execution. The deadline is an absolute monotonic timestamp.
+            Script = helper_script_path("sleep_forever"),
+            Port = erlang:open_port(
+                {spawn_executable, Script},
+                [binary, exit_status, use_stdio, stderr_to_stdout, hide]
+            ),
+            Deadline = erlang:monotonic_time(millisecond) + 500,
+            Result = aws_lib_credential_process:collect_output(Port, <<>>, Deadline),
+            ?assertEqual({error, {credential_process, timeout}}, Result)
+        end}
+    ]}.
+
+%%====================================================================
+%% Test helpers
+%%====================================================================
+
+helper_dir() ->
+    "/tmp/aws_credential_process_test_helpers".
+
+helper_script_path(Name) ->
+    filename:join(helper_dir(), Name).
+
+setup_helper_scripts() ->
+    Dir = helper_dir(),
+    filelib:ensure_dir(filename:join(Dir, "dummy")),
+
+    %% Full credentials output
+    write_script(
+        Dir,
+        "success_full",
+        "#!/bin/sh\n"
+        "echo '{\"Version\": 1, \"AccessKeyId\": \"AKIAIOSFODNN7EXAMPLE\", "
+        "\"SecretAccessKey\": \"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\", "
+        "\"SessionToken\": \"FwoGZXIvYXdzEBYaDA==\", "
+        "\"Expiration\": \"2026-12-31T23:59:59Z\"}'\n"
+    ),
+
+    %% Minimal credentials (no SessionToken, no Expiration)
+    write_script(
+        Dir,
+        "success_minimal",
+        "#!/bin/sh\n"
+        "echo '{\"Version\": 1, \"AccessKeyId\": \"AKIAIOSFODNN7EXAMPLE\", "
+        "\"SecretAccessKey\": \"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\"}'\n"
+    ),
+
+    %% Non-zero exit
+    write_script(
+        Dir,
+        "exit_nonzero",
+        "#!/bin/sh\nexit 1\n"
+    ),
+
+    %% Invalid JSON
+    write_script(
+        Dir,
+        "invalid_json",
+        "#!/bin/sh\necho 'this is not json'\n"
+    ),
+
+    %% Missing required fields
+    write_script(
+        Dir,
+        "missing_fields",
+        "#!/bin/sh\n"
+        "echo '{\"Version\": 1, \"AccessKeyId\": \"AKID\"}'\n"
+    ),
+
+    %% Invalid version
+    write_script(
+        Dir,
+        "invalid_version",
+        "#!/bin/sh\n"
+        "echo '{\"Version\": 99, \"AccessKeyId\": \"AKID\", \"SecretAccessKey\": \"SECRET\"}'\n"
+    ),
+
+    %% Output too large (> 64KB)
+    write_script(
+        Dir,
+        "output_too_large",
+        "#!/bin/sh\n"
+        "dd if=/dev/zero bs=1024 count=128 2>/dev/null | tr '\\0' 'A'\n"
+    ),
+
+    %% Sleep forever (for timeout testing)
+    write_script(
+        Dir,
+        "sleep_forever",
+        "#!/bin/sh\nsleep 60\n"
+    ),
+
+    Dir.
+
+cleanup_helper_scripts(Dir) ->
+    %% Remove all helper scripts
+    case file:list_dir(Dir) of
+        {ok, Files} ->
+            lists:foreach(fun(F) -> file:delete(filename:join(Dir, F)) end, Files),
+            file:del_dir(Dir);
+        _ ->
+            ok
+    end.
+
+write_script(Dir, Name, Content) ->
+    Path = filename:join(Dir, Name),
+    ok = file:write_file(Path, Content),
+    %% Make executable
+    {ok, Info} = file:read_file_info(Path),
+    ok = file:write_file_info(Path, Info#file_info{mode = 8#755}).

--- a/test/test_aws_config.ini
+++ b/test/test_aws_config.ini
@@ -23,3 +23,12 @@ aws_secret_access_key = foo4
 
 [profile bad-entry]
 aws_secret_access = foo5
+
+[profile credential-process]
+credential_process = /usr/bin/test-helper --arg1 --arg2
+region = us-east-1
+
+[profile credential-process-with-creds]
+aws_access_key_id = direct-key
+aws_secret_access_key = direct-secret
+credential_process = /usr/bin/should-not-run


### PR DESCRIPTION
Fixes #92.

Implements option 1 from the issue: the standard `credential_process` config
setting, which is how the AWS CLI integrates IAM Roles Anywhere via
`aws_signing_helper credential-process`. The native CreateSession/X.509 path is
deliberately not implemented.

## Change

New `src/aws_lib_credential_process.erl` (321 lines) plus chain integration in
`aws_lib_config`. Chain position is exactly as the issue specifies: env vars ->
config/credentials file -> **credential_process** -> IMDS.

## Security properties

- **No shell.** `erlang:open_port({spawn_executable, Path}, [{args, Argv}])`, never
  `os:cmd/1`. A custom tokenizer parses the configured command into an explicit argv,
  handling quotes and backslash escapes. Builds on the existing `ini_split_line/1`
  first-`=`-only split, which already exists so a `credential_process` line
  containing `=` survives.
- **No credential leakage.** Only the executable path (DEBUG) and error
  category atoms (ERROR) are logged. Error tuples are `{error, {credential_process, atom()}}`
  and never carry values or body fragments.
- **Bounded.** 30s wall-clock deadline (monotonic, not idle-based) and a 64KB output
  cap checked *before* the accumulated binary grows. Port killed on either.
- **Hard failure, no silent fallthrough.** A non-zero exit, malformed JSON, missing
  fields, or a bad `Version` propagates; IMDS is never contacted. An operator who
  configured `credential_process` intends *that* source -- silently using the
  instance role instead would be a confused-deputy risk and would mask the
  misconfiguration.
- **Fail-closed expiration.** An unparseable `Expiration` yields "already expired"
  rather than "never expires", forcing re-invocation. (Adversarial review caught the
  original fail-open form.)

## Verification

eunit **849 passed, 0 failed** (baseline `main` is 814). 31 new unit tests.

Manually exercised against local helper scripts, all 11 cases:

| Case | Result |
|---|---|
| valid credentials | `{ok, {aws_credentials, ...}}` |
| direct profile creds take precedence | returns the direct value, not the process one |
| non-zero exit | `{error, {credential_process, execution_failed}}`, no IMDS |
| malformed JSON | `{error, {credential_process, invalid_json}}` |
| hung helper | `{error, {credential_process, timeout}}` after 30s |
| output > 64KB | `{error, {credential_process, output_too_large}}` |
| `Version: 2` | `{error, {credential_process, invalid_version}}` |
| no `SessionToken` (optional) | `security_token = undefined` |
| re-invocation on expiry | helper invoke counter reaches 2 |
| **6 shell-injection vectors** | all neutralized |
| non-leakage grep at debug level | **zero hits** for secret/access key/token |

Injection was verified with filesystem canaries: a command of the form
`helper.sh ; touch /tmp/PWNED` and a `$(touch ...)` variant both left the canary
files **absent**, confirming no shell interprets the string.

## Worst-case boot latency

Up to 30s (the hard timeout) if a helper hangs. In practice `aws_signing_helper`
returns in well under a second.

## Known gap for reviewers

`parse_iso8601_timestamp/1` handles only a `Z` suffix, not `+00:00`/`+HH:MM`
offsets, which are valid RFC3339 and plausible in real helper output. The
fail-closed path mitigates it (forces re-invocation rather than trusting a stale
credential), but it is worth fixing. **This is pre-existing and also affects the
IMDS path**, so I left it out of scope here rather than widening this PR.
