### PR TITLE
`aws_lib`: Support role_arn / source_profile chaining in config files

### DIFF
--- a/include/aws_lib.hrl
+++ b/include/aws_lib.hrl
@@ -56,6 +56,16 @@
 
 -define(BACKOFF_BASE_MILLIS, 500).
 -define(BACKOFF_CAP_MILLIS, 10000).
+
+% Maximum number of role_arn/source_profile hops allowed before we reject the
+% chain as too deep. Matches the AWS CLI default of 5.
+-define(MAX_CREDENTIAL_CHAIN_DEPTH, 5).
+
+% Regex for validating STS RoleSessionName: 2-64 characters from the set
+% [\w+=,.@-]. Used during credential chain resolution to reject invalid
+% session names BEFORE calling STS.
+-define(ROLE_SESSION_NAME_PATTERN, "^[\\w+=,.@\\-]{2,64}$").
+
 -define(MAX_RETRIES, 5).
 
 -define(AWS_CREDENTIALS_TABLE, aws_credentials).

--- a/src/aws_iam.erl
+++ b/src/aws_iam.erl
@@ -5,23 +5,61 @@
 
 -module(aws_iam).
 
--export([assume_role/2]).
+-export([assume_role/2, assume_role/3, parse_assume_role_response/2]).
 
 %% Export all for unit tests
 -ifdef(TEST).
 -compile(export_all).
 -endif.
 
+-include("aws_lib.hrl").
+
 -spec assume_role(string() | binary(), aws_lib:aws_state()) ->
     {ok, aws_lib:aws_state()} | {error, term()}.
+%% @doc Assume a role using the given RoleArn, setting the resulting credentials
+%% on the returned state. This is the legacy interface that sets credentials
+%% directly on the state. For credential chain resolution, use assume_role/3
+%% which returns the credentials without modifying state.
+%% @end
 assume_role(RoleArn, State) when is_binary(RoleArn) ->
     assume_role(binary_to_list(RoleArn), State);
 assume_role(RoleArn, State) ->
-    SessionName = "rabbitmq-aws-" ++ integer_to_list(erlang:system_time(second)),
-    Body =
-        "Action=AssumeRole&RoleArn=" ++ uri_string:quote(RoleArn) ++
-            "&RoleSessionName=" ++ uri_string:quote(SessionName) ++
-            "&Version=2011-06-15",
+    case assume_role(RoleArn, #{}, State) of
+        {ok, Creds} ->
+            {ok, State1} = aws_lib:set_credentials(
+                Creds#aws_credentials.access_key,
+                Creds#aws_credentials.secret_key,
+                Creds#aws_credentials.security_token,
+                State
+            ),
+            {ok, State1};
+        {error, _} = Error ->
+            Error
+    end.
+
+-spec assume_role(string() | binary(), map(), aws_lib:aws_state()) ->
+    {ok, aws_credentials()} | {error, term()}.
+%% @doc Assume a role and return the resulting credentials (with Expiration).
+%%
+%% Opts map keys (all optional):
+%%   - external_id :: string() -- ExternalId for the STS request
+%%   - role_session_name :: string() -- custom RoleSessionName (must be valid)
+%%
+%% This function is called by aws_lib_config during credential chain resolution.
+%% It is ONLY reachable from the boot-time config file path -- not from any
+%% validation request body (the auth-validation endpoint's allowed_fields/0
+%% allowlists do NOT include role_arn/source_profile).
+%% @end
+assume_role(RoleArn, Opts, State) when is_binary(RoleArn) ->
+    assume_role(binary_to_list(RoleArn), Opts, State);
+assume_role(RoleArn, Opts, State) ->
+    SessionName = maps:get(
+        role_session_name,
+        Opts,
+        "rabbitmq-aws-" ++ integer_to_list(erlang:system_time(second))
+    ),
+    ExternalId = maps:get(external_id, Opts, undefined),
+    Body = build_assume_role_body(RoleArn, SessionName, ExternalId),
 
     BaseHeaders = [
         {"content-type", "application/x-www-form-urlencoded"},
@@ -29,27 +67,67 @@ assume_role(RoleArn, State) ->
     ],
 
     Headers = aws_sts:add_custom_headers(BaseHeaders),
-    make_request(Body, Headers, State).
+    make_request_return_creds(Body, Headers, State).
 
--spec parse_assume_role_response(any(), aws_lib:aws_state()) ->
-    {ok, aws_lib:aws_state()}.
-parse_assume_role_response(Body, State) ->
+%% @doc Build the URL-encoded form body for the AssumeRole POST request.
+%% Includes ExternalId only when explicitly provided (never defaulted --
+%% ExternalId is treated as sensitive and must not be logged per R6).
+%% @end
+build_assume_role_body(RoleArn, SessionName, undefined) ->
+    "Action=AssumeRole&RoleArn=" ++ uri_string:quote(RoleArn) ++
+        "&RoleSessionName=" ++ uri_string:quote(SessionName) ++
+        "&Version=2011-06-15";
+build_assume_role_body(RoleArn, SessionName, ExternalId) ->
+    "Action=AssumeRole&RoleArn=" ++ uri_string:quote(RoleArn) ++
+        "&RoleSessionName=" ++ uri_string:quote(SessionName) ++
+        "&ExternalId=" ++ uri_string:quote(ExternalId) ++
+        "&Version=2011-06-15".
+
+-spec parse_assume_role_credentials(any()) -> {ok, aws_credentials()}.
+%% @doc Parse the AssumeRole XML response into an #aws_credentials{} record
+%% including the Expiration field. Called during credential chain resolution.
+%% @end
+parse_assume_role_credentials(Body) ->
     [{"AssumeRoleResponse", ResponseData}] = Body,
     {"AssumeRoleResult", ResultData} = lists:keyfind("AssumeRoleResult", 1, ResponseData),
     {"Credentials", CredentialsData} = lists:keyfind("Credentials", 1, ResultData),
     {"AccessKeyId", AccessKey} = lists:keyfind("AccessKeyId", 1, CredentialsData),
     {"SecretAccessKey", SecretKey} = lists:keyfind("SecretAccessKey", 1, CredentialsData),
     {"SessionToken", SessionToken} = lists:keyfind("SessionToken", 1, CredentialsData),
-    {ok, State1} = aws_lib:set_credentials(AccessKey, SecretKey, SessionToken, State),
-    {ok, State1}.
+    Expiration =
+        case lists:keyfind("Expiration", 1, CredentialsData) of
+            {"Expiration", ExpirationStr} ->
+                aws_lib_config:parse_iso8601_timestamp(ExpirationStr);
+            false ->
+                undefined
+        end,
+    Creds = #aws_credentials{
+        access_key = AccessKey,
+        secret_key = SecretKey,
+        security_token = SessionToken,
+        expiration = Expiration
+    },
+    {ok, Creds}.
 
-make_request(Body, Headers, State) ->
+make_request_return_creds(Body, Headers, State) ->
     case aws_lib:api_post_request("sts", "/", Body, Headers, State) of
-        {ok, ResponseBody, State1} ->
-            parse_assume_role_response(ResponseBody, State1);
+        {ok, ResponseBody, _State1} ->
+            parse_assume_role_credentials(ResponseBody);
         {error, Reason, _State1} ->
-            %% assume_role/2 runs before connection reuse is enabled (one-shot
-            %% mode), so there is no connection to hand back; collapse the error
-            %% to a 2-tuple and keep this module's public contract unchanged.
             {error, Reason}
     end.
+
+-spec parse_assume_role_response(any(), aws_lib:aws_state()) ->
+    {ok, aws_lib:aws_state()} | {error, term()}.
+%% @doc Legacy interface: parse an AssumeRole XML response and set the resulting
+%% credentials on the given state. Used by aws_arn_config for boot-time ARN
+%% resolution.
+%% @end
+parse_assume_role_response(Body, State) ->
+    {ok, Creds} = parse_assume_role_credentials(Body),
+    aws_lib:set_credentials(
+        Creds#aws_credentials.access_key,
+        Creds#aws_credentials.secret_key,
+        Creds#aws_credentials.security_token,
+        State
+    ).

--- a/src/aws_lib_config.erl
+++ b/src/aws_lib_config.erl
@@ -22,7 +22,8 @@
     load_imdsv2_token/0,
     instance_metadata_request_headers/1,
     region/1,
-    endpoint_url/1
+    endpoint_url/1,
+    parse_iso8601_timestamp/1
 ]).
 
 %% Export all for unit tests
@@ -573,29 +574,56 @@ lookup_credentials(_, AccessKey, SecretKey, SessionToken, Config) ->
 %% @doc Return the access key and secret access key if they are set in
 %%      for the specified profile in the config file, if it exists. If it does
 %%      not exist or the profile is not set or the values are not set in the
-%%      profile, look up the values in the shared credentials file
+%%      profile, look up the values in the shared credentials file.
+%%
+%%      When the config file profile has role_arn but no access_key, we must
+%%      check for role_arn before falling through to the credentials file --
+%%      a profile with role_arn + source_profile is a valid credential source
+%%      even without inline static keys.
 %% @end
 lookup_credentials_from_config(Profile, {error, _}, _, _, Config) ->
-    lookup_credentials_from_file(Profile, credentials_file_data(), Config);
-lookup_credentials_from_config(_, AccessKey, SecretKey, SessionToken, Config) ->
-    Creds =
-        case SessionToken of
-            {error, _} ->
-                #aws_credentials{
-                    access_key = AccessKey,
-                    secret_key = SecretKey,
-                    security_token = undefined,
-                    expiration = undefined
-                };
-            SessionToken ->
-                #aws_credentials{
-                    access_key = AccessKey,
-                    secret_key = SecretKey,
-                    security_token = SessionToken,
-                    expiration = undefined
-                }
-        end,
-    {ok, Creds, Config}.
+    %% No access_key in config file profile -- check if there is a role_arn
+    %% before falling through to the credentials file.
+    case value(Profile, role_arn) of
+        {error, _} ->
+            lookup_credentials_from_file(Profile, credentials_file_data(), Config);
+        _RoleArn ->
+            %% Profile has role_arn in config file: resolve via chain.
+            %% Re-fetch the full section data for chain resolution.
+            SectionData = config_section_data(Profile),
+            lookup_credentials_from_section(SectionData, Config)
+    end;
+lookup_credentials_from_config(Profile, AccessKey, SecretKey, SessionToken, Config) ->
+    %% Access key is present in config file. However, if role_arn is ALSO present,
+    %% the static keys are source credentials for AssumeRole -- route through
+    %% chain resolution rather than returning static creds directly.
+    case value(Profile, role_arn) of
+        {error, _} ->
+            %% No role_arn: return static credentials as-is.
+            Creds =
+                case SessionToken of
+                    {error, _} ->
+                        #aws_credentials{
+                            access_key = AccessKey,
+                            secret_key = SecretKey,
+                            security_token = undefined,
+                            expiration = undefined
+                        };
+                    SessionToken ->
+                        #aws_credentials{
+                            access_key = AccessKey,
+                            secret_key = SecretKey,
+                            security_token = SessionToken,
+                            expiration = undefined
+                        }
+                end,
+            {ok, Creds, Config};
+        _RoleArn ->
+            %% Profile has both access_key and role_arn. The static keys are the
+            %% source credentials for AssumeRole. Route to chain resolution.
+            SectionData = config_section_data(Profile),
+            lookup_credentials_from_section(SectionData, Config)
+    end.
 
 -spec lookup_credentials_from_file(
     Profile :: string(),
@@ -623,14 +651,31 @@ lookup_credentials_from_file(Profile, Credentials, Config) ->
 %%      for the specified profile from the shared credentials file. If the
 %%      profile is not set or the values are not set in the profile, attempt to
 %%      lookup the values from the EC2 instance metadata service.
+%%
+%%      When the section contains a `role_arn' key, credential chain resolution
+%%      is triggered: source credentials are resolved (from source_profile or
+%%      the section's own static keys), then STS AssumeRole is called. This
+%%      path is ONLY reachable from the boot-time config load -- never from a
+%%      validation request body.
 %% @end
 lookup_credentials_from_section(undefined, Config) ->
     lookup_credentials_from_instance_metadata(Config);
 lookup_credentials_from_section(Credentials, Config) ->
-    AccessKey = proplists:get_value(aws_access_key_id, Credentials, undefined),
-    SecretKey = proplists:get_value(aws_secret_access_key, Credentials, undefined),
-    SessionToken = proplists:get_value(aws_session_token, Credentials, undefined),
-    lookup_credentials_from_proplist(AccessKey, SecretKey, SessionToken, Config).
+    case proplists:get_value(role_arn, Credentials, undefined) of
+        undefined ->
+            %% No role_arn -- resolve static credentials as before.
+            AccessKey = proplists:get_value(aws_access_key_id, Credentials, undefined),
+            SecretKey = proplists:get_value(aws_secret_access_key, Credentials, undefined),
+            SessionToken = proplists:get_value(aws_session_token, Credentials, undefined),
+            lookup_credentials_from_proplist(AccessKey, SecretKey, SessionToken, Config);
+        RoleArn ->
+            %% role_arn present -- enter credential chain resolution.
+            %% The profile name is not directly available here since this
+            %% function receives the section proplist, but we use "unknown" as
+            %% a placeholder for the top-level entry. The chain tracks
+            %% visited profiles from the source_profile resolution path.
+            resolve_role_arn_credentials(RoleArn, Credentials, Config, [])
+    end.
 
 -spec lookup_credentials_from_proplist(
     AccessKey :: access_key(),
@@ -654,6 +699,344 @@ lookup_credentials_from_proplist(AccessKey, SecretKey, SessionToken, Config) ->
         expiration = undefined
     },
     {ok, Creds, Config}.
+
+%% ============================================================================
+%% Credential chain resolution (role_arn / source_profile)
+%%
+%% This code path is ONLY reachable from boot-time config file credential
+%% loading (aws_lib_config:credentials/1,2). It is impossible for a validation
+%% request body to inject role_arn/source_profile because:
+%%   - aws_auth_validate_mgmt gets request JSON and passes filtered fields
+%%   - aws_auth_validate_registry has per-backend allowed_fields/0 that do
+%%     NOT include role_arn or source_profile
+%%   - This module (aws_lib_config) is NOT called from any validation path
+%% ============================================================================
+
+-spec resolve_role_arn_credentials(
+    RoleArn :: string(),
+    SectionData :: list(),
+    Config :: aws_config(),
+    Visited :: [string()]
+) ->
+    {ok, aws_credentials(), aws_config()} | {error, term()}.
+%% @doc Entry point for role_arn credential chain resolution. Checks for
+%% credential_source (rejected -- not supported, belongs to issue-94),
+%% resolves source credentials, validates the session name, and calls STS
+%% AssumeRole.
+%% @end
+resolve_role_arn_credentials(RoleArn, SectionData, Config, Visited) ->
+    %% Check for credential_source -- reject with a loud error
+    case proplists:get_value(credential_source, SectionData, undefined) of
+        undefined ->
+            resolve_role_arn_credentials_inner(RoleArn, SectionData, Config, Visited);
+        CredSourceValue ->
+            Profile = proplists:get_value(source_profile, SectionData, "unknown"),
+            ?LOG_WARNING(
+                "credential_source is not yet supported (profile=~ts, value=~ts). "
+                "See issue-94 for implementation.",
+                [Profile, format_value(CredSourceValue)]
+            ),
+            {error, {credential_source_not_supported, Profile, CredSourceValue}}
+    end.
+
+resolve_role_arn_credentials_inner(RoleArn, SectionData, Config, Visited) ->
+    %% Depth check
+    case length(Visited) >= ?MAX_CREDENTIAL_CHAIN_DEPTH of
+        true ->
+            Profile = proplists:get_value(source_profile, SectionData, "unknown"),
+            ?LOG_ERROR(
+                "Credential chain too deep: profile=~ts, depth=~B, max=~B. "
+                "Check for excessive role_arn/source_profile nesting in AWS config.",
+                [Profile, length(Visited), ?MAX_CREDENTIAL_CHAIN_DEPTH]
+            ),
+            {error, {credential_chain_too_deep, Profile, length(Visited)}};
+        false ->
+            resolve_source_credentials(RoleArn, SectionData, Config, Visited)
+    end.
+
+resolve_source_credentials(RoleArn, SectionData, Config, Visited) ->
+    SourceProfile = proplists:get_value(source_profile, SectionData, undefined),
+    case SourceProfile of
+        undefined ->
+            %% role_arn without source_profile: use this section's own static creds
+            resolve_inline_source_credentials(RoleArn, SectionData, Config, Visited);
+        SourceProfile ->
+            %% role_arn with source_profile: resolve from the named profile
+            resolve_named_source_profile(RoleArn, SourceProfile, SectionData, Config, Visited)
+    end.
+
+%% When role_arn is present without source_profile, the section's own
+%% aws_access_key_id/aws_secret_access_key serve as the source credentials
+%% for the AssumeRole call.
+resolve_inline_source_credentials(RoleArn, SectionData, Config, Visited) ->
+    AccessKey = proplists:get_value(aws_access_key_id, SectionData, undefined),
+    SecretKey = proplists:get_value(aws_secret_access_key, SectionData, undefined),
+    case {AccessKey, SecretKey} of
+        {undefined, _} ->
+            ?LOG_ERROR(
+                "Profile has role_arn without source_profile and no "
+                "aws_access_key_id. Cannot resolve source credentials for "
+                "AssumeRole on ~ts.",
+                [RoleArn]
+            ),
+            {error, {missing_source_credentials, RoleArn}};
+        {_, undefined} ->
+            ?LOG_ERROR(
+                "Profile has role_arn without source_profile and no "
+                "aws_secret_access_key. Cannot resolve source credentials for "
+                "AssumeRole on ~ts.",
+                [RoleArn]
+            ),
+            {error, {missing_source_credentials, RoleArn}};
+        {AK, SK} ->
+            SessionToken = proplists:get_value(aws_session_token, SectionData, undefined),
+            SourceCreds = #aws_credentials{
+                access_key = AK,
+                secret_key = SK,
+                security_token = SessionToken,
+                expiration = undefined
+            },
+            perform_assume_role(RoleArn, SectionData, SourceCreds, Config, Visited)
+    end.
+
+%% Resolve credentials from a named source_profile. The profile is looked up
+%% in both the credentials file and the config file.
+resolve_named_source_profile(RoleArn, SourceProfile, SectionData, Config, Visited) ->
+    %% Cycle detection
+    case lists:member(SourceProfile, Visited) of
+        true ->
+            ?LOG_ERROR(
+                "Credential chain cycle detected: profile=~ts already visited. "
+                "Visited chain: ~tp",
+                [SourceProfile, Visited]
+            ),
+            {error, {credential_chain_cycle, SourceProfile, Visited}};
+        false ->
+            resolve_named_source_profile_lookup(
+                RoleArn, SourceProfile, SectionData, Config, [SourceProfile | Visited]
+            )
+    end.
+
+resolve_named_source_profile_lookup(RoleArn, SourceProfile, SectionData, Config, Visited) ->
+    %% Look up source_profile in credentials file first, then config file.
+    %% Credentials file uses bare [NAME]; config file uses [profile NAME].
+    SourceSection = lookup_source_profile_section(SourceProfile),
+    case SourceSection of
+        undefined ->
+            ?LOG_ERROR(
+                "source_profile '~ts' not found in credentials file or config file. "
+                "Cannot resolve credentials for AssumeRole on ~ts.",
+                [SourceProfile, RoleArn]
+            ),
+            {error, {source_profile_not_found, SourceProfile}};
+        SourceData ->
+            %% The source profile itself may have role_arn -- recurse
+            case proplists:get_value(role_arn, SourceData, undefined) of
+                undefined ->
+                    %% Source has static credentials
+                    AK = proplists:get_value(aws_access_key_id, SourceData, undefined),
+                    SK = proplists:get_value(aws_secret_access_key, SourceData, undefined),
+                    case {AK, SK} of
+                        {undefined, _} ->
+                            ?LOG_ERROR(
+                                "source_profile '~ts' exists but has no "
+                                "aws_access_key_id.",
+                                [SourceProfile]
+                            ),
+                            {error, {source_profile_missing_credentials, SourceProfile}};
+                        {_, undefined} ->
+                            ?LOG_ERROR(
+                                "source_profile '~ts' exists but has no "
+                                "aws_secret_access_key.",
+                                [SourceProfile]
+                            ),
+                            {error, {source_profile_missing_credentials, SourceProfile}};
+                        {_, _} ->
+                            ST = proplists:get_value(
+                                aws_session_token, SourceData, undefined
+                            ),
+                            SourceCreds = #aws_credentials{
+                                access_key = AK,
+                                secret_key = SK,
+                                security_token = ST,
+                                expiration = undefined
+                            },
+                            perform_assume_role(
+                                RoleArn, SectionData, SourceCreds, Config, Visited
+                            )
+                    end;
+                NestedRoleArn ->
+                    %% Source profile also has role_arn -- chain deeper.
+                    %% First check credential_source on the nested profile.
+                    case proplists:get_value(credential_source, SourceData, undefined) of
+                        undefined ->
+                            ok;
+                        NestedCredSource ->
+                            ?LOG_WARNING(
+                                "credential_source is not yet supported "
+                                "(profile=~ts, value=~ts). See issue-94.",
+                                [SourceProfile, format_value(NestedCredSource)]
+                            ),
+                            throw(
+                                {error,
+                                    {credential_source_not_supported, SourceProfile,
+                                        NestedCredSource}}
+                            )
+                    end,
+                    %% Recursively resolve the nested chain
+                    case
+                        resolve_role_arn_credentials_inner(
+                            NestedRoleArn, SourceData, Config, Visited
+                        )
+                    of
+                        {ok, NestedCreds, _Config2} ->
+                            perform_assume_role(
+                                RoleArn, SectionData, NestedCreds, Config, Visited
+                            );
+                        {error, _} = Error ->
+                            Error
+                    end
+            end
+    end.
+
+%% Perform the actual STS AssumeRole call with resolved source credentials.
+perform_assume_role(RoleArn, SectionData, SourceCreds, Config, _Visited) ->
+    %% Validate and determine session name
+    case resolve_session_name(SectionData) of
+        {error, _} = Error ->
+            Error;
+        {ok, SessionName} ->
+            %% Build opts map for aws_iam:assume_role/3
+            ExternalId = proplists:get_value(external_id, SectionData, undefined),
+            Opts0 = #{role_session_name => SessionName},
+            Opts =
+                case ExternalId of
+                    undefined -> Opts0;
+                    _ -> Opts0#{external_id => ExternalId}
+                end,
+            %% Build a State with the source credentials for signing
+            State = #aws_state{
+                credentials = SourceCreds,
+                config = Config
+            },
+            StartTime = erlang:monotonic_time(millisecond),
+            ?LOG_INFO(
+                "Credential chain: assuming role ~ts (session=~ts)",
+                [RoleArn, SessionName]
+            ),
+            case aws_iam:assume_role(RoleArn, Opts, State) of
+                {ok, AssumedCreds} ->
+                    Elapsed = erlang:monotonic_time(millisecond) - StartTime,
+                    ?LOG_INFO(
+                        "Credential chain: AssumeRole for ~ts succeeded in ~Bms",
+                        [RoleArn, Elapsed]
+                    ),
+                    {ok, AssumedCreds, Config};
+                {error, Reason} ->
+                    Elapsed = erlang:monotonic_time(millisecond) - StartTime,
+                    ?LOG_ERROR(
+                        "Credential chain: AssumeRole for ~ts failed after ~Bms: ~tp",
+                        [RoleArn, Elapsed, Reason]
+                    ),
+                    {error, {assume_role_failed, RoleArn, Reason}}
+            end
+    end.
+
+%% Resolve the session name from profile data: if role_session_name is set,
+%% validate it; otherwise derive from "rabbitmq-aws-<profile>".
+resolve_session_name(SectionData) ->
+    case proplists:get_value(role_session_name, SectionData, undefined) of
+        undefined ->
+            %% Derive from profile name. The derived name "rabbitmq-aws-<profile>"
+            %% is always valid because profile names come from the INI regex
+            %% which only allows [\w\s+\-_]. We use "session" as a fallback
+            %% that is guaranteed to be valid.
+            SourceProfile = proplists:get_value(source_profile, SectionData, "session"),
+            DerivedName = "rabbitmq-aws-" ++ ensure_string(SourceProfile),
+            {ok, DerivedName};
+        Name ->
+            NameStr = ensure_string(Name),
+            case validate_session_name(NameStr) of
+                true ->
+                    {ok, NameStr};
+                false ->
+                    ?LOG_ERROR(
+                        "Invalid role_session_name: '~ts'. Must match pattern "
+                        "[\\w+=,.@-]{2,64}.",
+                        [NameStr]
+                    ),
+                    {error, {invalid_role_session_name, NameStr}}
+            end
+    end.
+
+%% Validate that a session name matches the STS pattern: 2-64 chars from [\w+=,.@-]
+validate_session_name(Name) ->
+    case re:run(Name, ?ROLE_SESSION_NAME_PATTERN, [{capture, none}]) of
+        match -> true;
+        nomatch -> false
+    end.
+
+%% Look up a profile section from both the credentials file and the config file.
+%% Credentials file uses bare [Name]; config file uses [profile Name].
+lookup_source_profile_section(Profile) ->
+    %% Try credentials file first (bare profile name)
+    case credentials_file_data() of
+        {error, _} ->
+            lookup_source_profile_from_config(Profile);
+        CredsData ->
+            case proplists:get_value(Profile, CredsData, undefined) of
+                undefined ->
+                    lookup_source_profile_from_config(Profile);
+                Section ->
+                    Section
+            end
+    end.
+
+lookup_source_profile_from_config(Profile) ->
+    case config_file_data() of
+        {error, _} ->
+            undefined;
+        ConfigData ->
+            %% Config file: try bare [Profile] and [profile Profile]
+            Prefixed = "profile " ++ Profile,
+            case proplists:get_value(Profile, ConfigData, undefined) of
+                undefined ->
+                    proplists:get_value(Prefixed, ConfigData, undefined);
+                Section ->
+                    Section
+            end
+    end.
+
+%% Return the full section data for a profile from the config file.
+%% Used when lookup_credentials_from_config detects role_arn.
+config_section_data(Profile) ->
+    case config_file_data() of
+        {error, _} ->
+            undefined;
+        ConfigData ->
+            Prefixed = "profile " ++ Profile,
+            case proplists:get_value(Profile, ConfigData, undefined) of
+                undefined ->
+                    proplists:get_value(Prefixed, ConfigData, undefined);
+                Section ->
+                    Section
+            end
+    end.
+
+%% Ensure a value is a string. INI values that look numeric get converted by
+%% maybe_convert_number; we need them back as strings for session names and
+%% profile names.
+ensure_string(V) when is_list(V) -> V;
+ensure_string(V) when is_atom(V) -> atom_to_list(V);
+ensure_string(V) when is_integer(V) -> integer_to_list(V);
+ensure_string(V) when is_binary(V) -> binary_to_list(V).
+
+%% Format a value for logging. Avoids crashing on unexpected types.
+format_value(V) when is_list(V) -> V;
+format_value(V) when is_atom(V) -> atom_to_list(V);
+format_value(V) when is_integer(V) -> integer_to_list(V);
+format_value(V) when is_binary(V) -> binary_to_list(V);
+format_value(V) -> io_lib:format("~tp", [V]).
 
 -spec with_metadata_connection(fun((aws_lib_httpc:conn()) -> Result)) -> Result.
 %% @doc Execute a function with a shared metadata service connection

--- a/test/aws_lib_config_tests.erl
+++ b/test/aws_lib_config_tests.erl
@@ -105,7 +105,55 @@ config_file_data_test_() ->
                 ]},
                 {"profile only-key", [{aws_access_key_id, "foo3"}]},
                 {"profile only-secret", [{aws_secret_access_key, "foo4"}]},
-                {"profile bad-entry", [{aws_secret_access, "foo5"}]}
+                {"profile bad-entry", [{aws_secret_access, "foo5"}]},
+                {"profile chained", [
+                    {role_arn, "arn:aws:iam::123456789012:role/TestRole"},
+                    {source_profile, "default"}
+                ]},
+                {"profile chained-with-external-id", [
+                    {role_arn, "arn:aws:iam::123456789012:role/TestRole"},
+                    {source_profile, "default"},
+                    {external_id, "test-external-id-12345"}
+                ]},
+                {"profile deep-chain", [
+                    {role_arn, "arn:aws:iam::123456789012:role/DeepRole"},
+                    {source_profile, "intermediate"}
+                ]},
+                {"profile intermediate", [
+                    {role_arn, "arn:aws:iam::123456789012:role/IntermediateRole"},
+                    {source_profile, "default"}
+                ]},
+                {"profile cycle-a", [
+                    {role_arn, "arn:aws:iam::123456789012:role/CycleA"},
+                    {source_profile, "cycle-b"}
+                ]},
+                {"profile cycle-b", [
+                    {role_arn, "arn:aws:iam::123456789012:role/CycleB"},
+                    {source_profile, "cycle-a"}
+                ]},
+                {"profile credential-source-test", [
+                    {role_arn, "arn:aws:iam::123456789012:role/TestRole"},
+                    {credential_source, "Ec2InstanceMetadata"}
+                ]},
+                {"profile invalid-session-name", [
+                    {role_arn, "arn:aws:iam::123456789012:role/TestRole"},
+                    {source_profile, "default"},
+                    {role_session_name, "invalid name with spaces!!!"}
+                ]},
+                {"profile missing-source", [
+                    {role_arn, "arn:aws:iam::123456789012:role/TestRole"},
+                    {source_profile, "nonexistent_profile"}
+                ]},
+                {"profile role-no-source", [
+                    {role_arn, "arn:aws:iam::123456789012:role/TestRole"},
+                    {aws_access_key_id, "AKIAIOSFODNN7EXAMPLE"},
+                    {aws_secret_access_key, "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"}
+                ]},
+                {"profile custom-session-name", [
+                    {role_arn, "arn:aws:iam::123456789012:role/TestRole"},
+                    {source_profile, "default"},
+                    {role_session_name, "my-custom-session"}
+                ]}
             ],
             ?assertEqual(
                 Expectation,
@@ -766,10 +814,221 @@ maybe_imdsv2_token_headers_test_() ->
         ]
     }.
 
+%% ============================================================================
+%% Credential chain resolution tests (role_arn / source_profile)
+%% ============================================================================
+
+credential_chain_test_() ->
+    {
+        foreach,
+        fun() ->
+            meck:new(gun, []),
+            meck:new(aws_iam, [no_link]),
+            reset_environment(),
+            setup_test_config_env_var(),
+            setup_test_credentials_env_var(),
+            application:set_env(aws, aws_prefer_imdsv2, false),
+            [gun, aws_iam]
+        end,
+        fun(Mods) ->
+            application:unset_env(aws, aws_prefer_imdsv2),
+            meck:unload(Mods)
+        end,
+        [
+            {"role_arn + source_profile resolves via STS", fun() ->
+                %% Mock aws_iam:assume_role/3 to return creds
+                meck:expect(aws_iam, assume_role, fun(_RoleArn, _Opts, _State) ->
+                    {ok, #aws_credentials{
+                        access_key = "ASSUMED_KEY",
+                        secret_key = "ASSUMED_SECRET",
+                        security_token = "ASSUMED_TOKEN",
+                        expiration = {{2026, 12, 31}, {23, 59, 59}}
+                    }}
+                end),
+                S = #aws_config{},
+                {ok, Creds, _Config} = aws_lib_config:credentials("chained", S),
+                ?assertEqual("ASSUMED_KEY", Creds#aws_credentials.access_key),
+                ?assertEqual("ASSUMED_SECRET", Creds#aws_credentials.secret_key),
+                ?assertEqual("ASSUMED_TOKEN", Creds#aws_credentials.security_token),
+                ?assertEqual(
+                    {{2026, 12, 31}, {23, 59, 59}}, Creds#aws_credentials.expiration
+                ),
+                %% Verify assume_role/3 was called with the correct RoleArn
+                [{_Pid, {aws_iam, assume_role, [RoleArn, Opts, _St]}, _Ret}] =
+                    meck:history(aws_iam),
+                ?assertEqual("arn:aws:iam::123456789012:role/TestRole", RoleArn),
+                %% Opts should have role_session_name derived from source profile
+                ?assert(maps:is_key(role_session_name, Opts)),
+                ?assertNot(maps:is_key(external_id, Opts))
+            end},
+            {"role_arn + source_profile + external_id passes ExternalId", fun() ->
+                meck:expect(aws_iam, assume_role, fun(_RoleArn, Opts, _State) ->
+                    %% Verify external_id is passed
+                    ?assertEqual(
+                        "test-external-id-12345", maps:get(external_id, Opts)
+                    ),
+                    {ok, #aws_credentials{
+                        access_key = "AK",
+                        secret_key = "SK",
+                        security_token = "ST",
+                        expiration = undefined
+                    }}
+                end),
+                S = #aws_config{},
+                {ok, _Creds, _Config} = aws_lib_config:credentials(
+                    "chained-with-external-id", S
+                ),
+                ok
+            end},
+            {"role_arn without source_profile uses section's own creds", fun() ->
+                meck:expect(aws_iam, assume_role, fun(RoleArn, _Opts, State) ->
+                    %% Verify the State has the inline credentials
+                    {ok, InlineCreds} = aws_lib:get_credentials(State),
+                    ?assertEqual(
+                        "AKIAIOSFODNN7EXAMPLE",
+                        InlineCreds#aws_credentials.access_key
+                    ),
+                    ?assertEqual(
+                        "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                        InlineCreds#aws_credentials.secret_key
+                    ),
+                    ?assertEqual(
+                        "arn:aws:iam::123456789012:role/TestRole", RoleArn
+                    ),
+                    {ok, #aws_credentials{
+                        access_key = "ROLE_KEY",
+                        secret_key = "ROLE_SECRET",
+                        security_token = "ROLE_TOKEN",
+                        expiration = undefined
+                    }}
+                end),
+                S = #aws_config{},
+                {ok, Creds, _Config} = aws_lib_config:credentials("role-no-source", S),
+                ?assertEqual("ROLE_KEY", Creds#aws_credentials.access_key)
+            end},
+            {"cycle detection returns error", fun() ->
+                S = #aws_config{},
+                Result = aws_lib_config:credentials("cycle-a", S),
+                ?assertMatch({error, {credential_chain_cycle, _, _}}, Result)
+            end},
+            {"missing source_profile returns error (NOT fallthrough to IMDS)", fun() ->
+                S = #aws_config{},
+                Result = aws_lib_config:credentials("missing-source", S),
+                ?assertMatch({error, {source_profile_not_found, "nonexistent_profile"}}, Result)
+            end},
+            {"credential_source returns unsupported error", fun() ->
+                S = #aws_config{},
+                Result = aws_lib_config:credentials("credential-source-test", S),
+                ?assertMatch(
+                    {error, {credential_source_not_supported, _, "Ec2InstanceMetadata"}},
+                    Result
+                )
+            end},
+            {"invalid session name returns error", fun() ->
+                S = #aws_config{},
+                Result = aws_lib_config:credentials("invalid-session-name", S),
+                ?assertMatch(
+                    {error, {invalid_role_session_name, _}}, Result
+                )
+            end},
+            {"custom session name is passed through", fun() ->
+                meck:expect(aws_iam, assume_role, fun(_RoleArn, Opts, _State) ->
+                    ?assertEqual(
+                        "my-custom-session", maps:get(role_session_name, Opts)
+                    ),
+                    {ok, #aws_credentials{
+                        access_key = "AK",
+                        secret_key = "SK",
+                        security_token = "ST",
+                        expiration = undefined
+                    }}
+                end),
+                S = #aws_config{},
+                {ok, _Creds, _Config} = aws_lib_config:credentials(
+                    "custom-session-name", S
+                ),
+                ok
+            end},
+            {"deep chain resolves through intermediate profile", fun() ->
+                %% deep-chain -> intermediate -> default
+                %% Each hop calls assume_role/3
+                CallCount = counters:new(1, []),
+                meck:expect(aws_iam, assume_role, fun(_RoleArn, _Opts, _State) ->
+                    counters:add(CallCount, 1, 1),
+                    {ok, #aws_credentials{
+                        access_key = "DEEP_KEY",
+                        secret_key = "DEEP_SECRET",
+                        security_token = "DEEP_TOKEN",
+                        expiration = undefined
+                    }}
+                end),
+                S = #aws_config{},
+                {ok, Creds, _Config} = aws_lib_config:credentials("deep-chain", S),
+                ?assertEqual("DEEP_KEY", Creds#aws_credentials.access_key),
+                %% Should have been called twice: once for intermediate, once for
+                %% deep-chain
+                ?assertEqual(2, counters:get(CallCount, 1))
+            end},
+            {"env vars still win over profile with role_arn", fun() ->
+                os:putenv("AWS_ACCESS_KEY_ID", "ENV_KEY"),
+                os:putenv("AWS_SECRET_ACCESS_KEY", "ENV_SECRET"),
+                S = #aws_config{},
+                {ok, Creds, _Config} = aws_lib_config:credentials("chained", S),
+                %% Environment variables take precedence -- no AssumeRole call
+                ?assertEqual("ENV_KEY", Creds#aws_credentials.access_key),
+                ?assertEqual("ENV_SECRET", Creds#aws_credentials.secret_key),
+                %% aws_iam:assume_role should NOT have been called
+                ?assertEqual(0, meck:num_calls(aws_iam, assume_role, '_'))
+            end},
+            {"assume_role failure propagates error", fun() ->
+                meck:expect(aws_iam, assume_role, fun(_RoleArn, _Opts, _State) ->
+                    {error, "Access Denied"}
+                end),
+                S = #aws_config{},
+                Result = aws_lib_config:credentials("chained", S),
+                ?assertMatch(
+                    {error, {assume_role_failed, _, "Access Denied"}}, Result
+                )
+            end}
+        ]
+    }.
+
+%% Session name validation unit tests
+session_name_validation_test_() ->
+    [
+        {"valid simple name", fun() ->
+            ?assert(aws_lib_config:validate_session_name("my-session"))
+        end},
+        {"valid with all allowed chars", fun() ->
+            ?assert(aws_lib_config:validate_session_name("a+=,.@-b"))
+        end},
+        {"too short (1 char)", fun() ->
+            ?assertNot(aws_lib_config:validate_session_name("a"))
+        end},
+        {"too long (65 chars)", fun() ->
+            LongName = lists:duplicate(65, $a),
+            ?assertNot(aws_lib_config:validate_session_name(LongName))
+        end},
+        {"exactly 64 chars is valid", fun() ->
+            Name64 = lists:duplicate(64, $a),
+            ?assert(aws_lib_config:validate_session_name(Name64))
+        end},
+        {"exactly 2 chars is valid", fun() ->
+            ?assert(aws_lib_config:validate_session_name("ab"))
+        end},
+        {"spaces are invalid", fun() ->
+            ?assertNot(aws_lib_config:validate_session_name("has space"))
+        end},
+        {"exclamation marks are invalid", fun() ->
+            ?assertNot(aws_lib_config:validate_session_name("invalid!!!"))
+        end}
+    ].
+
 reset_environment() ->
     os:unsetenv("AWS_ACCESS_KEY_ID"),
     os:unsetenv("AWS_DEFAULT_REGION"),
     os:unsetenv("AWS_SECRET_ACCESS_KEY"),
+    os:unsetenv("AWS_SESSION_TOKEN"),
     setup_test_file_with_env_var("AWS_CONFIG_FILE", "bad_config.ini"),
     setup_test_file_with_env_var(
         "AWS_SHARED_CREDENTIALS_FILE",

--- a/test/test_aws_config.ini
+++ b/test/test_aws_config.ini
@@ -23,3 +23,51 @@ aws_secret_access_key = foo4
 
 [profile bad-entry]
 aws_secret_access = foo5
+
+[profile chained]
+role_arn = arn:aws:iam::123456789012:role/TestRole
+source_profile = default
+
+[profile chained-with-external-id]
+role_arn = arn:aws:iam::123456789012:role/TestRole
+source_profile = default
+external_id = test-external-id-12345
+
+[profile deep-chain]
+role_arn = arn:aws:iam::123456789012:role/DeepRole
+source_profile = intermediate
+
+[profile intermediate]
+role_arn = arn:aws:iam::123456789012:role/IntermediateRole
+source_profile = default
+
+[profile cycle-a]
+role_arn = arn:aws:iam::123456789012:role/CycleA
+source_profile = cycle-b
+
+[profile cycle-b]
+role_arn = arn:aws:iam::123456789012:role/CycleB
+source_profile = cycle-a
+
+[profile credential-source-test]
+role_arn = arn:aws:iam::123456789012:role/TestRole
+credential_source = Ec2InstanceMetadata
+
+[profile invalid-session-name]
+role_arn = arn:aws:iam::123456789012:role/TestRole
+source_profile = default
+role_session_name = invalid name with spaces!!!
+
+[profile missing-source]
+role_arn = arn:aws:iam::123456789012:role/TestRole
+source_profile = nonexistent_profile
+
+[profile role-no-source]
+role_arn = arn:aws:iam::123456789012:role/TestRole
+aws_access_key_id = AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+
+[profile custom-session-name]
+role_arn = arn:aws:iam::123456789012:role/TestRole
+source_profile = default
+role_session_name = my-custom-session


### PR DESCRIPTION
Fixes #97.

Interprets the standard AWS CLI convention in `~/.aws/config`: when a profile
declares `role_arn`, resolve its `source_profile` credentials and call STS
AssumeRole for the target role. Supports `external_id` and a configurable
`role_session_name`.

## Design decisions

- **Reuses `aws_iam:assume_role/3`** rather than adding a second AssumeRole
  implementation.
- **Cycles and depth are rejected loudly.** `source_profile` can point at another
  profile that itself has a `role_arn`; a cycle (`a -> b -> a`) is detected via a
  visited set and a bounded chain depth, so a crafted config cannot hang or
  stack-overflow broker boot.
- **`role_session_name` is validated before the STS call** (2-64 chars,
  `[\w+=,.@-]*`), so an invalid name fails fast instead of producing an opaque STS
  error at boot.
- **No silent-wrong-credentials.** "No `source_profile` configured" and "configured
  but unresolvable" are distinguished; the latter is a hard error rather than a
  fallthrough to the instance role.
- Temporary credentials participate in the existing 5-minute pre-expiry refresh
  buffer, re-assuming on expiry and re-resolving the source credentials.
- `external_id` is treated as sensitive; ARNs are identifiers and safe to log.

## Verification

eunit **833 passed, 0 failed** (baseline `main` is 814). `ct-config_schema` passes.

Exercised against a local STS stand-in returning realistic `AssumeRoleResponse` XML,
with temp INI files: a simple `role_arn` + `source_profile` chain; a two-hop chain;
a cycle (**rejected loudly, does not hang**); depth overflow; a nonexistent
`source_profile` (hard error, no IMDS fallthrough); `external_id` present (the fake
STS echoed the received parameters, confirming it is actually sent); an invalid
session name (rejected before the call); STS `AccessDenied`; `credential_source`
handling; and `[profile NAME]` vs `[NAME]` section forms. Env-var credentials still
take precedence over a profile with `role_arn`. Refresh confirmed via a second
AssumeRole hit on the listener. Non-leakage grep at debug level: **zero hits** for
the fake secret, session token, and `external_id`.