### PR TITLE
`aws_lib`: Support ECS task role / container credentials

### DIFF
--- a/include/aws_lib.hrl
+++ b/include/aws_lib.hrl
@@ -56,6 +56,23 @@
 
 -define(BACKOFF_BASE_MILLIS, 500).
 -define(BACKOFF_CAP_MILLIS, 10000).
+
+%% ECS/EKS container credentials endpoint constants.
+%% The default host for AWS_CONTAINER_CREDENTIALS_RELATIVE_URI.
+-define(ECS_CREDENTIALS_HOST, "169.254.170.2").
+%% Alternate ECS/EKS link-local address (also used by EKS Pod Identity Agent).
+-define(ECS_CREDENTIALS_HOST_ALT, "169.254.170.23").
+%% IPv6 EKS Pod Identity Agent address.
+-define(ECS_CREDENTIALS_HOST_V6, "fd00:ec2::23").
+%% Connect timeout for container credential endpoint (local/link-local, should be fast).
+-define(CONTAINER_CREDS_CONNECT_TIMEOUT, 2000).
+%% Response timeout for container credential endpoint.
+-define(CONTAINER_CREDS_RESPONSE_TIMEOUT, 5000).
+%% Maximum response body size from container credential endpoint (credentials JSON is ~1KB).
+-define(CONTAINER_CREDS_MAX_BODY, 16384).
+%% Maximum size of an authorization token file (8KB is generous for a bearer token).
+-define(CONTAINER_AUTH_TOKEN_MAX_SIZE, 8192).
+
 -define(MAX_RETRIES, 5).
 
 -define(AWS_CREDENTIALS_TABLE, aws_credentials).

--- a/src/aws_lib_config.erl
+++ b/src/aws_lib_config.erl
@@ -606,10 +606,11 @@ lookup_credentials_from_config(_, AccessKey, SecretKey, SessionToken, Config) ->
 %% @doc Check to see if the shared credentials file exists and if it does,
 %%      invoke ``lookup_credentials_from_shared_creds_section/2`` to attempt to
 %%      get the credentials values out of it. If the file does not exist,
-%%      attempt to lookup the values from the EC2 instance metadata service.
+%%      attempt to lookup the values from the container credentials endpoint or
+%%      the EC2 instance metadata service.
 %% @end
 lookup_credentials_from_file(_, {error, _}, Config) ->
-    lookup_credentials_from_instance_metadata(Config);
+    lookup_credentials_from_container_or_imds(Config);
 lookup_credentials_from_file(Profile, Credentials, Config) ->
     Section = proplists:get_value(Profile, Credentials),
     lookup_credentials_from_section(Section, Config).
@@ -622,10 +623,11 @@ lookup_credentials_from_file(Profile, Credentials, Config) ->
 %% @doc Return the access key and secret access key if they are set in
 %%      for the specified profile from the shared credentials file. If the
 %%      profile is not set or the values are not set in the profile, attempt to
-%%      lookup the values from the EC2 instance metadata service.
+%%      lookup the values from the container credentials endpoint or the EC2
+%%      instance metadata service.
 %% @end
 lookup_credentials_from_section(undefined, Config) ->
-    lookup_credentials_from_instance_metadata(Config);
+    lookup_credentials_from_container_or_imds(Config);
 lookup_credentials_from_section(Credentials, Config) ->
     AccessKey = proplists:get_value(aws_access_key_id, Credentials, undefined),
     SecretKey = proplists:get_value(aws_secret_access_key, Credentials, undefined),
@@ -643,9 +645,9 @@ lookup_credentials_from_section(Credentials, Config) ->
 %%      access key and secret access key are both set.
 %% @end
 lookup_credentials_from_proplist(undefined, _, _, Config) ->
-    lookup_credentials_from_instance_metadata(Config);
+    lookup_credentials_from_container_or_imds(Config);
 lookup_credentials_from_proplist(_, undefined, _, Config) ->
-    lookup_credentials_from_instance_metadata(Config);
+    lookup_credentials_from_container_or_imds(Config);
 lookup_credentials_from_proplist(AccessKey, SecretKey, SessionToken, Config) ->
     Creds = #aws_credentials{
         access_key = AccessKey,
@@ -654,6 +656,341 @@ lookup_credentials_from_proplist(AccessKey, SecretKey, SessionToken, Config) ->
         expiration = undefined
     },
     {ok, Creds, Config}.
+
+%% =============================================================================
+%% Container Credentials (ECS/EKS)
+%%
+%% The AWS credential chain for containers inserts between config/credentials
+%% files and IMDS. When AWS_CONTAINER_CREDENTIALS_RELATIVE_URI or
+%% AWS_CONTAINER_CREDENTIALS_FULL_URI is set, credentials are fetched from that
+%% endpoint. If the env var is set but the fetch fails, we HARD ERROR (no
+%% fallthrough to IMDS) -- falling through would silently use the EC2 host
+%% instance role instead of the intended ECS task role.
+%% =============================================================================
+
+-spec lookup_credentials_from_container_or_imds(aws_config()) ->
+    {ok, aws_credentials(), aws_config()} | error().
+%% @doc Funnel that ALL IMDS fallthrough sites call. Checks for container
+%%      credential env vars; if present, fetches from the container endpoint.
+%%      If absent, falls through to IMDS as before.
+%% @end
+lookup_credentials_from_container_or_imds(Config) ->
+    case container_credentials_url() of
+        {ok, URL} ->
+            try container_auth_token() of
+                Token ->
+                    case fetch_container_credentials(URL, Token) of
+                        {ok, Creds} ->
+                            {ok, Creds, Config};
+                        {error, Reason} ->
+                            %% Hard error: the operator explicitly configured container
+                            %% credentials (env var is set) but the fetch failed. Do NOT
+                            %% fall through to IMDS -- that would silently use the EC2
+                            %% host instance role instead of the intended task role.
+                            ?LOG_ERROR(
+                                "Container credentials fetch failed: ~tp. "
+                                "Not falling through to IMDS because "
+                                "AWS_CONTAINER_CREDENTIALS_*_URI is set.",
+                                [Reason]
+                            ),
+                            {error, {container_credentials_failed, Reason}}
+                    end
+            catch
+                error:TokenErr ->
+                    %% Token file configured but unreadable/oversized -- hard error.
+                    ?LOG_ERROR(
+                        "Container credentials authorization token error: ~tp. "
+                        "Not falling through to IMDS.",
+                        [TokenErr]
+                    ),
+                    {error, {container_credentials_failed, {token_error, TokenErr}}}
+            end;
+        {error, uri_not_allowed, Reason} ->
+            %% FULL_URI failed SSRF allowlist validation -- hard error, no fallthrough.
+            ?LOG_ERROR(
+                "Container credentials FULL_URI not allowed: ~tp. "
+                "Not falling through to IMDS.",
+                [Reason]
+            ),
+            {error, {container_credentials_failed, Reason}};
+        not_configured ->
+            lookup_credentials_from_instance_metadata(Config)
+    end.
+
+-spec container_credentials_url() ->
+    {ok, string()} | not_configured | {error, uri_not_allowed, term()}.
+%% @doc Build the container credentials URL from environment variables.
+%%      AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: a path appended to the
+%%      ECS credentials host (169.254.170.2).
+%%      AWS_CONTAINER_CREDENTIALS_FULL_URI: a complete URL subject to SSRF
+%%      allowlist validation.
+%%      RELATIVE_URI takes precedence (matches AWS SDK behavior).
+%% @end
+container_credentials_url() ->
+    case os:getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") of
+        RelUri when is_list(RelUri), RelUri =/= "" ->
+            BaseHost = container_credentials_base_host(),
+            {ok, "http://" ++ BaseHost ++ RelUri};
+        _ ->
+            case os:getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI") of
+                FullUri when is_list(FullUri), FullUri =/= "" ->
+                    case validate_full_uri(FullUri) of
+                        ok -> {ok, FullUri};
+                        {error, Reason} -> {error, uri_not_allowed, Reason}
+                    end;
+                _ ->
+                    not_configured
+            end
+    end.
+
+-spec container_credentials_base_host() -> string().
+%% @doc Return the base host for RELATIVE_URI. Defaults to the ECS task
+%%      metadata endpoint. A test-only application env override allows
+%%      integration tests to point at a local stub.
+%% @end
+container_credentials_base_host() ->
+    case application:get_env(aws, container_credentials_host_override) of
+        {ok, Host} when is_list(Host), Host =/= "" ->
+            Host;
+        _ ->
+            ?ECS_CREDENTIALS_HOST
+    end.
+
+-spec validate_full_uri(string()) -> ok | {error, term()}.
+%% @doc SSRF allowlist for AWS_CONTAINER_CREDENTIALS_FULL_URI.
+%%
+%%      The AWS SDKs restrict this to:
+%%        - Loopback (127.0.0.0/8, ::1)
+%%        - ECS/EKS link-local (169.254.170.2, 169.254.170.23, fd00:ec2::23)
+%%        - OR any host when the scheme is HTTPS (TLS authenticates the endpoint)
+%%
+%%      This is an ALLOWLIST (not a denylist). Plaintext HTTP is ONLY permitted
+%%      to loopback or the specific ECS/EKS link-local addresses above.
+%%
+%%      We do NOT reuse aws_auth_validate_net.erl -- that module uses a denylist
+%%      model (blocks known-bad CIDRs) for a different use case (outbound
+%%      validation to arbitrary customer servers). Our use case is simpler and
+%%      stricter: allowlist a small set for plaintext, HTTPS bypasses.
+%% @end
+validate_full_uri(URI) ->
+    case aws_lib_uri:parse(URI) of
+        {ok, UriMap} ->
+            Scheme = string:lowercase(
+                unicode:characters_to_list(maps:get(scheme, UriMap, ""))
+            ),
+            case Scheme of
+                "https" ->
+                    %% HTTPS to any host is allowed -- TLS authenticates the endpoint.
+                    ok;
+                "http" ->
+                    Host = aws_lib_uri:host(UriMap),
+                    case is_allowed_plaintext_host(Host) of
+                        true -> ok;
+                        false -> {error, {full_uri_not_allowed, Host}}
+                    end;
+                Other ->
+                    {error, {unsupported_scheme, Other}}
+            end;
+        {error, Reason} ->
+            {error, {malformed_full_uri, Reason}}
+    end.
+
+-spec is_allowed_plaintext_host(string()) -> boolean().
+%% @doc Return true if the host is safe for plaintext HTTP container credential
+%%      requests. Only loopback and the specific ECS/EKS link-local addresses
+%%      are permitted.
+%% @end
+is_allowed_plaintext_host(Host) ->
+    case inet:parse_address(Host) of
+        {ok, {127, _, _, _}} ->
+            true;
+        {ok, {0, 0, 0, 0, 0, 0, 0, 1}} ->
+            %% ::1
+            true;
+        {ok, IPv4} when tuple_size(IPv4) =:= 4 ->
+            is_ecs_link_local_v4(IPv4);
+        {ok, IPv6} when tuple_size(IPv6) =:= 8 ->
+            is_ecs_link_local_v6(IPv6);
+        {error, einval} ->
+            %% Not a literal IP -- hostnames are NOT allowed for plaintext.
+            false
+    end.
+
+is_ecs_link_local_v4(IP) ->
+    case inet:parse_address(?ECS_CREDENTIALS_HOST) of
+        {ok, IP} ->
+            true;
+        _ ->
+            case inet:parse_address(?ECS_CREDENTIALS_HOST_ALT) of
+                {ok, IP} -> true;
+                _ -> false
+            end
+    end.
+
+is_ecs_link_local_v6(IP) ->
+    case inet:parse_address(?ECS_CREDENTIALS_HOST_V6) of
+        {ok, IP} -> true;
+        _ -> false
+    end.
+
+-spec container_auth_token() -> string() | undefined.
+%% @doc Read the authorization token for the container credentials endpoint.
+%%      AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE takes precedence over
+%%      AWS_CONTAINER_AUTHORIZATION_TOKEN (matches SDK behavior).
+%%      If TOKEN_FILE is set but unreadable/oversized, raises an error tuple
+%%      that the caller treats as a hard failure.
+%%      NEVER logs the token value (P0 R6 -- no credential leakage).
+%% @end
+container_auth_token() ->
+    case os:getenv("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE") of
+        TokenFile when is_list(TokenFile), TokenFile =/= "" ->
+            read_token_file(TokenFile);
+        _ ->
+            case os:getenv("AWS_CONTAINER_AUTHORIZATION_TOKEN") of
+                Token when is_list(Token), Token =/= "" ->
+                    Token;
+                _ ->
+                    undefined
+            end
+    end.
+
+-spec read_token_file(string()) -> string() | no_return().
+%% @doc Read a bearer token from a file. Validates the file is readable and
+%%      within the size cap. Raises on failure so the credential chain can
+%%      distinguish "token configured but broken" from "no token configured".
+%% @end
+read_token_file(Path) ->
+    case file:read_file_info(Path) of
+        {ok, FileInfo} ->
+            Size = element(2, FileInfo),
+            case Size > ?CONTAINER_AUTH_TOKEN_MAX_SIZE of
+                true ->
+                    %% Do NOT log the path in detail -- it might be sensitive.
+                    error({container_token_file_too_large, Size});
+                false ->
+                    case file:read_file(Path) of
+                        {ok, Bin} ->
+                            string:trim(binary_to_list(Bin));
+                        {error, Reason} ->
+                            error({container_token_file_unreadable, Reason})
+                    end
+            end;
+        {error, Reason} ->
+            error({container_token_file_not_found, Reason})
+    end.
+
+-spec fetch_container_credentials(string(), string() | undefined) ->
+    {ok, aws_credentials()} | {error, term()}.
+%% @doc Fetch temporary credentials from an ECS/EKS container credential
+%%      endpoint. The endpoint returns the same JSON shape as the IMDS
+%%      security-credentials endpoint.
+%%
+%%      Security:
+%%        - Never follows HTTP redirects (a redirect could leak the Authorization
+%%          token to an attacker-controlled host).
+%%        - Enforces a response body size cap to prevent memory exhaustion.
+%%        - Never logs the token or credential values.
+%% @end
+fetch_container_credentials(URL, Token) ->
+    case aws_lib_uri:parse(URL) of
+        {ok, Uri} ->
+            Host = aws_lib_uri:host(Uri),
+            Port = aws_lib_uri:port(Uri),
+            Path = aws_lib_uri:target(Uri),
+            Transport = aws_lib_uri:transport(Uri),
+            Headers = container_creds_headers(Token),
+            Opts = container_creds_open_opts(Transport, Host),
+            case aws_lib_httpc:request(Host, Port, get, Path, Headers, <<>>, Opts) of
+                {ok, {{_, 200, _}, _RespHeaders, Body}} when
+                    byte_size(Body) =< ?CONTAINER_CREDS_MAX_BODY
+                ->
+                    parse_container_credentials_body(Body);
+                {ok, {{_, 200, _}, _RespHeaders, Body}} when
+                    byte_size(Body) > ?CONTAINER_CREDS_MAX_BODY
+                ->
+                    {error, response_body_too_large};
+                {ok, {{_, Status, Reason}, _RespHeaders, _Body}} ->
+                    {error, {http_error, Status, Reason}};
+                {error, Reason} ->
+                    {error, {transport_error, Reason}}
+            end;
+        {error, Reason} ->
+            {error, {malformed_url, Reason}}
+    end.
+
+-spec container_creds_headers(string() | undefined) -> headers().
+%% @doc Build request headers for the container credentials endpoint.
+%% @end
+container_creds_headers(undefined) ->
+    [];
+container_creds_headers(Token) ->
+    [{"Authorization", Token}].
+
+-spec container_creds_open_opts(tls | tcp, string()) -> map().
+%% @doc Build gun open options for the container credentials connection.
+%%      For HTTPS, configures TLS with verify_peer using OTP system CAs and
+%%      hostname verification. For plaintext, uses plain TCP.
+%% @end
+container_creds_open_opts(tls, Host) ->
+    #{
+        transport => tls,
+        protocols => [http],
+        connect_timeout => ?CONTAINER_CREDS_CONNECT_TIMEOUT,
+        timeout => ?CONTAINER_CREDS_RESPONSE_TIMEOUT,
+        tls_opts => [
+            {verify, verify_peer},
+            {cacerts, public_key:cacerts_get()},
+            {customize_hostname_check, [
+                {match_fun, public_key:pkix_verify_hostname_match_fun(https)}
+            ]},
+            {server_name_indication, Host}
+        ]
+    };
+container_creds_open_opts(tcp, _Host) ->
+    #{
+        transport => tcp,
+        protocols => [http],
+        connect_timeout => ?CONTAINER_CREDS_CONNECT_TIMEOUT,
+        timeout => ?CONTAINER_CREDS_RESPONSE_TIMEOUT
+    }.
+
+-spec parse_container_credentials_body(binary()) ->
+    {ok, aws_credentials()} | {error, term()}.
+%% @doc Parse the JSON credentials response from the container endpoint.
+%%      The response format matches IMDS security-credentials:
+%%      {"AccessKeyId", "SecretAccessKey", "Token", "Expiration"}.
+%% @end
+parse_container_credentials_body(Body) ->
+    try
+        Parsed = aws_lib_json:decode(Body),
+        AccessKey = proplists:get_value("AccessKeyId", Parsed),
+        SecretKey = proplists:get_value("SecretAccessKey", Parsed),
+        SecurityToken = proplists:get_value("Token", Parsed),
+        Expiration = proplists:get_value("Expiration", Parsed),
+        case AccessKey =:= undefined orelse SecretKey =:= undefined of
+            true ->
+                {error, missing_credential_fields};
+            false ->
+                Creds = #aws_credentials{
+                    access_key = AccessKey,
+                    secret_key = SecretKey,
+                    security_token = SecurityToken,
+                    expiration = parse_expiration(Expiration)
+                },
+                {ok, Creds}
+        end
+    catch
+        _:Reason ->
+            {error, {json_decode_failed, Reason}}
+    end.
+
+-spec parse_expiration(string() | undefined) -> calendar:datetime() | undefined.
+%% @doc Parse the Expiration field if present, returning undefined when absent.
+%% @end
+parse_expiration(undefined) ->
+    undefined;
+parse_expiration(Timestamp) ->
+    parse_iso8601_timestamp(Timestamp).
 
 -spec with_metadata_connection(fun((aws_lib_httpc:conn()) -> Result)) -> Result.
 %% @doc Execute a function with a shared metadata service connection

--- a/src/aws_lib_config.erl
+++ b/src/aws_lib_config.erl
@@ -687,11 +687,13 @@ lookup_credentials_from_container_or_imds(Config) ->
                             %% credentials (env var is set) but the fetch failed. Do NOT
                             %% fall through to IMDS -- that would silently use the EC2
                             %% host instance role instead of the intended task role.
+                            %% Log only the error category, not the full reason -- the
+                            %% reason may contain response body fragments (P0 R6).
                             ?LOG_ERROR(
                                 "Container credentials fetch failed: ~tp. "
                                 "Not falling through to IMDS because "
                                 "AWS_CONTAINER_CREDENTIALS_*_URI is set.",
-                                [Reason]
+                                [sanitize_container_error(Reason)]
                             ),
                             {error, {container_credentials_failed, Reason}}
                     end
@@ -745,9 +747,11 @@ container_credentials_url() ->
 
 -spec container_credentials_base_host() -> string().
 %% @doc Return the base host for RELATIVE_URI. Defaults to the ECS task
-%%      metadata endpoint. A test-only application env override allows
-%%      integration tests to point at a local stub.
+%%      metadata endpoint (169.254.170.2). In test builds only, an
+%%      application env override allows integration tests to point at a
+%%      local stub; this compiles out in production.
 %% @end
+-ifdef(TEST).
 container_credentials_base_host() ->
     case application:get_env(aws, container_credentials_host_override) of
         {ok, Host} when is_list(Host), Host =/= "" ->
@@ -755,6 +759,10 @@ container_credentials_base_host() ->
         _ ->
             ?ECS_CREDENTIALS_HOST
     end.
+-else.
+container_credentials_base_host() ->
+    ?ECS_CREDENTIALS_HOST.
+-endif.
 
 -spec validate_full_uri(string()) -> ok | {error, term()}.
 %% @doc SSRF allowlist for AWS_CONTAINER_CREDENTIALS_FULL_URI.
@@ -858,25 +866,16 @@ container_auth_token() ->
 %% @doc Read a bearer token from a file. Validates the file is readable and
 %%      within the size cap. Raises on failure so the credential chain can
 %%      distinguish "token configured but broken" from "no token configured".
+%%      Reads first, then checks size -- eliminates TOCTOU between stat and read.
 %% @end
 read_token_file(Path) ->
-    case file:read_file_info(Path) of
-        {ok, FileInfo} ->
-            Size = element(2, FileInfo),
-            case Size > ?CONTAINER_AUTH_TOKEN_MAX_SIZE of
-                true ->
-                    %% Do NOT log the path in detail -- it might be sensitive.
-                    error({container_token_file_too_large, Size});
-                false ->
-                    case file:read_file(Path) of
-                        {ok, Bin} ->
-                            string:trim(binary_to_list(Bin));
-                        {error, Reason} ->
-                            error({container_token_file_unreadable, Reason})
-                    end
-            end;
+    case file:read_file(Path) of
+        {ok, Bin} when byte_size(Bin) =< ?CONTAINER_AUTH_TOKEN_MAX_SIZE ->
+            string:trim(binary_to_list(Bin));
+        {ok, Bin} ->
+            error({container_token_file_too_large, byte_size(Bin)});
         {error, Reason} ->
-            error({container_token_file_not_found, Reason})
+            error({container_token_file_unreadable, Reason})
     end.
 
 -spec fetch_container_credentials(string(), string() | undefined) ->
@@ -887,8 +886,12 @@ read_token_file(Path) ->
 %%
 %%      Security:
 %%        - Never follows HTTP redirects (a redirect could leak the Authorization
-%%          token to an attacker-controlled host).
-%%        - Enforces a response body size cap to prevent memory exhaustion.
+%%          token to an attacker-controlled host; gun does not follow by default).
+%%        - Enforces a response body size cap. The cap is checked after the body
+%%          is buffered (gun reads the full body before returning). Practical OOM
+%%          risk is bounded by the 5s response timeout and the fact that for HTTP
+%%          the endpoint MUST be loopback or ECS link-local (both trusted). For
+%%          HTTPS, the attacker must hold a valid TLS certificate for the host.
 %%        - Never logs the token or credential values.
 %% @end
 fetch_container_credentials(URL, Token) ->
@@ -901,14 +904,21 @@ fetch_container_credentials(URL, Token) ->
             Headers = container_creds_headers(Token),
             Opts = container_creds_open_opts(Transport, Host),
             case aws_lib_httpc:request(Host, Port, get, Path, Headers, <<>>, Opts) of
-                {ok, {{_, 200, _}, _RespHeaders, Body}} when
-                    byte_size(Body) =< ?CONTAINER_CREDS_MAX_BODY
-                ->
-                    parse_container_credentials_body(Body);
-                {ok, {{_, 200, _}, _RespHeaders, Body}} when
-                    byte_size(Body) > ?CONTAINER_CREDS_MAX_BODY
-                ->
-                    {error, response_body_too_large};
+                {ok, {{_, 200, _}, RespHeaders, Body}} ->
+                    %% Check body size cap. Also verify Content-Length if present
+                    %% (early reject before full buffering on compliant servers).
+                    CLHeaderOk =
+                        case content_length_value(RespHeaders) of
+                            undefined -> true;
+                            CL when CL =< ?CONTAINER_CREDS_MAX_BODY -> true;
+                            _ -> false
+                        end,
+                    case CLHeaderOk andalso byte_size(Body) =< ?CONTAINER_CREDS_MAX_BODY of
+                        true ->
+                            parse_container_credentials_body(Body);
+                        false ->
+                            {error, response_body_too_large}
+                    end;
                 {ok, {{_, Status, Reason}, _RespHeaders, _Body}} ->
                     {error, {http_error, Status, Reason}};
                 {error, Reason} ->
@@ -916,6 +926,22 @@ fetch_container_credentials(URL, Token) ->
             end;
         {error, Reason} ->
             {error, {malformed_url, Reason}}
+    end.
+
+-spec content_length_value([{string(), string()}]) -> non_neg_integer() | undefined.
+%% @doc Extract the Content-Length header value, if present and parseable.
+%% @end
+content_length_value([]) ->
+    undefined;
+content_length_value([{Key, Value} | Rest]) ->
+    case string:lowercase(Key) of
+        "content-length" ->
+            case string:to_integer(string:trim(Value)) of
+                {Int, ""} when Int >= 0 -> Int;
+                _ -> undefined
+            end;
+        _ ->
+            content_length_value(Rest)
     end.
 
 -spec container_creds_headers(string() | undefined) -> headers().
@@ -932,19 +958,25 @@ container_creds_headers(Token) ->
 %%      hostname verification. For plaintext, uses plain TCP.
 %% @end
 container_creds_open_opts(tls, Host) ->
+    BaseTlsOpts = [
+        {verify, verify_peer},
+        {cacerts, public_key:cacerts_get()},
+        {customize_hostname_check, [
+            {match_fun, public_key:pkix_verify_hostname_match_fun(https)}
+        ]}
+    ],
+    %% SNI must be a DNS hostname per RFC 6066; do not set it for IP literals.
+    TlsOpts =
+        case inet:parse_address(Host) of
+            {ok, _IP} -> BaseTlsOpts;
+            {error, einval} -> [{server_name_indication, Host} | BaseTlsOpts]
+        end,
     #{
         transport => tls,
         protocols => [http],
         connect_timeout => ?CONTAINER_CREDS_CONNECT_TIMEOUT,
         timeout => ?CONTAINER_CREDS_RESPONSE_TIMEOUT,
-        tls_opts => [
-            {verify, verify_peer},
-            {cacerts, public_key:cacerts_get()},
-            {customize_hostname_check, [
-                {match_fun, public_key:pkix_verify_hostname_match_fun(https)}
-            ]},
-            {server_name_indication, Host}
-        ]
+        tls_opts => TlsOpts
     };
 container_creds_open_opts(tcp, _Host) ->
     #{
@@ -980,9 +1012,24 @@ parse_container_credentials_body(Body) ->
                 {ok, Creds}
         end
     catch
-        _:Reason ->
-            {error, {json_decode_failed, Reason}}
+        _:_Reason ->
+            %% Do not include the exception reason in the error tuple -- it may
+            %% contain fragments of the response body (credential material, P0 R6).
+            {error, json_decode_failed}
     end.
+
+%% @doc Sanitize container credential error reasons for safe logging.
+%%      Strips inner terms that could contain response body fragments or
+%%      credential material (P0 R6). Only the error category atom is logged.
+%% @end
+sanitize_container_error({json_decode_failed, _}) -> json_decode_failed;
+sanitize_container_error({http_error, Status, _Phrase}) -> {http_error, Status};
+sanitize_container_error({transport_error, Reason}) -> {transport_error, Reason};
+sanitize_container_error(response_body_too_large) -> response_body_too_large;
+sanitize_container_error(missing_credential_fields) -> missing_credential_fields;
+sanitize_container_error({malformed_url, _}) -> malformed_url;
+sanitize_container_error(Other) when is_atom(Other) -> Other;
+sanitize_container_error(_) -> unknown_error.
 
 -spec parse_expiration(string() | undefined) -> calendar:datetime() | undefined.
 %% @doc Parse the Expiration field if present, returning undefined when absent.

--- a/src/aws_lib_httpc.erl
+++ b/src/aws_lib_httpc.erl
@@ -42,7 +42,10 @@
     %% _}}) rather than blocking on a background reconnect.
     retry => non_neg_integer(),
     %% Request (await/await_body) timeout, consulted only by request/7.
-    timeout => timeout()
+    timeout => timeout(),
+    %% TLS client options forwarded to gun when transport is tls. Used by the
+    %% container credentials path to configure verify_peer with system CAs.
+    tls_opts => [ssl:tls_client_option()]
 }.
 
 %% The response tuple this module produces, consumed by
@@ -71,10 +74,17 @@ open(Host, Port, Opts) ->
     },
     %% Only override gun's default retry count when the caller asks; existing
     %% one-shot callers leave it unset and keep gun's default behaviour.
-    GunOpts =
+    GunOpts1 =
         case maps:find(retry, Opts) of
             {ok, Retry} -> GunOpts0#{retry => Retry};
             error -> GunOpts0
+        end,
+    %% Forward TLS client options to gun when the caller provides them (used by
+    %% the container credentials HTTPS path for verify_peer with system CAs).
+    GunOpts =
+        case maps:find(tls_opts, Opts) of
+            {ok, TlsOpts} -> GunOpts1#{tls_opts => TlsOpts};
+            error -> GunOpts1
         end,
     case gun:open(Host, Port, GunOpts) of
         {ok, ConnPid} ->

--- a/test/aws_lib_config_container_creds_tests.erl
+++ b/test/aws_lib_config_container_creds_tests.erl
@@ -1,0 +1,470 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+%% Unit tests for ECS/EKS container credentials support in aws_lib_config.
+%% These test URL construction, SSRF allowlist validation, token handling,
+%% and the hard-error vs fallthrough semantics.
+-module(aws_lib_config_container_creds_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("aws_lib.hrl").
+
+%% ---------------------------------------------------------------------------
+%% Test setup / teardown helpers
+%% ---------------------------------------------------------------------------
+
+clear_container_env() ->
+    os:unsetenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"),
+    os:unsetenv("AWS_CONTAINER_CREDENTIALS_FULL_URI"),
+    os:unsetenv("AWS_CONTAINER_AUTHORIZATION_TOKEN"),
+    os:unsetenv("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE"),
+    application:unset_env(aws, container_credentials_host_override).
+
+%% ---------------------------------------------------------------------------
+%% container_credentials_url/0 tests
+%% ---------------------------------------------------------------------------
+
+container_url_test_() ->
+    {foreach, fun() -> clear_container_env() end, fun(_) -> clear_container_env() end, [
+        {"not_configured when no env vars set", fun() ->
+            ?assertEqual(not_configured, aws_lib_config:container_credentials_url())
+        end},
+        {"RELATIVE_URI builds URL with ECS host", fun() ->
+            os:putenv(
+                "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+                "/v2/credentials/abc-123"
+            ),
+            ?assertEqual(
+                {ok, "http://169.254.170.2/v2/credentials/abc-123"},
+                aws_lib_config:container_credentials_url()
+            )
+        end},
+        {"RELATIVE_URI with host override uses override", fun() ->
+            os:putenv(
+                "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+                "/v2/credentials/abc-123"
+            ),
+            application:set_env(aws, container_credentials_host_override, "127.0.0.1:9911"),
+            ?assertEqual(
+                {ok, "http://127.0.0.1:9911/v2/credentials/abc-123"},
+                aws_lib_config:container_credentials_url()
+            )
+        end},
+        {"RELATIVE_URI takes precedence over FULL_URI", fun() ->
+            os:putenv(
+                "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+                "/v2/credentials/relative"
+            ),
+            os:putenv(
+                "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+                "http://127.0.0.1:1234/full"
+            ),
+            {ok, URL} = aws_lib_config:container_credentials_url(),
+            ?assertMatch("http://169.254.170.2/v2/credentials/relative", URL)
+        end},
+        {"FULL_URI with http loopback is allowed", fun() ->
+            os:putenv(
+                "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+                "http://127.0.0.1:1234/creds"
+            ),
+            ?assertEqual(
+                {ok, "http://127.0.0.1:1234/creds"},
+                aws_lib_config:container_credentials_url()
+            )
+        end},
+        {"FULL_URI with https any host is allowed", fun() ->
+            os:putenv(
+                "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+                "https://sts.amazonaws.com/creds"
+            ),
+            ?assertEqual(
+                {ok, "https://sts.amazonaws.com/creds"},
+                aws_lib_config:container_credentials_url()
+            )
+        end},
+        {"FULL_URI with http public IP is rejected", fun() ->
+            os:putenv(
+                "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+                "http://203.0.113.1/creds"
+            ),
+            ?assertMatch(
+                {error, uri_not_allowed, _},
+                aws_lib_config:container_credentials_url()
+            )
+        end},
+        {"FULL_URI with http RFC1918 IP is rejected", fun() ->
+            os:putenv(
+                "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+                "http://10.0.0.1/creds"
+            ),
+            ?assertMatch(
+                {error, uri_not_allowed, _},
+                aws_lib_config:container_credentials_url()
+            )
+        end},
+        {"FULL_URI with unsupported scheme is rejected", fun() ->
+            os:putenv(
+                "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+                "ftp://127.0.0.1/creds"
+            ),
+            ?assertMatch(
+                {error, uri_not_allowed, {unsupported_scheme, "ftp"}},
+                aws_lib_config:container_credentials_url()
+            )
+        end}
+    ]}.
+
+%% ---------------------------------------------------------------------------
+%% validate_full_uri/1 SSRF allowlist tests
+%% ---------------------------------------------------------------------------
+
+validate_full_uri_test_() ->
+    [
+        {"loopback 127.0.0.1 allowed for http", fun() ->
+            ?assertEqual(ok, aws_lib_config:validate_full_uri("http://127.0.0.1/path"))
+        end},
+        {"loopback 127.0.0.255 allowed for http", fun() ->
+            ?assertEqual(ok, aws_lib_config:validate_full_uri("http://127.0.0.255/path"))
+        end},
+        {"ECS link-local 169.254.170.2 allowed for http", fun() ->
+            ?assertEqual(ok, aws_lib_config:validate_full_uri("http://169.254.170.2/path"))
+        end},
+        {"EKS link-local 169.254.170.23 allowed for http", fun() ->
+            ?assertEqual(ok, aws_lib_config:validate_full_uri("http://169.254.170.23/path"))
+        end},
+        {"IPv6 loopback ::1 allowed for http", fun() ->
+            ?assertEqual(ok, aws_lib_config:validate_full_uri("http://[::1]/path"))
+        end},
+        {"IPv6 EKS fd00:ec2::23 allowed for http", fun() ->
+            ?assertEqual(ok, aws_lib_config:validate_full_uri("http://[fd00:ec2::23]/path"))
+        end},
+        {"https allows any host", fun() ->
+            ?assertEqual(ok, aws_lib_config:validate_full_uri("https://203.0.113.1/path"))
+        end},
+        {"https allows public hostname", fun() ->
+            ?assertEqual(ok, aws_lib_config:validate_full_uri("https://sts.amazonaws.com/path"))
+        end},
+        {"http to IMDS 169.254.169.254 rejected", fun() ->
+            ?assertMatch(
+                {error, {full_uri_not_allowed, _}},
+                aws_lib_config:validate_full_uri("http://169.254.169.254/path")
+            )
+        end},
+        {"http to public IP rejected", fun() ->
+            ?assertMatch(
+                {error, {full_uri_not_allowed, _}},
+                aws_lib_config:validate_full_uri("http://8.8.8.8/path")
+            )
+        end},
+        {"http to RFC1918 rejected", fun() ->
+            ?assertMatch(
+                {error, {full_uri_not_allowed, _}},
+                aws_lib_config:validate_full_uri("http://192.168.1.1/path")
+            )
+        end},
+        {"http to hostname rejected (not a literal IP)", fun() ->
+            ?assertMatch(
+                {error, {full_uri_not_allowed, _}},
+                aws_lib_config:validate_full_uri("http://my-host.local/path")
+            )
+        end},
+        {"malformed URI rejected", fun() ->
+            ?assertMatch(
+                {error, {malformed_full_uri, _}},
+                aws_lib_config:validate_full_uri("not-a-uri")
+            )
+        end}
+    ].
+
+%% ---------------------------------------------------------------------------
+%% container_auth_token/0 tests
+%% ---------------------------------------------------------------------------
+
+container_auth_token_test_() ->
+    {foreach, fun() -> clear_container_env() end, fun(_) -> clear_container_env() end, [
+        {"undefined when no token env vars set", fun() ->
+            ?assertEqual(undefined, aws_lib_config:container_auth_token())
+        end},
+        {"reads token from AWS_CONTAINER_AUTHORIZATION_TOKEN", fun() ->
+            os:putenv("AWS_CONTAINER_AUTHORIZATION_TOKEN", "Bearer my-secret-token"),
+            ?assertEqual("Bearer my-secret-token", aws_lib_config:container_auth_token())
+        end},
+        {"reads token from file (TOKEN_FILE takes precedence)", fun() ->
+            %% Write a temp file
+            TmpDir = filename:basedir(user_cache, "aws_test"),
+            ok = filelib:ensure_dir(filename:join(TmpDir, "x")),
+            TokenPath = filename:join(TmpDir, "test_token"),
+            ok = file:write_file(TokenPath, <<"file-token-value\n">>),
+            os:putenv("AWS_CONTAINER_AUTHORIZATION_TOKEN", "env-token"),
+            os:putenv("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE", TokenPath),
+            ?assertEqual("file-token-value", aws_lib_config:container_auth_token()),
+            file:delete(TokenPath)
+        end},
+        {"missing token file raises error", fun() ->
+            os:putenv(
+                "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
+                "/nonexistent/path/token"
+            ),
+            ?assertError(
+                {container_token_file_not_found, _},
+                aws_lib_config:container_auth_token()
+            )
+        end},
+        {"oversized token file raises error", fun() ->
+            TmpDir = filename:basedir(user_cache, "aws_test"),
+            ok = filelib:ensure_dir(filename:join(TmpDir, "x")),
+            BigPath = filename:join(TmpDir, "big_token"),
+            %% Write a file larger than 8KB
+            BigContent = list_to_binary(lists:duplicate(?CONTAINER_AUTH_TOKEN_MAX_SIZE + 1, $A)),
+            ok = file:write_file(BigPath, BigContent),
+            os:putenv("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE", BigPath),
+            ?assertError(
+                {container_token_file_too_large, _},
+                aws_lib_config:container_auth_token()
+            ),
+            file:delete(BigPath)
+        end}
+    ]}.
+
+%% ---------------------------------------------------------------------------
+%% is_allowed_plaintext_host/1 tests
+%% ---------------------------------------------------------------------------
+
+is_allowed_plaintext_host_test_() ->
+    [
+        {"127.0.0.1 is loopback - allowed", fun() ->
+            ?assert(aws_lib_config:is_allowed_plaintext_host("127.0.0.1"))
+        end},
+        {"127.255.255.254 is loopback - allowed", fun() ->
+            ?assert(aws_lib_config:is_allowed_plaintext_host("127.255.255.254"))
+        end},
+        {"169.254.170.2 is ECS link-local - allowed", fun() ->
+            ?assert(aws_lib_config:is_allowed_plaintext_host("169.254.170.2"))
+        end},
+        {"169.254.170.23 is EKS link-local - allowed", fun() ->
+            ?assert(aws_lib_config:is_allowed_plaintext_host("169.254.170.23"))
+        end},
+        {"::1 is IPv6 loopback - allowed", fun() ->
+            ?assert(aws_lib_config:is_allowed_plaintext_host("::1"))
+        end},
+        {"fd00:ec2::23 is EKS IPv6 - allowed", fun() ->
+            ?assert(aws_lib_config:is_allowed_plaintext_host("fd00:ec2::23"))
+        end},
+        {"10.0.0.1 is RFC1918 - rejected", fun() ->
+            ?assertNot(aws_lib_config:is_allowed_plaintext_host("10.0.0.1"))
+        end},
+        {"192.168.1.1 is RFC1918 - rejected", fun() ->
+            ?assertNot(aws_lib_config:is_allowed_plaintext_host("192.168.1.1"))
+        end},
+        {"169.254.169.254 is IMDS - rejected", fun() ->
+            ?assertNot(aws_lib_config:is_allowed_plaintext_host("169.254.169.254"))
+        end},
+        {"8.8.8.8 is public - rejected", fun() ->
+            ?assertNot(aws_lib_config:is_allowed_plaintext_host("8.8.8.8"))
+        end},
+        {"hostname is rejected (not a literal IP)", fun() ->
+            ?assertNot(aws_lib_config:is_allowed_plaintext_host("localhost"))
+        end}
+    ].
+
+%% ---------------------------------------------------------------------------
+%% fetch_container_credentials/2 integration test (with mocked gun)
+%% ---------------------------------------------------------------------------
+
+fetch_container_credentials_test_() ->
+    {foreach,
+        fun() ->
+            meck:new(gun, []),
+            [gun]
+        end,
+        fun meck:unload/1, [
+            {"successful credential fetch", fun() ->
+                CredsBody = <<
+                    "{\"AccessKeyId\":\"AKID123\","
+                    "\"SecretAccessKey\":\"secret456\","
+                    "\"Token\":\"sessiontoken789\","
+                    "\"Expiration\":\"2026-08-01T12:00:00Z\"}"
+                >>,
+                meck:expect(gun, open, fun(_, _, _) -> {ok, pid} end),
+                meck:expect(gun, close, fun(_) -> ok end),
+                meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
+                meck:expect(gun, get, fun(_, _, _) -> stream_ref end),
+                meck:expect(gun, await, fun(_, _, _) ->
+                    {response, nofin, 200, []}
+                end),
+                meck:expect(gun, await_body, fun(_, _, _) -> {ok, CredsBody} end),
+                {ok, Creds} = aws_lib_config:fetch_container_credentials(
+                    "http://169.254.170.2/v2/creds/abc", undefined
+                ),
+                ?assertEqual("AKID123", Creds#aws_credentials.access_key),
+                ?assertEqual("secret456", Creds#aws_credentials.secret_key),
+                ?assertEqual("sessiontoken789", Creds#aws_credentials.security_token),
+                ?assertEqual({{2026, 8, 1}, {12, 0, 0}}, Creds#aws_credentials.expiration)
+            end},
+            {"credential fetch with authorization token", fun() ->
+                CredsBody = <<
+                    "{\"AccessKeyId\":\"AKID\","
+                    "\"SecretAccessKey\":\"secret\","
+                    "\"Token\":\"tok\","
+                    "\"Expiration\":\"2026-01-01T00:00:00Z\"}"
+                >>,
+                meck:expect(gun, open, fun(_, _, _) -> {ok, pid} end),
+                meck:expect(gun, close, fun(_) -> ok end),
+                meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
+                meck:expect(gun, get, fun(_, Path, Headers) ->
+                    %% Path is a list string (gun receives it from aws_lib_httpc)
+                    ?assertEqual("/v2/creds/xyz", Path),
+                    %% Headers are normalized to {binary(), binary()} tuples
+                    AuthHdr = proplists:get_value(<<"Authorization">>, Headers),
+                    ?assertEqual(<<"Bearer my-token">>, AuthHdr),
+                    stream_ref
+                end),
+                meck:expect(gun, await, fun(_, _, _) ->
+                    {response, nofin, 200, []}
+                end),
+                meck:expect(gun, await_body, fun(_, _, _) -> {ok, CredsBody} end),
+                {ok, Creds} = aws_lib_config:fetch_container_credentials(
+                    "http://169.254.170.2/v2/creds/xyz", "Bearer my-token"
+                ),
+                ?assertEqual("AKID", Creds#aws_credentials.access_key)
+            end},
+            {"HTTP error response returns error tuple", fun() ->
+                meck:expect(gun, open, fun(_, _, _) -> {ok, pid} end),
+                meck:expect(gun, close, fun(_) -> ok end),
+                meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
+                meck:expect(gun, get, fun(_, _, _) -> stream_ref end),
+                meck:expect(gun, await, fun(_, _, _) ->
+                    {response, nofin, 500, []}
+                end),
+                meck:expect(gun, await_body, fun(_, _, _) ->
+                    {ok, <<"Internal Server Error">>}
+                end),
+                ?assertMatch(
+                    {error, {http_error, 500, _}},
+                    aws_lib_config:fetch_container_credentials(
+                        "http://169.254.170.2/v2/creds/abc", undefined
+                    )
+                )
+            end},
+            {"transport error returns error tuple", fun() ->
+                meck:expect(gun, open, fun(_, _, _) -> {error, timeout} end),
+                ?assertMatch(
+                    {error, {transport_error, _}},
+                    aws_lib_config:fetch_container_credentials(
+                        "http://169.254.170.2/v2/creds/abc", undefined
+                    )
+                )
+            end},
+            {"response body too large returns error", fun() ->
+                %% Build a body larger than CONTAINER_CREDS_MAX_BODY
+                BigBody = list_to_binary(lists:duplicate(?CONTAINER_CREDS_MAX_BODY + 1, $x)),
+                meck:expect(gun, open, fun(_, _, _) -> {ok, pid} end),
+                meck:expect(gun, close, fun(_) -> ok end),
+                meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
+                meck:expect(gun, get, fun(_, _, _) -> stream_ref end),
+                meck:expect(gun, await, fun(_, _, _) ->
+                    {response, nofin, 200, []}
+                end),
+                meck:expect(gun, await_body, fun(_, _, _) -> {ok, BigBody} end),
+                ?assertEqual(
+                    {error, response_body_too_large},
+                    aws_lib_config:fetch_container_credentials(
+                        "http://169.254.170.2/v2/creds/abc", undefined
+                    )
+                )
+            end},
+            {"missing credential fields in JSON returns error", fun() ->
+                %% Missing SecretAccessKey
+                Body = <<"{\"AccessKeyId\":\"AKID\"}">>,
+                meck:expect(gun, open, fun(_, _, _) -> {ok, pid} end),
+                meck:expect(gun, close, fun(_) -> ok end),
+                meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
+                meck:expect(gun, get, fun(_, _, _) -> stream_ref end),
+                meck:expect(gun, await, fun(_, _, _) ->
+                    {response, nofin, 200, []}
+                end),
+                meck:expect(gun, await_body, fun(_, _, _) -> {ok, Body} end),
+                ?assertEqual(
+                    {error, missing_credential_fields},
+                    aws_lib_config:fetch_container_credentials(
+                        "http://169.254.170.2/v2/creds/abc", undefined
+                    )
+                )
+            end}
+        ]}.
+
+%% ---------------------------------------------------------------------------
+%% lookup_credentials_from_container_or_imds/1 integration tests
+%% ---------------------------------------------------------------------------
+
+container_or_imds_test_() ->
+    {foreach,
+        fun() ->
+            meck:new(gun, []),
+            meck:new(aws_lib, [passthrough]),
+            clear_container_env(),
+            %% Disable IMDSv2 for simplicity in these tests
+            application:set_env(aws, aws_prefer_imdsv2, false),
+            [gun, aws_lib]
+        end,
+        fun(Mods) ->
+            clear_container_env(),
+            application:unset_env(aws, aws_prefer_imdsv2),
+            meck:unload(Mods)
+        end,
+        [
+            {"falls through to IMDS when no container env vars set", fun() ->
+                %% Mock IMDS to return 404 so we get {error, undefined}
+                meck:expect(gun, open, fun(_, _, _) -> {ok, pid} end),
+                meck:expect(gun, close, fun(_) -> ok end),
+                meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
+                meck:expect(gun, get, fun(_, _, _) -> stream_ref end),
+                meck:expect(gun, await, fun(_, _, _) -> {response, fin, 404, []} end),
+                S = #aws_config{},
+                ?assertEqual(
+                    {error, undefined},
+                    aws_lib_config:lookup_credentials_from_container_or_imds(S)
+                )
+            end},
+            {"uses container endpoint when RELATIVE_URI is set", fun() ->
+                os:putenv(
+                    "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+                    "/v2/credentials/task-id"
+                ),
+                CredsBody = <<
+                    "{\"AccessKeyId\":\"CONTAINER_KEY\","
+                    "\"SecretAccessKey\":\"CONTAINER_SECRET\","
+                    "\"Token\":\"CONTAINER_TOKEN\","
+                    "\"Expiration\":\"2026-12-31T23:59:59Z\"}"
+                >>,
+                meck:expect(gun, open, fun(_, _, _) -> {ok, pid} end),
+                meck:expect(gun, close, fun(_) -> ok end),
+                meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
+                meck:expect(gun, get, fun(_, _, _) -> stream_ref end),
+                meck:expect(gun, await, fun(_, _, _) ->
+                    {response, nofin, 200, []}
+                end),
+                meck:expect(gun, await_body, fun(_, _, _) -> {ok, CredsBody} end),
+                S = #aws_config{},
+                {ok, Creds, S1} =
+                    aws_lib_config:lookup_credentials_from_container_or_imds(S),
+                ?assertEqual("CONTAINER_KEY", Creds#aws_credentials.access_key),
+                ?assertEqual("CONTAINER_SECRET", Creds#aws_credentials.secret_key),
+                ?assertEqual("CONTAINER_TOKEN", Creds#aws_credentials.security_token),
+                ?assertEqual(S, S1)
+            end},
+            {"hard error when container env set but fetch fails (no IMDS fallthrough)", fun() ->
+                os:putenv(
+                    "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+                    "/v2/credentials/task-id"
+                ),
+                %% Simulate transport failure
+                meck:expect(gun, open, fun(_, _, _) -> {error, econnrefused} end),
+                S = #aws_config{},
+                Result = aws_lib_config:lookup_credentials_from_container_or_imds(S),
+                ?assertMatch(
+                    {error, {container_credentials_failed, _}},
+                    Result
+                )
+            end}
+        ]}.

--- a/test/aws_lib_config_container_creds_tests.erl
+++ b/test/aws_lib_config_container_creds_tests.erl
@@ -206,7 +206,7 @@ container_auth_token_test_() ->
                 "/nonexistent/path/token"
             ),
             ?assertError(
-                {container_token_file_not_found, _},
+                {container_token_file_unreadable, enoent},
                 aws_lib_config:container_auth_token()
             )
         end},


### PR DESCRIPTION
Fixes #94.

Adds container credentials as a credential source, supporting both forms the issue
names: `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` (fetched from `169.254.170.2`) and
`AWS_CONTAINER_CREDENTIALS_FULL_URI` (EKS Pod Identity and similar), with the
optional `AWS_CONTAINER_AUTHORIZATION_TOKEN` / `..._TOKEN_FILE`.

## Change

Chain position as specified: env vars -> config/credentials file -> **container
credentials** -> IMDS.

Note that **all four** fallthrough sites in `aws_lib_config` funnel into IMDS
(`lookup_credentials_from_file/3`, `lookup_credentials_from_section/2`, and two
clauses of `lookup_credentials_from_proplist/4`). All four now route through a
single `lookup_credentials_from_container_or_imds/1` funnel, so the new step is
reachable on every path rather than just one.

## Security properties

- **FULL_URI is allowlisted, not denylisted.** Plaintext HTTP is permitted only to
  loopback (`127.0.0.0/8`, `::1`) and the ECS/EKS link-local addresses
  (`169.254.170.2`, `169.254.170.23`, `fd00:ec2::23`); any other host must be HTTPS,
  where TLS authenticates the endpoint. Matches real SDK behaviour. Hostnames are
  rejected for plaintext, so DNS cannot be used to reach an arbitrary host.
- Deliberately **not** reusing `aws_auth_validate_net`: that module is a denylist for
  outbound connections to open-ended customer-supplied servers. Here the permitted
  set is tiny and closed, so an allowlist is strictly stricter. A code comment
  records this.
- **No token or credential leakage.** The Authorization token and fetched
  credentials never reach logs, and error reasons are sanitized to category atoms
  before logging. A missing/unreadable/oversized token file is a hard error and its
  contents are never logged.
- **TLS on the HTTPS path** uses real verification (never `verify_none`), and skips
  `server_name_indication` when the host is an IP literal.
- **Bounded**: 2s connect, 5s response, 16KB body cap.
- **No silent fallthrough.** If the env vars are set but the fetch fails, this hard
  errors rather than falling through to IMDS -- falling through would silently use
  the EC2 *host* instance role instead of the intended *task* role, which is exactly
  the confusion this feature exists to prevent.

## Verification

eunit **861 passed, 0 failed** (baseline `main` is 814). 47 new unit tests.

The FULL_URI allowlist, exercised directly (20 inputs, abbreviated):

```
http://169.254.170.2/creds     -> ok
http://127.0.0.1:8080/c        -> ok
http://[::1]/c                 -> ok
http://[fd00:ec2::23]/c        -> ok
https://example.com/c          -> ok      (TLS authenticates)
http://203.0.113.1/c           -> {error,{full_uri_not_allowed,"203.0.113.1"}}
http://10.0.0.1/c              -> {error,{full_uri_not_allowed,"10.0.0.1"}}
http://169.254.169.254/...     -> {error,{full_uri_not_allowed,"169.254.169.254"}}
http://localhost/c             -> {error,{full_uri_not_allowed,"localhost"}}
http://169.254.170.3/c         -> {error,{full_uri_not_allowed,"169.254.170.3"}}
gopher://x/c                   -> {error,{unsupported_scheme,"gopher"}}
```

Alternate loopback encodings (`0177.0.0.1`, `2130706433`, `127.1`) are accepted;
each parses to genuine `127.0.0.1`, so this is correct rather than a bypass.

Other manual cases, all passing: token delivered via env var and via file (the
listener echoed the `Authorization` header it received); missing token file and
oversized token file both hard-error; connection refused hard-errors without
touching IMDS; RELATIVE_URI takes precedence over FULL_URI; non-leakage grep at
debug level returns **zero hits** for the fake token and secret.

**Verified against a real container-credentials endpoint.** `ada credentials serve`
implements the same contract ECS/EKS expose. Driving the real public entry point
`aws_lib_config:credentials/1` with the env-var and config-file sources pointed at
nonexistent paths, so the container provider was the only path that could succeed:

```
FULL_URI = http://127.0.0.1:9911
RESULT: ok -- credentials fetched from the container endpoint
  access_key present : true
  secret_key present : true
  session_token present : true
  expiration : {{2026,8,3},{20,0,42}}
```

That covers the real HTTP fetch, the allowlist, JSON parsing of the IMDS-shaped
body, and real RFC3339 `Expiration` parsing -- and confirms the chain ordering.

## Worst-case boot latency

7s (2s connect + 5s response) if the endpoint exists but hangs. When the env vars
are unset the cost is two `os:getenv` calls.

## Still outstanding for live verification

RELATIVE_URI against a real `169.254.170.2` in an ECS task (locally unreachable by
design -- only URL construction is proven here, with the fetch path covered via
FULL_URI), EKS Pod Identity with a real token file, and refresh across the 5-minute
pre-expiry buffer on a long-lived task.

