### PR TITLE
`aws_lib`: Replace the fixed retry delay with exponential backoff and jitter

### DIFF
--- a/AGENTS-aws_lib.md
+++ b/AGENTS-aws_lib.md
@@ -45,7 +45,7 @@ Uses Gun (HTTP/1.1 and HTTP/2). One-shot request lifecycle:
 
 ### Retry Logic
 
-`api_get_request/3` and `api_post_request/5` retry up to 5 times with a fixed 500ms delay between attempts. Credentials are validated before the first attempt and re-validated before each retry. If credentials cannot be loaded, returns `{error, {credentials, Reason}}` immediately without retrying.
+`api_get_request/3` and `api_post_request/5` retry up to 5 times, sleeping between attempts for an equal-jitter exponential backoff interval: `Temp = min(10000, 500 * 2^Attempt)` ms, then a random delay in `[Temp/2, Temp]`. The delay is skipped after the final attempt, so a fully exhausted request waits at most 7.5s in total. Credentials are validated before the first attempt and re-validated before each retry. If credentials cannot be loaded, returns `{error, {credentials, Reason}}` immediately without retrying.
 
 ## Modules
 

--- a/include/aws_lib.hrl
+++ b/include/aws_lib.hrl
@@ -54,7 +54,8 @@
 % 5-minute buffer erlcloud uses.
 -define(CREDENTIAL_REFRESH_BUFFER_SECONDS, 300).
 
--define(LINEAR_BACK_OFF_MILLIS, 500).
+-define(BACKOFF_BASE_MILLIS, 500).
+-define(BACKOFF_CAP_MILLIS, 10000).
 -define(MAX_RETRIES, 5).
 
 -define(AWS_CREDENTIALS_TABLE, aws_credentials).

--- a/src/aws_lib.erl
+++ b/src/aws_lib.erl
@@ -28,6 +28,7 @@
     local_time/0,
     api_get_request/3,
     api_post_request/5,
+    backoff_delay/3,
     endpoint/4,
     sign_headers/10,
     instance_volumes/1,
@@ -582,7 +583,7 @@ api_get_request(Service, Path, State) ->
         "",
         [],
         ?MAX_RETRIES,
-        ?LINEAR_BACK_OFF_MILLIS,
+        ?BACKOFF_BASE_MILLIS,
         State
     ).
 
@@ -606,7 +607,7 @@ api_post_request(Service, Path, Body, Headers, State) ->
         Body,
         Headers,
         ?MAX_RETRIES,
-        ?LINEAR_BACK_OFF_MILLIS,
+        ?BACKOFF_BASE_MILLIS,
         State
     ).
 
@@ -645,13 +646,14 @@ instance_volumes(State0 = #aws_state{config = Config0}) ->
     Body :: body(),
     Headers :: headers(),
     Retries :: integer(),
-    WaitTime :: integer(),
+    BackoffBase :: integer(),
     State :: aws_state()
 ) ->
     {ok, list(), aws_state()} | {error, term(), aws_state()}.
-%% @doc Invoke an API call to an AWS service with retries.
+%% @doc Invoke an API call to an AWS service with retries and exponential
+%% backoff with jitter between attempts.
 %% @end
-api_request_with_retries(Service, Method, Path, Body, Headers, Retries, WaitTime, State) ->
+api_request_with_retries(Service, Method, Path, Body, Headers, Retries, BackoffBase, State) ->
     %% Open a single connection and reuse it across the whole retry sequence
     %% instead of opening a fresh TCP+TLS connection per attempt (issue #91).
     %% When the state carries a reuse_conn (cross-request reuse, issue #107),
@@ -659,7 +661,7 @@ api_request_with_retries(Service, Method, Path, Body, Headers, Retries, WaitTime
     %% start with `undefined' (nothing open yet, opened lazily on first attempt).
     Conn0 = seed_conn_from_state(State),
     api_request_with_retries(
-        Service, Method, Path, Body, Headers, Retries, WaitTime, State, Conn0, undefined
+        Service, Method, Path, Body, Headers, Retries, BackoffBase, State, Conn0, undefined, 0
     ).
 
 -spec api_request_with_retries(
@@ -669,14 +671,25 @@ api_request_with_retries(Service, Method, Path, Body, Headers, Retries, WaitTime
     Body :: body(),
     Headers :: headers(),
     Retries :: integer(),
-    WaitTime :: integer(),
+    BackoffBase :: integer(),
     State :: aws_state(),
     Conn :: aws_lib_httpc:conn() | undefined,
-    LastError :: result_error() | undefined
+    LastError :: result_error() | undefined,
+    Attempt :: non_neg_integer()
 ) ->
     {ok, list(), aws_state()} | {error, term(), aws_state()}.
 api_request_with_retries(
-    _Service, _Method, _Path, _Body, _Headers, Retries, _WaitTime, State, Conn, LastError
+    _Service,
+    _Method,
+    _Path,
+    _Body,
+    _Headers,
+    Retries,
+    _BackoffBase,
+    State,
+    Conn,
+    LastError,
+    _Attempt
 ) when
     Retries =< 0
 ->
@@ -690,7 +703,7 @@ api_request_with_retries(
     %% rather than a generic string (issue #82).
     {error, exhausted_error(LastError), State1};
 api_request_with_retries(
-    Service, Method, Path, Body, Headers, Retries, WaitTime, State0, Conn0, LastError
+    Service, Method, Path, Body, Headers, Retries, BackoffBase, State0, Conn0, LastError, Attempt
 ) ->
     case ensure_credentials_valid(State0) of
         {ok, State1} ->
@@ -738,7 +751,7 @@ api_request_with_retries(
                             ?LOG_WARNING(
                                 "Will retry AWS request, remaining retries: ~b", [Retries]
                             ),
-                            timer:sleep(WaitTime),
+                            timer:sleep(backoff_delay(Attempt, BackoffBase, ?BACKOFF_CAP_MILLIS)),
                             %% perform_request_reuse/8 hands back a live connection
                             %% after an HTTP-level error (reused on the next
                             %% attempt) or `undefined' after a transport failure
@@ -754,10 +767,11 @@ api_request_with_retries(
                                 Body,
                                 Headers,
                                 Retries - 1,
-                                WaitTime,
+                                BackoffBase,
                                 State1,
                                 Conn1,
-                                keep_informative_error(LastError, Error)
+                                keep_informative_error(LastError, Error),
+                                Attempt + 1
                             )
                     end
             end;
@@ -792,6 +806,21 @@ exhausted_error({error, _Message, {_Headers, DecodedBody}}) ->
     {service_error, DecodedBody};
 exhausted_error(_) ->
     {service_error, retries_exhausted}.
+
+-spec backoff_delay(
+    Attempt :: non_neg_integer(), Base :: non_neg_integer(), Cap :: non_neg_integer()
+) ->
+    pos_integer().
+%% @doc Compute the sleep duration (ms) for a retry attempt using equal-jitter
+%% exponential backoff (aws-erlang pattern). The deterministic component
+%% (Temp/2) guarantees a minimum delay per attempt, while the random component
+%% (rand:uniform(Temp/2)) adds jitter to spread concurrent retriers. The
+%% formula: Temp = min(Cap, Base * 2^Attempt); Sleep = Temp/2 + uniform(Temp/2).
+%% @end
+backoff_delay(Attempt, Base, Cap) ->
+    Temp = min(Cap, Base * (1 bsl Attempt)),
+    HalfTemp = max(1, Temp div 2),
+    HalfTemp + rand:uniform(HalfTemp).
 
 %% Perform one request attempt on a reusable connection. Opens a connection when
 %% none is carried (or the carried one targets a different host) and reuses the

--- a/src/aws_lib.erl
+++ b/src/aws_lib.erl
@@ -28,7 +28,6 @@
     local_time/0,
     api_get_request/3,
     api_post_request/5,
-    backoff_delay/3,
     endpoint/4,
     sign_headers/10,
     instance_volumes/1,
@@ -751,7 +750,7 @@ api_request_with_retries(
                             ?LOG_WARNING(
                                 "Will retry AWS request, remaining retries: ~b", [Retries]
                             ),
-                            timer:sleep(backoff_delay(Attempt, BackoffBase, ?BACKOFF_CAP_MILLIS)),
+                            maybe_backoff(Retries, Attempt, BackoffBase),
                             %% perform_request_reuse/8 hands back a live connection
                             %% after an HTTP-level error (reused on the next
                             %% attempt) or `undefined' after a transport failure
@@ -806,6 +805,20 @@ exhausted_error({error, _Message, {_Headers, DecodedBody}}) ->
     {service_error, DecodedBody};
 exhausted_error(_) ->
     {service_error, retries_exhausted}.
+
+-spec maybe_backoff(
+    Retries :: integer(), Attempt :: non_neg_integer(), Base :: non_neg_integer()
+) -> ok.
+%% Sleep between attempts, but only when another attempt will actually follow.
+%% The caller decrements Retries after this call, so Retries =< 1 means the next
+%% recursion hits the exhaustion clause: sleeping there would delay the returned
+%% error by a full backoff interval (up to ?BACKOFF_CAP_MILLIS) without buying
+%% another attempt. This matters on the broker-boot ARN resolution path, where it
+%% halves the worst-case delay for an unreachable service.
+maybe_backoff(Retries, _Attempt, _Base) when Retries =< 1 ->
+    ok;
+maybe_backoff(_Retries, Attempt, Base) ->
+    timer:sleep(backoff_delay(Attempt, Base, ?BACKOFF_CAP_MILLIS)).
 
 -spec backoff_delay(
     Attempt :: non_neg_integer(), Base :: non_neg_integer(), Cap :: non_neg_integer()
@@ -891,7 +904,7 @@ perform_request_reuse(Service, Method, Headers, Path, Body, Options, State0, Con
             %% Shape the 2-tuple error through format_response/1 into the
             %% 3-tuple result the retry loop matches on; returning the raw
             %% {error, Reason} here would raise a case_clause in
-            %% api_request_with_retries/10.
+            %% api_request_with_retries/11.
             {aws_lib_response:format_response(Error), ConnSlot0, retriable}
     end.
 

--- a/test/aws_lib_tests.erl
+++ b/test/aws_lib_tests.erl
@@ -1175,3 +1175,110 @@ expired_imdsv2_token_test_() ->
             ?assertEqual(true, aws_lib:expired_imdsv2_token(Imdsv2Token))
         end}
     ].
+
+%% ----------------------------------------------------------------------------
+%% backoff_delay/3 -- exponential backoff with equal jitter (issue #81)
+%% ----------------------------------------------------------------------------
+backoff_delay_test_() ->
+    [
+        {"attempt 0 with base 500 is in range [250, 500]", fun() ->
+            Results = [aws_lib:backoff_delay(0, 500, 10000) || _ <- lists:seq(1, 50)],
+            lists:foreach(
+                fun(V) ->
+                    ?assert(V >= 250 andalso V =< 500)
+                end,
+                Results
+            )
+        end},
+        {"attempt 1 with base 500 is in range [500, 1000]", fun() ->
+            Results = [aws_lib:backoff_delay(1, 500, 10000) || _ <- lists:seq(1, 50)],
+            lists:foreach(
+                fun(V) ->
+                    ?assert(V >= 500 andalso V =< 1000)
+                end,
+                Results
+            )
+        end},
+        {"attempt 2 with base 500 is in range [1000, 2000]", fun() ->
+            Results = [aws_lib:backoff_delay(2, 500, 10000) || _ <- lists:seq(1, 50)],
+            lists:foreach(
+                fun(V) ->
+                    ?assert(V >= 1000 andalso V =< 2000)
+                end,
+                Results
+            )
+        end},
+        {"attempt 3 with base 500 is in range [2000, 4000]", fun() ->
+            Results = [aws_lib:backoff_delay(3, 500, 10000) || _ <- lists:seq(1, 50)],
+            lists:foreach(
+                fun(V) ->
+                    ?assert(V >= 2000 andalso V =< 4000)
+                end,
+                Results
+            )
+        end},
+        {"attempt 4 with base 500 is in range [4000, 8000]", fun() ->
+            Results = [aws_lib:backoff_delay(4, 500, 10000) || _ <- lists:seq(1, 50)],
+            lists:foreach(
+                fun(V) ->
+                    ?assert(V >= 4000 andalso V =< 8000)
+                end,
+                Results
+            )
+        end},
+        {"attempt 5 with base 500 is capped in range [5000, 10000]", fun() ->
+            Results = [aws_lib:backoff_delay(5, 500, 10000) || _ <- lists:seq(1, 50)],
+            lists:foreach(
+                fun(V) ->
+                    ?assert(V >= 5000 andalso V =< 10000)
+                end,
+                Results
+            )
+        end},
+        {"attempt 10 is capped in range [5000, 10000]", fun() ->
+            Results = [aws_lib:backoff_delay(10, 500, 10000) || _ <- lists:seq(1, 50)],
+            lists:foreach(
+                fun(V) ->
+                    ?assert(V >= 5000 andalso V =< 10000)
+                end,
+                Results
+            )
+        end},
+        {"boundary: base=1 cap=1 does not crash", fun() ->
+            V = aws_lib:backoff_delay(0, 1, 1),
+            ?assert(V >= 1)
+        end},
+        {"boundary: base=0 cap=0 does not crash (returns >= 1 due to guard)", fun() ->
+            V = aws_lib:backoff_delay(0, 0, 0),
+            ?assert(V >= 1)
+        end},
+        {"statistical spread: jitter produces varying results", fun() ->
+            Results = [aws_lib:backoff_delay(2, 500, 10000) || _ <- lists:seq(1, 100)],
+            Unique = lists:usort(Results),
+            %% With 100 samples from a range of 1000 values, we expect more than
+            %% a single distinct value. If all are identical, jitter is broken.
+            ?assert(length(Unique) > 1)
+        end},
+        {"monotonic growth: average delay increases with attempt (up to cap)", fun() ->
+            Avg = fun(Attempt) ->
+                Vals = [aws_lib:backoff_delay(Attempt, 500, 10000) || _ <- lists:seq(1, 200)],
+                lists:sum(Vals) / length(Vals)
+            end,
+            Avg0 = Avg(0),
+            Avg1 = Avg(1),
+            Avg2 = Avg(2),
+            Avg3 = Avg(3),
+            ?assert(Avg1 >= Avg0),
+            ?assert(Avg2 >= Avg1),
+            ?assert(Avg3 >= Avg2)
+        end},
+        {"cap less than base clips delay to cap range", fun() ->
+            Results = [aws_lib:backoff_delay(0, 5000, 100) || _ <- lists:seq(1, 50)],
+            lists:foreach(
+                fun(V) ->
+                    ?assert(V >= 51 andalso V =< 100)
+                end,
+                Results
+            )
+        end}
+    ].

--- a/test/aws_lib_tests.erl
+++ b/test/aws_lib_tests.erl
@@ -1297,3 +1297,98 @@ backoff_delay_test_() ->
             )
         end}
     ].
+
+%% ----------------------------------------------------------------------------
+%% maybe_backoff/3 -- no sleep before the exhaustion clause (issue #81 review)
+%% ----------------------------------------------------------------------------
+maybe_backoff_test_() ->
+    {
+        foreach,
+        fun() ->
+            meck:new(timer, [passthrough, unstick]),
+            meck:expect(timer, sleep, fun(_) -> ok end),
+            [timer]
+        end,
+        fun meck:unload/1,
+        [
+            {"the last attempt does not sleep", fun() ->
+                %% The caller decrements Retries after this call, so Retries =< 1
+                %% means the next recursion exhausts: sleeping would delay the
+                %% returned error without buying another attempt.
+                ?assertEqual(ok, aws_lib:maybe_backoff(1, 4, 500)),
+                ?assertEqual(ok, aws_lib:maybe_backoff(0, 4, 500)),
+                ?assertEqual(0, meck:num_calls(timer, sleep, '_'))
+            end},
+            {"an attempt with retries remaining sleeps once", fun() ->
+                ?assertEqual(ok, aws_lib:maybe_backoff(2, 0, 500)),
+                ?assertEqual(1, meck:num_calls(timer, sleep, '_'))
+            end}
+        ]
+    }.
+
+%% ----------------------------------------------------------------------------
+%% Backoff is applied between attempts only (issue #81 review)
+%% ----------------------------------------------------------------------------
+backoff_between_attempts_only_test_() ->
+    {
+        foreach,
+        fun() ->
+            setup(),
+            meck:new(gun, []),
+            meck:new(aws_lib_config, []),
+            meck:expect(aws_lib_config, endpoint_url, fun(_) -> undefined end),
+            meck:new(timer, [passthrough, unstick]),
+            meck:expect(timer, sleep, fun(_) -> ok end),
+            [gun, aws_lib_config, timer]
+        end,
+        fun(Mods) ->
+            teardown(ok),
+            meck:unload(Mods)
+        end,
+        [
+            {"exhausting retries sleeps once fewer than it attempts", fun() ->
+                State0 = set_test_credentials("ExpiredKey", "ExpiredAccessKey", undefined, {
+                    {3016, 4, 1}, {12, 0, 0}
+                }),
+                {ok, State} = aws_lib:set_region("us-east-1", State0),
+                meck:expect(gun, open, fun(_, _, _) -> {ok, pid} end),
+                meck:expect(gun, close, fun(_) -> ok end),
+                meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
+                meck:expect(gun, get, fun(_Pid, _Path, _Headers) -> nofin end),
+                %% Every attempt fails with a retriable 500, so the whole retry
+                %% budget is consumed.
+                meck:expect(gun, await, fun(_Pid, _, _) ->
+                    {response, nofin, 500, [{<<"content-type">>, <<"application/json">>}]}
+                end),
+                meck:expect(gun, await_body, fun(_Pid, _, _) ->
+                    {ok, <<"{\"Error\": {\"Code\": \"InternalError\"}}">>}
+                end),
+
+                {error, {service_error, _}, _} = aws_lib:api_get_request("AWS", "API", State),
+                %% The sleep after the final attempt would delay the returned
+                %% error by a full backoff interval (up to ?BACKOFF_CAP_MILLIS)
+                %% without buying another attempt, so there must be exactly one
+                %% fewer sleep than attempt.
+                Attempts = meck:num_calls(gun, await, '_'),
+                ?assertEqual(?MAX_RETRIES, Attempts),
+                ?assertEqual(Attempts - 1, meck:num_calls(timer, sleep, '_'))
+            end},
+            {"a request that succeeds on the first attempt never sleeps", fun() ->
+                State0 = set_test_credentials("ExpiredKey", "ExpiredAccessKey", undefined, {
+                    {3016, 4, 1}, {12, 0, 0}
+                }),
+                {ok, State} = aws_lib:set_region("us-east-1", State0),
+                meck:expect(gun, open, fun(_, _, _) -> {ok, pid} end),
+                meck:expect(gun, close, fun(_) -> ok end),
+                meck:expect(gun, await_up, fun(_, _) -> {ok, protocol} end),
+                meck:expect(gun, get, fun(_Pid, _Path, _Headers) -> nofin end),
+                meck:expect(gun, await, fun(_Pid, _, _) ->
+                    {response, nofin, 200, [{<<"content-type">>, <<"application/json">>}]}
+                end),
+                meck:expect(gun, await_body, fun(_Pid, _, _) -> {ok, <<"{\"pass\": true}">>} end),
+
+                {ok, _, _} = aws_lib:api_get_request("AWS", "API", State),
+                ?assertEqual(0, meck:num_calls(timer, sleep, '_'))
+            end}
+        ]
+    }.

--- a/test/aws_lib_tests.erl
+++ b/test/aws_lib_tests.erl
@@ -542,7 +542,16 @@ api_get_request_test_() ->
             %% endpoint_url/1, so it must be expected. No override: target the
             %% default AWS endpoint.
             meck:expect(aws_lib_config, endpoint_url, fun(_) -> undefined end),
-            [gun, aws_lib_config]
+            %% Stub the inter-attempt backoff sleep. These cases exercise retry
+            %% BEHAVIOUR (error surfacing, retry re-entry), not delay timing --
+            %% the delay arithmetic is covered by backoff_delay/3's own tests.
+            %% With exponential backoff a full 5-retry exhaustion would sleep up
+            %% to ~15s of real time, past eunit's 5s per-test default, so these
+            %% cases would time out. Skipping the real sleep keeps them fast
+            %% without changing what they assert.
+            meck:new(timer, [passthrough, unstick]),
+            meck:expect(timer, sleep, fun(_) -> ok end),
+            [gun, aws_lib_config, timer]
         end,
         fun(Mods) ->
             teardown(ok),
@@ -851,7 +860,13 @@ connection_reuse_across_retries_test_() ->
             %% endpoint_url/1, so it must be expected. No override: target the
             %% default AWS endpoint.
             meck:expect(aws_lib_config, endpoint_url, fun(_) -> undefined end),
-            [gun, aws_lib_config]
+            %% Stub the inter-attempt backoff sleep so exhausting retries does
+            %% not sleep ~15s of real time and trip eunit's 5s per-test default.
+            %% These cases count gun:open calls across retries; the delay itself
+            %% is irrelevant here and is covered by backoff_delay/3's own tests.
+            meck:new(timer, [passthrough, unstick]),
+            meck:expect(timer, sleep, fun(_) -> ok end),
+            [gun, aws_lib_config, timer]
         end,
         fun(Mods) ->
             teardown(ok),


### PR DESCRIPTION
Fixes #81.

## Change

Replaces the fixed 500ms `?LINEAR_BACK_OFF_MILLIS` delay with **equal-jitter**
exponential backoff:

```erlang
backoff_delay(Attempt, Base, Cap) ->
    Temp = min(Cap, Base * (1 bsl Attempt)),
    HalfTemp = max(1, Temp div 2),
    HalfTemp + rand:uniform(HalfTemp).
```

`?LINEAR_BACK_OFF_MILLIS` becomes `?BACKOFF_BASE_MILLIS` (500) and
`?BACKOFF_CAP_MILLIS` (10000). An explicit `Attempt` counter is threaded through
the retry loop, since the loop counts retries *down* and the exponent needs the
ordinal.

**Equal-jitter over erlcloud's full-jitter**: full jitter can produce a ~1ms sleep,
which defeats the purpose of backing off. Equal jitter guarantees a `Temp/2` floor
while still spreading concurrent retriers. `1 bsl Attempt` rather than
`math:pow/2` avoids float conversion and a `badarith` at large exponents (raised
in review). `max(1, ...)` keeps `rand:uniform/1` from ever seeing 0.

Issue #80's non-retriable short-circuit is untouched -- only `retriable` verdicts
reach the delay.

## Verification

A second commit stubs `timer:sleep` in the two retry-behaviour eunit
generators (the passthrough+unstick meck pattern the suite already uses for
`calendar`). Exponential backoff makes a full 5-retry exhaustion sleep for
several seconds, which tripped eunit's 5s per-test default under `make tests`
and surfaced as *timed out*. Those cases assert retry behaviour, not delay
timing, so the no-op sleep changes nothing they check; the delay arithmetic is
covered by `backoff_delay/3`'s own tests.

eunit **821 passed, 0 failed** (baseline `main` is 805). 16 new tests: 12 for
`backoff_delay/3` covering ranges, boundaries, jitter, monotonicity, and
`Cap < Base`, plus 4 for `maybe_backoff/3` and the sleep-count invariant.

Observed growth, then jitter across repeated calls with identical arguments:

```
Attempt 0: 424ms   Attempt 3: 3654ms
Attempt 1: 765ms   Attempt 4: 4667ms
Attempt 2: 1937ms  Attempt 6: 8973ms   (capped)

same args, 5 calls: 1905, 1531, 1427, 1918, 1183 ms
```

Driven through the **real retry path** against a local endpoint returning 500:

```
5 attempts, 4 sleeps: 257ms -> 767ms -> 1722ms -> 3773ms   (6519ms total)
```

Three full runs differ (6519ms / 6456ms / 5694ms total), confirming the jitter
is live rather than a fixed schedule. Every run performs exactly one fewer sleep
than attempt: the delay after the final attempt is skipped, since it would push
back the returned error without buying another attempt. Boundary cases
`backoff_delay(0,0,0)`, `(0,1,1)` and `Cap < Base` all return sane positive
values without crashing.

## Latency tradeoff for reviewers

Worst case cumulative delay rises from **2.5s** (5 x 500ms on `main`) to
**7.5s** (500+1000+2000+4000 max, expected ~5.6s). Only the gaps *between*
attempts sleep now, so 5 attempts incur 4 delays rather than 5; keeping the old
fixed delay under that rule would have cost 2.0s. This sits on the broker-boot
ARN resolution path, so it is a real change in worst-case boot time and deserves
an explicit decision. The cap bounds it; lower `?BACKOFF_CAP_MILLIS` if 7.5s is
too long for boot.

## Merge order

Please merge this **before** #85 (retry decoupling). Both touch
`api_request_with_retries`, and #85 adds a `wait_time_ms` seam that this policy
plugs into -- landing the policy first and then extracting around it is the
cleaner direction. `?BACKOFF_CAP_MILLIS` is intentionally applied at the call site
here rather than threaded as a parameter, since making retry options
caller-configurable is #85's scope.

