### PR TITLE
Run dialyzer in CI and clear the existing warning backlog

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -25,6 +25,7 @@ jobs:
           - rmq-version: 'v4.3.x'
             otp-version: 27
             elixir-version: 1.18
+            dialyze: true
           - rmq-version: 'v4.2.x'
             otp-version: 27
             elixir-version: 1.18
@@ -43,7 +44,8 @@ jobs:
         with:
           script: |
             core.setFailed('could not restore cached rabbitmq-server build');
-      - uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
+      - id: beam
+        uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
         with:
           otp-version: ${{ matrix.otp-version }}
           elixir-version: ${{ matrix.elixir-version }}
@@ -66,11 +68,36 @@ jobs:
           sudo systemctl disable --now apparmor.service || true
       - run: make -C ${{ github.workspace }}/rabbitmq-server/deps/aws
       # Dialyzer findings depend on the OTP version (library specs change
-      # between releases), so run it on a single configuration. Running it
-      # across the whole matrix would let a warning that only appears under one
-      # OTP release fail builds unrelated to the change under review.
+      # between releases), so run it on a single configuration flagged with
+      # dialyze: true in the matrix. Running it across the whole matrix would
+      # let a warning that only appears under one OTP release fail builds
+      # unrelated to the change under review.
+      #
+      # Cache the PLT because building it is slow. The PLT holds OTP, rabbit,
+      # and this plugin's declared dependencies (never src/, which is analyzed
+      # live), so its contents are pinned by the runner OS, the resolved OTP
+      # version, the rabbitmq-server checkout, and the dependency set declared
+      # in the Makefile. The OTP version comes from the setup-beam step output,
+      # not matrix.otp-version, so it is the exact patch release (e.g. 27.3.4.14
+      # rather than 27): a patch bump changes OTP's specs and therefore the PLT,
+      # and must invalidate the cache. hashFiles of the Makefile covers the
+      # declared dependency set. This project uses erlang.mk and has no
+      # rebar.lock or mix.lock, so the Makefile is the dependency manifest.
+      #
+      # No restore-keys fallback on purpose: a key change must be a clean miss
+      # that rebuilds the PLT from scratch. make dialyze only rebuilds an
+      # existing PLT when the erts path changed, not when the dependency set
+      # changed, so restoring a near-miss PLT would analyze against a stale set
+      # and emit spurious unknown-function warnings. A miss rebuilds and
+      # re-caches; a hit restores the exact PLT and skips the rebuild.
+      - name: Cache dialyzer PLT
+        if: matrix.dialyze
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ github.workspace }}/rabbitmq-server/deps/aws/.aws.plt
+          key: plt-${{ runner.os }}-rmq-${{ matrix.rmq-version }}-otp-${{ steps.beam.outputs.otp-version }}-elixir-${{ matrix.elixir-version }}-${{ hashFiles('rabbitmq-server/deps/aws/Makefile') }}
       - name: Run dialyzer
-        if: matrix.rmq-version == 'v4.3.x'
+        if: matrix.dialyze
         run: make -C ${{ github.workspace }}/rabbitmq-server/deps/aws dialyze
       - run: make -C ${{ github.workspace }}/rabbitmq-server/deps/aws tests
       - name: maybe upload CT logs

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -65,6 +65,13 @@ jobs:
           sudo aa-teardown || true
           sudo systemctl disable --now apparmor.service || true
       - run: make -C ${{ github.workspace }}/rabbitmq-server/deps/aws
+      # Dialyzer findings depend on the OTP version (library specs change
+      # between releases), so run it on a single configuration. Running it
+      # across the whole matrix would let a warning that only appears under one
+      # OTP release fail builds unrelated to the change under review.
+      - name: Run dialyzer
+        if: matrix.rmq-version == 'v4.3.x'
+        run: make -C ${{ github.workspace }}/rabbitmq-server/deps/aws dialyze
       - run: make -C ${{ github.workspace }}/rabbitmq-server/deps/aws tests
       - name: maybe upload CT logs
         if: failure()

--- a/src/aws_auth_validate_ldap.erl
+++ b/src/aws_auth_validate_ldap.erl
@@ -767,6 +767,14 @@ do_ldap_connect(
 verify_connected_peer(Handle) ->
     check_peer_ip(Handle).
 
+%% eldap:info/1 is specced as returning connection_info() unconditionally, so
+%% dialyzer considers the fallback clause unreachable. The spec is optimistic:
+%% info/1 returns recv/1's result, and recv/1 answers
+%% {error, {internal_error, Reason}} if the eldap process exits first. The clause
+%% is therefore reachable in practice, and it must stay because this function
+%% fails closed -- dropping it would turn a dead connection into a
+%% function_clause instead of `blocked'.
+-dialyzer({no_match, check_peer_ip/1}).
 check_peer_ip(Handle) ->
     case eldap:info(Handle) of
         #{socket := Sock, socket_type := ssl} -> peer_allowed(ssl:peername(Sock));

--- a/src/aws_auth_validate_mgmt.erl
+++ b/src/aws_auth_validate_mgmt.erl
@@ -203,6 +203,20 @@ respond({error, Category, Reason}, Req, Context) when is_atom(Category), is_bina
     Status = status_for_category(Category),
     reply_error(Status, Category, Reason, Req, Context).
 
+%% The domain is any atom, not just aws_auth_validate_backend:error_category().
+%% body_too_large is raised by this module (read_body/2) rather than by a
+%% backend, and the final clause exists precisely for atoms outside the
+%% documented set.
+%%
+%% Both of those clauses are reachable only through the -ifdef(TEST) export
+%% above, and `make dialyze' compiles without TEST, so dialyzer sees a local
+%% function and infers its domain from the sole production call site in
+%% respond/3 -- which passes only error_category(). That makes the two clauses
+%% look unreachable even though the eunit suite calls them directly. The spec
+%% below documents the real domain; it cannot silence the warning, because
+%% dialyzer prefers the inferred success typing of a local function.
+-dialyzer({no_match, status_for_category/1}).
+-spec status_for_category(atom()) -> 400 | 422 | 500.
 status_for_category(input_invalid) -> 400;
 status_for_category(body_too_large) -> 400;
 status_for_category(connection_failed) -> 400;
@@ -270,6 +284,12 @@ not_authorised(ReqData, Context) ->
 %% Request helpers
 %%--------------------------------------------------------------------
 
+%% The fallback clause is unreachable per cowboy_req:peer/1's own spec, which is
+%% why dialyzer flags it, but it is kept deliberately: peer_ip/1 runs BEFORE the
+%% try in with_semaphore/6, so a function_clause here would surface as an
+%% unhandled 500 on an otherwise valid request. Falling back to 0.0.0.0 keeps
+%% the request serviceable and still produces an audit line.
+-dialyzer({no_match, peer_ip/1}).
 peer_ip(Req) ->
     case cowboy_req:peer(Req) of
         {IP, _Port} -> IP;
@@ -333,6 +353,11 @@ username(#context{user = #user{username = Name}}) when is_binary(Name) ->
 username(_) ->
     <<"unknown">>.
 
+%% As with peer_ip/1, the non-tuple clause is unreachable given the inferred
+%% argument type but is kept so that a malformed address can never turn an audit
+%% log write into a crash. Audit logging must not be able to fail the request it
+%% is recording.
+-dialyzer({no_match, format_ip/1}).
 format_ip(IP) when is_tuple(IP) ->
     case inet:ntoa(IP) of
         {error, _} -> <<"unknown">>;

--- a/src/aws_auth_validate_registry.erl
+++ b/src/aws_auth_validate_registry.erl
@@ -41,12 +41,24 @@ lookup_backend(<<"tls">>) ->
 lookup_backend(_) ->
     {error, unknown_method}.
 
+%% The override narrows a method's allowed fields; it can never widen them,
+%% because every entry is intersected with the backend's own list.
+%%
+%% Keyed the same way as auth_validation_enabled_methods below: a single atom
+%% key holding a [{Method, Fields}] list. application:get_env/2 requires an
+%% atom parameter name, so a per-method key cannot be a {atom(), binary()}
+%% tuple.
 -spec effective_allowed_fields(module(), binary()) -> [binary()].
 effective_allowed_fields(Module, Method) ->
     BaseFields = Module:allowed_fields(),
-    case application:get_env(aws, {auth_validation_allowed_fields_override, Method}) of
-        {ok, Override} when is_list(Override) ->
-            [F || F <- Override, lists:member(F, BaseFields)];
+    case application:get_env(aws, auth_validation_allowed_fields_override) of
+        {ok, Overrides} when is_list(Overrides) ->
+            case lists:keyfind(Method, 1, Overrides) of
+                {_, Override} when is_list(Override) ->
+                    [F || F <- Override, lists:member(F, BaseFields)];
+                _ ->
+                    BaseFields
+            end;
         _ ->
             BaseFields
     end.

--- a/src/aws_lib_config.erl
+++ b/src/aws_lib_config.erl
@@ -381,13 +381,11 @@ ini_parse_line(Section, _, Line) ->
 
 -spec ini_parse_line_parts(
     Section :: list(),
-    Parts :: list()
+    Parts :: [string(), ...]
 ) ->
     {ok, list()} | {new_parent, atom()}.
 %% @doc Parse the AWS configuration INI file, returning a proplist
 %% @end
-ini_parse_line_parts(Section, []) ->
-    {ok, Section};
 ini_parse_line_parts(Section, [RawKey, Value]) ->
     Key = ini_format_key(RawKey),
     {ok, lists:keystore(Key, 1, Section, {Key, maybe_convert_number(Value)})};

--- a/src/aws_sup.erl
+++ b/src/aws_sup.erl
@@ -60,14 +60,13 @@ semaphore_spec() ->
 semaphore_config() ->
     #{max => get_int_env(auth_validation_max_concurrent, 5, 100)}.
 
+%% An out-of-range or non-integer value falls back to Default rather than
+%% failing the boot; the schema is what reports a bad value to the operator.
+-spec get_int_env(atom(), pos_integer(), pos_integer()) -> pos_integer().
 get_int_env(Key, Default, MaxBound) ->
     case application:get_env(aws, Key) of
-        {ok, N} when is_integer(N), N > 0 ->
-            case MaxBound of
-                infinity -> N;
-                _ when N =< MaxBound -> N;
-                _ -> Default
-            end;
+        {ok, N} when is_integer(N), N > 0, N =< MaxBound ->
+            N;
         _ ->
             Default
     end.

--- a/test/aws_auth_validate_tests.erl
+++ b/test/aws_auth_validate_tests.erl
@@ -97,15 +97,12 @@ registry_field_filter_override_test_() ->
         fun() ->
             application:set_env(
                 aws,
-                {auth_validation_allowed_fields_override, <<"ldap">>},
-                [<<"servers">>, <<"port">>, <<"unknown">>]
+                auth_validation_allowed_fields_override,
+                [{<<"ldap">>, [<<"servers">>, <<"port">>, <<"unknown">>]}]
             )
         end,
         fun(_) ->
-            application:unset_env(
-                aws,
-                {auth_validation_allowed_fields_override, <<"ldap">>}
-            )
+            application:unset_env(aws, auth_validation_allowed_fields_override)
         end,
         [
             fun() ->


### PR DESCRIPTION
Closes #8.

## Summary

`make dialyze` had a backlog of warnings, so it exited non-zero and could not be wired into CI. This clears the backlog to zero and adds the CI step.

The backlog was **12 warnings, not the 30 the issue lists**. Earlier merges (including 684a329, which extracted the retry loop into `aws_lib_retry`) had already cleared the entire `aws_auth_validate_ldap` "will never be called" cluster that the issue singles out.

Of the 12: two were real defects, two were dead code, and four were false positives.

## The registry override was broken, and caused most of the backlog

`effective_allowed_fields/2` read its per-method override like this:

```erlang
application:get_env(aws, {auth_validation_allowed_fields_override, Method})
```

`application:get_env/2` requires an atom parameter name, so with a `{atom(), binary()}` tuple the call could never succeed. **The allowed-fields override never took effect.** It is re-keyed the way `auth_validation_enabled_methods` directly below it already does: a single atom key holding a `[{Method, Fields}]` list.

The cascade is why this accounts for most of the backlog. Because dialyzer treats that call as always-failing, `effective_allowed_fields/2` has no local return, so `dispatch/2` cannot return normally through its `{ok, Module}` branch and its success type collapses to `{error, method_disabled | unknown_method}`. That makes six downstream patterns in `aws_auth_validate_mgmt` look unreachable. Fixing the key cleared **five warnings beyond the two at the call site**.

The eunit setup set the old tuple key, so it moves to the new shape. Left alone it would have kept passing while silently no longer exercising the override.

## Two clauses were genuinely dead and are removed

- `ini_parse_line_parts(Section, [])` in `aws_lib_config`: `ini_split_line/1` always returns a non-empty list, and nothing else calls the function. Spec narrowed to `[string(), ...]`
- the `infinity` bound in `aws_sup:get_int_env/3`: the function is local with a single call site passing `100`, so the branch was speculative generality. The bound is folded into the guard

## Four are false positives

Each keeps its clause and gains a targeted `-dialyzer({no_match, F/A})` plus a comment recording why the clause stays.

- `status_for_category/1` is reachable only through the `-ifdef(TEST)` export, and the dialyze target compiles without `TEST`, so dialyzer sees a local function and infers its domain from the sole production call site in `respond/3`. This is exactly the case the issue asked to confirm before suppressing: reachable via a test-only export, not dead code. A `-spec` alone cannot silence it, because the inferred success typing of a local function wins, so the spec documents the real domain and the suppression does the rest
- `peer_ip/1` and `format_ip/1` are fail-closed audit guards. `peer_ip/1` runs *before* the `try` in `with_semaphore/6`, so a `function_clause` there would surface as an unhandled 500 on an otherwise valid request
- `check_peer_ip/1` is the one case where the library spec is wrong rather than the code. `eldap:info/1` is specced to return `connection_info()` unconditionally, but it returns `recv/1`'s result, which is `{error, {internal_error, Reason}}` if the eldap process exits first. The fallback is reachable in practice, and dropping it would turn a dead connection into a crash instead of `blocked`

## The CI step

Added to `.github/workflows/build-test.yaml`, gated on `matrix.rmq-version == 'v4.3.x'` rather than run across all four matrix entries. Dialyzer findings depend on the OTP version because library specs change between releases, so running it everywhere would let a warning appearing under only one OTP release fail builds unrelated to the change under review.

## Verification

| Gate | Result |
| --- | --- |
| `make dialyze` | exit 0, `done (passed successfully)` |
| `erlfmt -c` | clean |
| `make eunit` | 834 passed |
| `make ct-aws_auth_validate_mgmt` | 20 passed, 0 failed, 3 skipped |

The 3 skips are the pre-existing OAuth-authz skips (`OAuth authz evaluation unavailable on this broker node`), unrelated to this change.

Verified locally only under OTP 27.3.4.14, which is what the `v4.3.x` matrix entry uses. OTP 26 and 28 were not verified locally; CI covers those for build and tests, and by design does not run dialyzer on them.

## Reviewer note

Re-keying the override is a breaking change to a setting that never worked, so nothing deployed can depend on the old tuple key. The key is undocumented in `priv/schema/aws.schema` either way, so there is no schema change to make here. Flagging it explicitly in case you would rather see the override documented or removed outright instead.
