### PR TITLE
`aws_lib`: Decouple retry logic from the request functions

### DIFF
--- a/src/aws_lib.erl
+++ b/src/aws_lib.erl
@@ -649,8 +649,13 @@ instance_volumes(State0 = #aws_state{config = Config0}) ->
     State :: aws_state()
 ) ->
     {ok, list(), aws_state()} | {error, term(), aws_state()}.
-%% @doc Invoke an API call to an AWS service with retries and exponential
-%% backoff with jitter between attempts.
+%% @doc Invoke an API call to an AWS service with retries, delegating the retry
+%% loop to aws_lib_retry:with_retries/3 (issue #85). The attempt closure threads
+%% {State, Conn, LastError} as context; a credential failure short-circuits via
+%% {stop, ...}; perform_request_reuse/8 drives the HTTP attempt; and
+%% classify_response's verdict decides retriability. The inter-attempt delay is
+%% supplied as a wait_time_ms fun computing exponential backoff with jitter
+%% (issue #81); with_retries skips the sleep before the final attempt.
 %% @end
 api_request_with_retries(Service, Method, Path, Body, Headers, Retries, BackoffBase, State) ->
     %% Open a single connection and reuse it across the whole retry sequence
@@ -659,124 +664,115 @@ api_request_with_retries(Service, Method, Path, Body, Headers, Retries, BackoffB
     %% seed from it so the first attempt avoids a fresh handshake; otherwise
     %% start with `undefined' (nothing open yet, opened lazily on first attempt).
     Conn0 = seed_conn_from_state(State),
-    api_request_with_retries(
-        Service, Method, Path, Body, Headers, Retries, BackoffBase, State, Conn0, undefined, 0
-    ).
+    Ctx0 = {State, Conn0, undefined},
 
--spec api_request_with_retries(
-    Service :: string(),
-    Method :: method(),
-    Path :: path(),
-    Body :: body(),
-    Headers :: headers(),
-    Retries :: integer(),
-    BackoffBase :: integer(),
-    State :: aws_state(),
-    Conn :: aws_lib_httpc:conn() | undefined,
-    LastError :: result_error() | undefined,
-    Attempt :: non_neg_integer()
-) ->
-    {ok, list(), aws_state()} | {error, term(), aws_state()}.
-api_request_with_retries(
-    _Service,
-    _Method,
-    _Path,
-    _Body,
-    _Headers,
-    Retries,
-    _BackoffBase,
-    State,
-    Conn,
-    LastError,
-    _Attempt
-) when
-    Retries =< 0
-->
-    ?LOG_ERROR("Request to AWS service has failed after ~b retries", [?MAX_RETRIES]),
-    %% Reconcile the carried connection into the returned state: in reuse mode a
-    %% still-live connection is handed back, a transport-dropped one (undefined)
-    %% clears the slot; in one-shot mode it is closed.
-    State1 = finish_conn(Conn, State),
-    %% Surface the last attempt's decoded AWS error so the caller can act on the
-    %% service error code (throttling vs invalid parameter vs access denied)
-    %% rather than a generic string (issue #82).
-    {error, exhausted_error(LastError), State1};
-api_request_with_retries(
-    Service, Method, Path, Body, Headers, Retries, BackoffBase, State0, Conn0, LastError, Attempt
-) ->
-    case ensure_credentials_valid(State0) of
-        {ok, State1} ->
-            {Result, Conn1, Verdict} =
-                perform_request_reuse(Service, Method, Headers, Path, Body, [], State1, Conn0),
-            case Result of
-                {ok, {_Headers, Payload}, State2} ->
-                    ?LOG_DEBUG("AWS request: ~ts~nResponse: ~tp", [Path, Payload]),
-                    State3 = finish_conn(Conn1, State2),
-                    {ok, Payload, State3};
-                {error, Message, Response} = Error ->
-                    %% Message may be a status string (from format_response/1
-                    %% on an HTTP error) or a tuple such as
-                    %% {gun_open_failed, Reason} on a connection failure, so
-                    %% use ~tp rather than ~ts.
-                    ?LOG_WARNING("Error occurred: ~tp", [Message]),
-                    case Response of
-                        {_, Payload} ->
-                            ?LOG_WARNING("Failed AWS request: ~ts~nResponse: ~tp", [
-                                Path, Payload
-                            ]);
-                        _ ->
-                            ok
-                    end,
-                    case Verdict of
-                        not_retriable ->
-                            %% A 4xx client error that will not succeed on retry
-                            %% (issue #80): return the decoded error to the caller
-                            %% immediately rather than burning the remaining
-                            %% retries. The exchange completed cleanly, so in
-                            %% reuse mode the connection is handed back for the
-                            %% next request; in one-shot mode finish_conn/2 closes
-                            %% it.
-                            %% Log at ERROR level so log-level alerting still sees
-                            %% a permanent failure: before issue #80 short-circuited
-                            %% the retry loop, this failure would have exhausted the
-                            %% retries and reached the ?LOG_ERROR clause above.
-                            ?LOG_ERROR(
-                                "Request to AWS service has failed with a permanent error: ~tp",
-                                [Message]
-                            ),
-                            State3 = finish_conn(Conn1, State1),
-                            {error, exhausted_error(Error), State3};
-                        retriable ->
-                            ?LOG_WARNING(
-                                "Will retry AWS request, remaining retries: ~b", [Retries]
-                            ),
-                            maybe_backoff(Retries, Attempt, BackoffBase),
-                            %% perform_request_reuse/8 hands back a live connection
-                            %% after an HTTP-level error (reused on the next
-                            %% attempt) or `undefined' after a transport failure
-                            %% (reopened next attempt). Carry the most informative
-                            %% error forward so retry exhaustion can return it: a
-                            %% decoded service-error body from an earlier attempt
-                            %% is kept even if a later attempt fails at the
-                            %% transport level with no body.
-                            api_request_with_retries(
-                                Service,
-                                Method,
-                                Path,
-                                Body,
-                                Headers,
-                                Retries - 1,
-                                BackoffBase,
-                                State1,
-                                Conn1,
-                                keep_informative_error(LastError, Error),
-                                Attempt + 1
-                            )
-                    end
-            end;
-        {error, Reason} ->
-            State1 = finish_conn(Conn0, State0),
-            {error, {credentials, Reason}, State1}
+    AttemptFun = fun({State0, ConnIn, PrevError}) ->
+        case ensure_credentials_valid(State0) of
+            {ok, State1} ->
+                {Result, Conn1, Verdict} =
+                    perform_request_reuse(Service, Method, Headers, Path, Body, [], State1, ConnIn),
+                case Result of
+                    {ok, {_RespHeaders, Payload}, State2} ->
+                        ?LOG_DEBUG("AWS request: ~ts~nResponse: ~tp", [Path, Payload]),
+                        State3 = finish_conn(Conn1, State2),
+                        %% finish_conn/2 has reconciled the connection into
+                        %% State3; drop it from the carried context so the outer
+                        %% success clause does not reconcile (and close) it a
+                        %% second time.
+                        {ok, Payload, {State3, undefined, PrevError}};
+                    {error, Message, Response} = Error ->
+                        %% Message may be a status string (from format_response/1
+                        %% on an HTTP error) or a tuple such as
+                        %% {gun_open_failed, Reason} on a connection failure, so
+                        %% use ~tp rather than ~ts.
+                        ?LOG_WARNING("Error occurred: ~tp", [Message]),
+                        case Response of
+                            {_, Payload} ->
+                                ?LOG_WARNING("Failed AWS request: ~ts~nResponse: ~tp", [
+                                    Path, Payload
+                                ]);
+                            _ ->
+                                ok
+                        end,
+                        case Verdict of
+                            not_retriable ->
+                                %% A 4xx client error that will not succeed on
+                                %% retry (issue #80): short-circuit rather than
+                                %% burning the remaining retries. Leave conn
+                                %% reconciliation to the outer {error, ...} clause
+                                %% so reuse mode hands the connection back and
+                                %% one-shot mode closes it (one finish_conn call
+                                %% on every exit path).
+                                %% Log at ERROR level so log-level alerting still
+                                %% sees a permanent failure.
+                                ?LOG_ERROR(
+                                    "Request to AWS service has failed with a permanent error: ~tp",
+                                    [Message]
+                                ),
+                                {stop, exhausted_error(Error), {State1, Conn1, PrevError}};
+                            retriable ->
+                                %% perform_request_reuse/8 hands back a live
+                                %% connection after an HTTP-level error (reused on
+                                %% the next attempt) or `undefined' after a
+                                %% transport failure (reopened next attempt).
+                                %% Carry the most informative error forward so
+                                %% retry exhaustion can return it: a decoded
+                                %% service-error body from an earlier attempt is
+                                %% kept even if a later attempt fails at the
+                                %% transport level with no body.
+                                NewLastError = keep_informative_error(PrevError, Error),
+                                {retry, Error, {State1, Conn1, NewLastError}}
+                        end
+                end;
+            {error, Reason} ->
+                State1 = finish_conn(ConnIn, State0),
+                {stop, {credentials, Reason}, {State1, ConnIn, PrevError}}
+        end
+    end,
+
+    OnRetry = fun(AttemptNumber, _Error, _Ctx) ->
+        %% AttemptNumber is 1-based; after N attempts, Retries - N remain.
+        Remaining = Retries - AttemptNumber,
+        ?LOG_WARNING("Will retry AWS request, remaining retries: ~b", [Remaining]),
+        ok
+    end,
+
+    OnExhausted = fun(_TotalAttempts, _LastAttemptError, {_St, _Co, LastErr}) ->
+        ?LOG_ERROR("Request to AWS service has failed after ~b retries", [?MAX_RETRIES]),
+        %% Surface the last attempt's decoded AWS error so the caller can act on
+        %% the service error code (throttling vs invalid parameter vs access
+        %% denied) rather than a generic string (issue #82).
+        exhausted_error(LastErr)
+    end,
+
+    %% Exponential backoff with jitter (issue #81), supplied as a fun so the
+    %% retry loop stays policy-agnostic. AttemptNumber is 1-based; the first
+    %% retry's delay uses exponent 0, matching the pre-extraction attempt
+    %% counter that started at 0.
+    WaitTimeMs = fun(AttemptNumber, _Ctx) ->
+        backoff_delay(AttemptNumber - 1, BackoffBase, ?BACKOFF_CAP_MILLIS)
+    end,
+
+    Opts = #{
+        max_retries => Retries,
+        wait_time_ms => WaitTimeMs,
+        on_retry => OnRetry,
+        on_exhausted => OnExhausted
+    },
+
+    case aws_lib_retry:with_retries(AttemptFun, Opts, Ctx0) of
+        {ok, Payload, {FinalState, _FinalConn, _}} ->
+            {ok, Payload, FinalState};
+        {error, {credentials, Reason}, {FinalState, _FinalConn, _}} ->
+            %% The attempt closure already reconciled the connection on the
+            %% credential-failure path.
+            {error, {credentials, Reason}, FinalState};
+        {error, ErrorTerm, {FinalState, FinalConn, _}} ->
+            %% On a not_retriable stop or retry exhaustion the connection is
+            %% still carried in the context; reconcile it into the returned
+            %% state here (reuse mode hands it back, one-shot mode closes it).
+            State1 = finish_conn(FinalConn, FinalState),
+            {error, ErrorTerm, State1}
     end.
 
 %% Keep the more informative of two retry errors: an error carrying a decoded
@@ -806,19 +802,10 @@ exhausted_error({error, _Message, {_Headers, DecodedBody}}) ->
 exhausted_error(_) ->
     {service_error, retries_exhausted}.
 
--spec maybe_backoff(
-    Retries :: integer(), Attempt :: non_neg_integer(), Base :: non_neg_integer()
-) -> ok.
-%% Sleep between attempts, but only when another attempt will actually follow.
-%% The caller decrements Retries after this call, so Retries =< 1 means the next
-%% recursion hits the exhaustion clause: sleeping there would delay the returned
-%% error by a full backoff interval (up to ?BACKOFF_CAP_MILLIS) without buying
-%% another attempt. This matters on the broker-boot ARN resolution path, where it
-%% halves the worst-case delay for an unreachable service.
-maybe_backoff(Retries, _Attempt, _Base) when Retries =< 1 ->
-    ok;
-maybe_backoff(_Retries, Attempt, Base) ->
-    timer:sleep(backoff_delay(Attempt, Base, ?BACKOFF_CAP_MILLIS)).
+%% Note: the "skip the sleep before the final attempt" logic (issue #81 review)
+%% now lives in aws_lib_retry:with_retries/3, which owns the inter-attempt sleep
+%% after the loop was extracted (issue #85). backoff_delay/3 below stays here as
+%% the policy the wait_time_ms fun computes.
 
 -spec backoff_delay(
     Attempt :: non_neg_integer(), Base :: non_neg_integer(), Cap :: non_neg_integer()
@@ -903,8 +890,9 @@ perform_request_reuse(Service, Method, Headers, Path, Body, Options, State0, Con
         {error, _} = Error ->
             %% Shape the 2-tuple error through format_response/1 into the
             %% 3-tuple result the retry loop matches on; returning the raw
-            %% {error, Reason} here would raise a case_clause in
-            %% api_request_with_retries/11.
+            %% {error, Reason} here would raise a case_clause in the attempt
+            %% closure api_request_with_retries/8 passes to
+            %% aws_lib_retry:with_retries/3.
             {aws_lib_response:format_response(Error), ConnSlot0, retriable}
     end.
 

--- a/src/aws_lib_retry.erl
+++ b/src/aws_lib_retry.erl
@@ -1,0 +1,120 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+%% Standalone retry primitive extracted from aws_lib (issue #85). The loop owns
+%% attempt sequencing, the inter-attempt sleep, exhaustion, and short-circuit;
+%% the caller supplies the attempt closure and threading context.
+%%
+%% wait_time_ms is either a fixed non_neg_integer() or a
+%% fun(AttemptNumber, Ctx) -> non_neg_integer(), so a caller can plug in a
+%% backoff strategy (aws_lib passes exponential-backoff-with-jitter, issue #81)
+%% without this module knowing the policy. The sleep is skipped before the final
+%% attempt's exhaustion so an exhausted request does not pay a trailing backoff
+%% interval that buys no further attempt (issue #81 review).
+-module(aws_lib_retry).
+
+%% The include registers this module in the erlang.mk dependency graph
+%% (aws.d) so it is compiled alongside the other aws_lib_* modules.
+-include("aws_lib.hrl").
+
+-export([with_retries/3]).
+
+-export_type([retry_ctx/0, attempt_result/0, attempt_fun/0, retry_opts/0, wait_time_ms/0]).
+
+-type retry_ctx() :: term().
+
+-type attempt_result() ::
+    {ok, term(), retry_ctx()}
+    | {retry, term(), retry_ctx()}
+    | {stop, term(), retry_ctx()}.
+
+-type attempt_fun() :: fun((retry_ctx()) -> attempt_result()).
+
+-type wait_time_ms() ::
+    non_neg_integer() | fun((non_neg_integer(), retry_ctx()) -> non_neg_integer()).
+
+-type retry_opts() :: #{
+    max_retries := non_neg_integer(),
+    wait_time_ms := wait_time_ms(),
+    on_retry => fun((non_neg_integer(), term(), retry_ctx()) -> ok),
+    on_exhausted => fun((non_neg_integer(), term(), retry_ctx()) -> term())
+}.
+
+-spec with_retries(attempt_fun(), retry_opts(), retry_ctx()) ->
+    {ok, term(), retry_ctx()} | {error, term(), retry_ctx()}.
+%% @doc Execute AttemptFun in a retry loop, threading Ctx across attempts.
+%%
+%% max_retries is the total number of attempts allowed (including the first).
+%% With max_retries=5 the function is called up to 5 times. With max_retries=0
+%% no attempt is made and the loop returns immediately with an error.
+%%
+%% AttemptFun receives the current context and returns one of:
+%%   {ok, Result, Ctx1}    -- success; loop stops and returns {ok, Result, Ctx1}
+%%   {retry, Error, Ctx1}  -- retriable failure; sleep and try again
+%%   {stop, Error, Ctx1}   -- non-retriable failure; loop stops immediately
+%%
+%% On exhaustion (max_retries attempts consumed), the on_exhausted callback
+%% (if provided) transforms the last error into the final error term; otherwise
+%% the last error is returned as-is.
+%%
+%% The on_retry callback (if provided) is invoked after each retriable failure
+%% (before sleeping) with (AttemptNumber, Error, Ctx) for logging or metrics.
+%% @end
+with_retries(AttemptFun, Opts, Ctx) ->
+    MaxRetries = maps:get(max_retries, Opts),
+    loop(AttemptFun, Opts, Ctx, MaxRetries, undefined).
+
+-spec loop(attempt_fun(), retry_opts(), retry_ctx(), non_neg_integer(), term()) ->
+    {ok, term(), retry_ctx()} | {error, term(), retry_ctx()}.
+%% Base case: no attempts remaining. The on_exhausted callback (if provided)
+%% transforms the last error into the final error term.
+loop(_AttemptFun, Opts, Ctx, 0, LastError) ->
+    FinalError =
+        case maps:find(on_exhausted, Opts) of
+            {ok, OnExhausted} ->
+                MaxRetries = maps:get(max_retries, Opts),
+                OnExhausted(MaxRetries, LastError, Ctx);
+            error ->
+                LastError
+        end,
+    {error, FinalError, Ctx};
+loop(AttemptFun, Opts, Ctx, AttemptsLeft, _LastError) ->
+    case AttemptFun(Ctx) of
+        {ok, Result, Ctx1} ->
+            {ok, Result, Ctx1};
+        {stop, Error, Ctx1} ->
+            {error, Error, Ctx1};
+        {retry, Error, Ctx1} ->
+            %% Invoke the on_retry callback (for logging/metrics) then sleep.
+            MaxRetries = maps:get(max_retries, Opts),
+            AttemptNumber = MaxRetries - AttemptsLeft + 1,
+            case maps:find(on_retry, Opts) of
+                {ok, OnRetry} ->
+                    OnRetry(AttemptNumber, Error, Ctx1);
+                error ->
+                    ok
+            end,
+            %% Sleep only when another attempt will follow. AttemptsLeft =< 1
+            %% means the next recursion hits the exhaustion clause, so sleeping
+            %% here would delay the returned error by a full backoff interval
+            %% without buying another attempt (issue #81 review). This matters
+            %% on the broker-boot ARN resolution path, where it halves the
+            %% worst-case delay for an unreachable service.
+            case AttemptsLeft =< 1 of
+                true ->
+                    ok;
+                false ->
+                    WaitTimeMs = compute_wait(
+                        maps:get(wait_time_ms, Opts), AttemptNumber, Ctx1
+                    ),
+                    timer:sleep(WaitTimeMs)
+            end,
+            loop(AttemptFun, Opts, Ctx1, AttemptsLeft - 1, Error)
+    end.
+
+%% Resolve the configured wait to a concrete millisecond value: a fixed integer
+%% passes through; a fun is called with the attempt ordinal and context so a
+%% caller can compute an attempt-dependent backoff (issue #81).
+-spec compute_wait(wait_time_ms(), non_neg_integer(), retry_ctx()) -> non_neg_integer().
+compute_wait(Ms, _AttemptNumber, _Ctx) when is_integer(Ms) -> Ms;
+compute_wait(Fun, AttemptNumber, Ctx) when is_function(Fun, 2) -> Fun(AttemptNumber, Ctx).

--- a/test/aws_lib_retry_tests.erl
+++ b/test/aws_lib_retry_tests.erl
@@ -1,0 +1,272 @@
+-module(aws_lib_retry_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% ============================================================================
+%% with_retries/3 tests
+%%
+%% max_retries is the total number of attempts allowed (including the first).
+%% With max_retries=5 the closure runs up to 5 times. With max_retries=0 the
+%% loop returns immediately without calling AttemptFun.
+%% ============================================================================
+
+success_on_first_attempt_test() ->
+    AttemptFun = fun(Ctx) -> {ok, result_value, Ctx} end,
+    Opts = #{max_retries => 3, wait_time_ms => 0},
+    ?assertEqual(
+        {ok, result_value, initial_ctx},
+        aws_lib_retry:with_retries(AttemptFun, Opts, initial_ctx)
+    ).
+
+success_after_retries_test() ->
+    %% Use a process dictionary counter to track attempts
+    erlang:put(attempt_count, 0),
+    AttemptFun = fun(Ctx) ->
+        Count = erlang:get(attempt_count),
+        erlang:put(attempt_count, Count + 1),
+        case Count of
+            N when N < 2 ->
+                {retry, {error, transient}, Ctx};
+            _ ->
+                {ok, success, Ctx}
+        end
+    end,
+    Opts = #{max_retries => 5, wait_time_ms => 0},
+    ?assertEqual(
+        {ok, success, my_ctx},
+        aws_lib_retry:with_retries(AttemptFun, Opts, my_ctx)
+    ),
+    %% 2 retries + 1 success = 3 total attempts
+    ?assertEqual(3, erlang:get(attempt_count)),
+    erlang:erase(attempt_count).
+
+exhaustion_test() ->
+    %% All attempts fail with retry -- should exhaust and return error.
+    %% max_retries=3 means 3 attempts total.
+    erlang:put(attempt_count, 0),
+    AttemptFun = fun(Ctx) ->
+        erlang:put(attempt_count, erlang:get(attempt_count) + 1),
+        {retry, {error, always_fails}, Ctx}
+    end,
+    Opts = #{max_retries => 3, wait_time_ms => 0},
+    ?assertEqual(
+        {error, {error, always_fails}, start_ctx},
+        aws_lib_retry:with_retries(AttemptFun, Opts, start_ctx)
+    ),
+    %% Exactly 3 attempts were made
+    ?assertEqual(3, erlang:get(attempt_count)),
+    erlang:erase(attempt_count).
+
+stop_short_circuits_test() ->
+    %% A stop result returns immediately without retrying
+    erlang:put(attempt_count, 0),
+    AttemptFun = fun(Ctx) ->
+        Count = erlang:get(attempt_count),
+        erlang:put(attempt_count, Count + 1),
+        {stop, {permanent_error, not_found}, Ctx}
+    end,
+    Opts = #{max_retries => 5, wait_time_ms => 0},
+    ?assertEqual(
+        {error, {permanent_error, not_found}, ctx},
+        aws_lib_retry:with_retries(AttemptFun, Opts, ctx)
+    ),
+    %% Only one attempt was made (no retries after stop)
+    ?assertEqual(1, erlang:get(attempt_count)),
+    erlang:erase(attempt_count).
+
+context_threading_test() ->
+    %% Each attempt receives the updated context from the previous attempt.
+    %% Starting at 0, each attempt increments the context. At ctx >= 3 it
+    %% succeeds; otherwise it retries.
+    AttemptFun = fun(Ctx) ->
+        NewCtx = Ctx + 1,
+        case NewCtx >= 3 of
+            true -> {ok, done, NewCtx};
+            false -> {retry, not_ready, NewCtx}
+        end
+    end,
+    Opts = #{max_retries => 5, wait_time_ms => 0},
+    ?assertEqual(
+        {ok, done, 3},
+        aws_lib_retry:with_retries(AttemptFun, Opts, 0)
+    ).
+
+on_retry_callback_test() ->
+    %% Verify the on_retry callback is invoked with correct arguments
+    Self = self(),
+    OnRetry = fun(AttemptNum, Error, Ctx) ->
+        Self ! {on_retry, AttemptNum, Error, Ctx},
+        ok
+    end,
+    erlang:put(attempt_count, 0),
+    AttemptFun = fun(Ctx) ->
+        Count = erlang:get(attempt_count),
+        erlang:put(attempt_count, Count + 1),
+        case Count of
+            2 -> {ok, done, Ctx};
+            N -> {retry, {fail, N}, Ctx}
+        end
+    end,
+    Opts = #{max_retries => 5, wait_time_ms => 0, on_retry => OnRetry},
+    ?assertEqual(
+        {ok, done, the_ctx},
+        aws_lib_retry:with_retries(AttemptFun, Opts, the_ctx)
+    ),
+    %% Two retriable failures -> two on_retry callbacks
+    ?assertEqual({on_retry, 1, {fail, 0}, the_ctx}, receive_msg()),
+    ?assertEqual({on_retry, 2, {fail, 1}, the_ctx}, receive_msg()),
+    erlang:erase(attempt_count).
+
+on_exhausted_callback_test() ->
+    %% Verify on_exhausted transforms the final error.
+    %% max_retries=2 means 2 attempts; on_exhausted receives the LAST error
+    %% from the final attempt (passed as LastError to the base case).
+    OnExhausted = fun(TotalAttempts, LastError, _Ctx) ->
+        {exhausted, TotalAttempts, LastError}
+    end,
+    erlang:put(attempt_count, 0),
+    AttemptFun = fun(Ctx) ->
+        N = erlang:get(attempt_count),
+        erlang:put(attempt_count, N + 1),
+        {retry, {timeout, N}, Ctx}
+    end,
+    Opts = #{max_retries => 2, wait_time_ms => 0, on_exhausted => OnExhausted},
+    Result = aws_lib_retry:with_retries(AttemptFun, Opts, my_ctx),
+    %% on_exhausted receives the last error from the final retry (attempt 2,
+    %% which is the error from the loop iteration that slept and then hit the
+    %% base case; i.e., the error logged by the last on_retry call).
+    ?assertEqual(
+        {error, {exhausted, 2, {timeout, 1}}, my_ctx},
+        Result
+    ),
+    erlang:erase(attempt_count).
+
+zero_retries_test() ->
+    %% With max_retries = 0, no attempt is made and the loop returns
+    %% immediately with on_exhausted(undefined) or undefined.
+    erlang:put(attempt_count, 0),
+    AttemptFun = fun(Ctx) ->
+        erlang:put(attempt_count, erlang:get(attempt_count) + 1),
+        {retry, failed, Ctx}
+    end,
+    Opts = #{max_retries => 0, wait_time_ms => 0},
+    ?assertEqual(
+        {error, undefined, ctx},
+        aws_lib_retry:with_retries(AttemptFun, Opts, ctx)
+    ),
+    %% No attempt was made
+    ?assertEqual(0, erlang:get(attempt_count)),
+    erlang:erase(attempt_count).
+
+context_preserved_on_stop_test() ->
+    %% The context returned by the stopping attempt is propagated
+    AttemptFun = fun(_Ctx) -> {stop, bad_request, updated_ctx} end,
+    Opts = #{max_retries => 5, wait_time_ms => 0},
+    ?assertEqual(
+        {error, bad_request, updated_ctx},
+        aws_lib_retry:with_retries(AttemptFun, Opts, original_ctx)
+    ).
+
+context_preserved_on_exhaustion_test() ->
+    %% The context from the LAST retry is carried into the base case.
+    %% max_retries=3: attempt(3) -> retry, ctx+1 -> sleep -> attempt(2) ->
+    %% retry, ctx+1 -> sleep -> attempt(1) -> retry, ctx+1 -> sleep ->
+    %% base(0) with ctx from last retry. 3 attempts, ctx goes 0->1->2->3.
+    AttemptFun = fun(Ctx) ->
+        {retry, err, Ctx + 1}
+    end,
+    Opts = #{max_retries => 3, wait_time_ms => 0},
+    ?assertEqual(
+        {error, err, 3},
+        aws_lib_retry:with_retries(AttemptFun, Opts, 0)
+    ).
+
+single_attempt_success_test() ->
+    %% max_retries=1 means exactly one attempt. If it succeeds, done.
+    AttemptFun = fun(Ctx) -> {ok, yep, Ctx} end,
+    Opts = #{max_retries => 1, wait_time_ms => 0},
+    ?assertEqual(
+        {ok, yep, ctx},
+        aws_lib_retry:with_retries(AttemptFun, Opts, ctx)
+    ).
+
+single_attempt_failure_test() ->
+    %% max_retries=1 means one attempt. If it retries, on_retry is called,
+    %% then the base case fires.
+    Self = self(),
+    OnRetry = fun(AttemptNum, Error, _Ctx) ->
+        Self ! {on_retry, AttemptNum, Error},
+        ok
+    end,
+    AttemptFun = fun(Ctx) -> {retry, oops, Ctx} end,
+    Opts = #{max_retries => 1, wait_time_ms => 0, on_retry => OnRetry},
+    ?assertEqual(
+        {error, oops, ctx},
+        aws_lib_retry:with_retries(AttemptFun, Opts, ctx)
+    ),
+    ?assertEqual({on_retry, 1, oops}, receive_msg()).
+
+wait_fun_test() ->
+    %% wait_time_ms can be a fun/2 for custom backoff strategies.
+    Self = self(),
+    WaitFun = fun(AttemptNumber, _Ctx) ->
+        Self ! {wait, AttemptNumber},
+        0
+    end,
+    erlang:put(attempt_count, 0),
+    AttemptFun = fun(Ctx) ->
+        N = erlang:get(attempt_count),
+        erlang:put(attempt_count, N + 1),
+        case N of
+            2 -> {ok, done, Ctx};
+            _ -> {retry, failed, Ctx}
+        end
+    end,
+    Opts = #{max_retries => 5, wait_time_ms => WaitFun},
+    ?assertEqual({ok, done, ctx}, aws_lib_retry:with_retries(AttemptFun, Opts, ctx)),
+    ?assertEqual({wait, 1}, receive_msg()),
+    ?assertEqual({wait, 2}, receive_msg()),
+    erlang:erase(attempt_count).
+
+no_wait_before_exhaustion_test() ->
+    %% The sleep is skipped before the final attempt's exhaustion: sleeping
+    %% there would delay the returned error by a full backoff interval without
+    %% buying another attempt (issue #81 review, now enforced by the loop).
+    %% With max_retries=3 and every attempt retriable, there are 3 attempts and
+    %% exactly 2 waits -- one fewer than the attempt count.
+    Self = self(),
+    WaitFun = fun(AttemptNumber, _Ctx) ->
+        Self ! {wait, AttemptNumber},
+        0
+    end,
+    AttemptFun = fun(Ctx) -> {retry, boom, Ctx} end,
+    Opts = #{max_retries => 3, wait_time_ms => WaitFun},
+    ?assertEqual({error, boom, ctx}, aws_lib_retry:with_retries(AttemptFun, Opts, ctx)),
+    ?assertEqual({wait, 1}, receive_msg()),
+    ?assertEqual({wait, 2}, receive_msg()),
+    %% No third wait: the third attempt is the last, so it does not sleep.
+    ?assertEqual(timeout, receive_msg()).
+
+single_retry_never_waits_test() ->
+    %% With max_retries=1 the only attempt is the final one, so a retriable
+    %% failure exhausts immediately with no wait at all.
+    Self = self(),
+    WaitFun = fun(AttemptNumber, _Ctx) ->
+        Self ! {wait, AttemptNumber},
+        0
+    end,
+    AttemptFun = fun(Ctx) -> {retry, boom, Ctx} end,
+    Opts = #{max_retries => 1, wait_time_ms => WaitFun},
+    ?assertEqual({error, boom, ctx}, aws_lib_retry:with_retries(AttemptFun, Opts, ctx)),
+    ?assertEqual(timeout, receive_msg()).
+
+%% ============================================================================
+%% Helpers
+%% ============================================================================
+
+receive_msg() ->
+    receive
+        Msg -> Msg
+    after 100 ->
+        timeout
+    end.

--- a/test/aws_lib_tests.erl
+++ b/test/aws_lib_tests.erl
@@ -1298,33 +1298,12 @@ backoff_delay_test_() ->
         end}
     ].
 
-%% ----------------------------------------------------------------------------
-%% maybe_backoff/3 -- no sleep before the exhaustion clause (issue #81 review)
-%% ----------------------------------------------------------------------------
-maybe_backoff_test_() ->
-    {
-        foreach,
-        fun() ->
-            meck:new(timer, [passthrough, unstick]),
-            meck:expect(timer, sleep, fun(_) -> ok end),
-            [timer]
-        end,
-        fun meck:unload/1,
-        [
-            {"the last attempt does not sleep", fun() ->
-                %% The caller decrements Retries after this call, so Retries =< 1
-                %% means the next recursion exhausts: sleeping would delay the
-                %% returned error without buying another attempt.
-                ?assertEqual(ok, aws_lib:maybe_backoff(1, 4, 500)),
-                ?assertEqual(ok, aws_lib:maybe_backoff(0, 4, 500)),
-                ?assertEqual(0, meck:num_calls(timer, sleep, '_'))
-            end},
-            {"an attempt with retries remaining sleeps once", fun() ->
-                ?assertEqual(ok, aws_lib:maybe_backoff(2, 0, 500)),
-                ?assertEqual(1, meck:num_calls(timer, sleep, '_'))
-            end}
-        ]
-    }.
+%% The "no sleep before the exhaustion clause" behaviour that maybe_backoff/3
+%% used to provide now lives in aws_lib_retry:with_retries/3 (the loop was
+%% extracted in issue #85). It is covered end-to-end by
+%% backoff_between_attempts_only_test_/0 below (one fewer sleep than attempts;
+%% first-attempt success never sleeps) and at the unit level by
+%% aws_lib_retry_tests.
 
 %% ----------------------------------------------------------------------------
 %% Backoff is applied between attempts only (issue #81 review)


### PR DESCRIPTION
Fixes #85.

Rebased onto current `main`, which now contains #81 (exponential backoff with
jitter) and #108 (dead two-step API removal). This branch reconciles the retry
extraction with both.

## Change

Extracts the retry loop into a standalone `aws_lib_retry:with_retries/3` and routes
`api_get_request`/`api_post_request` through it. Behaviour is preserved: same max
attempts, same delay policy, same short-circuit, same error on exhaustion, same
connection lifecycle, same log levels.

`with_retries/3` owns attempt sequencing, the inter-attempt sleep, exhaustion, and
short-circuit. `api_request_with_retries/8` supplies an attempt closure that threads
`{State, Conn, LastError}` as context:

- `ensure_credentials_valid/1` runs per attempt; a credential failure short-circuits
  via `{stop, ...}` without retrying.
- `perform_request_reuse/8` drives the HTTP attempt and carries the reused connection
  (#91/#107); `finish_conn/2` reconciles it on every exit path.
- `classify_response`'s verdict decides `{retry, ...}` vs `{stop, ...}` (#80).
- `keep_informative_error/2` preserves a decoded AWS error body across attempts (#82).

## Reconciliation with #81

- `wait_time_ms` accepts either a fixed integer or a `fun(AttemptNumber, Ctx) -> Ms`.
  `api_request_with_retries` passes
  `backoff_delay(AttemptNumber - 1, BackoffBase, ?BACKOFF_CAP_MILLIS)`, so the loop
  stays policy-agnostic and the first retry's exponent is 0 -- matching the
  pre-extraction attempt counter.
- #81's "skip the sleep before the final attempt" moves out of the (now removed)
  `maybe_backoff/3` and into `with_retries` (`AttemptsLeft =< 1 -> no sleep`). That
  is its natural home once the loop is extracted, and worst-case behaviour is
  unchanged: exactly one fewer sleep than attempts.

## Review fixes carried on the branch

- Return `undefined` rather than the live connection in the success context.
  `finish_conn/2` has already reconciled it, so handing it back risked a double close.
- Report remaining-retries correctly in the retry warning (was off by one).

## Verification

eunit **844 passed, 0 failed**, no timeouts.

- `aws_lib_retry_tests` covers the primitive directly (success, exhaustion, stop
  short-circuit, context threading, callbacks, the `wait_time_ms` fun seam), plus two
  new cases for the relocated skip-final-sleep behaviour:
  `no_wait_before_exhaustion` (3 attempts, 2 waits) and `single_retry_never_waits`.
- The `maybe_backoff/3` unit test is dropped with the function;
  `backoff_between_attempts_only_test_` still asserts the same behaviour end-to-end
  through the public path (one fewer sleep than attempts; a first-attempt success
  never sleeps).
- Behaviour-equivalence, connection reuse/close accounting, and the credentials
  short-circuit were exercised against a local listener through the real path.

## Deliberately out of scope

Making response *classification* pluggable (erlcloud's `retry_response_type`).
`aws_lib_response:classify_response/2` already owns that decision cleanly, and making
it injectable is a separate concern from decoupling the loop.