### PR TITLE
Make auth_validation allowed_fields override operator-configurable

### DIFF
--- a/AUTH_VALIDATION.md
+++ b/AUTH_VALIDATION.md
@@ -148,6 +148,30 @@ and no log entry. Setting `max_body_size = 2000000`, for example, leaves the
 limit at `65536`, and a 200 KB body is then rejected as `body_too_large` with
 nothing pointing at the ignored setting.
 
+### Narrowing accepted request fields (optional)
+
+Each backend already accepts only the fields relevant to it (its
+`allowed_fields`); any other top-level field is silently dropped. If you want to
+narrow that set further -- for example to reject `queries` and `dn_lookup_base`
+on the `ldap` method and accept only the basic bind fields -- set a per-method
+allowlist:
+
+```
+aws.auth_validation.allowed_fields.ldap = servers,port,user_dn,password_arn,use_ssl
+```
+
+The value is a comma-separated list of field names. The effective set is the
+**intersection** of this list and the backend's own defaults, so the key can
+only ever remove fields, never add one; an entry that is not a real field for
+that method simply never matches. A method left unset keeps the backend's full
+default set. Unknown method names (anything other than `ldap`, `http`, `oauth`,
+`tls`) are rejected at configuration-generation time rather than silently
+ignored, so a typo fails the boot rather than producing an allowlist that never
+applies.
+
+This is a defense-in-depth control on an endpoint that is already admin-gated,
+opt-in, and side-effect-free; most deployments will not need it.
+
 The plugin also registers an **Auth Validation** tab in the RabbitMQ management
 console UI that drives the same endpoint. Note that the tab is registered
 whenever the plugin itself is enabled, independently of the toggles above: with

--- a/priv/schema/aws.schema
+++ b/priv/schema/aws.schema
@@ -129,6 +129,42 @@
      [{list_to_binary(lists:last(Key)), Value} || {Key, Value} <- Settings]
  end}.
 
+%% @doc Optional per-method request-field allowlist. Narrows the fields a
+%% backend will accept to the intersection of this list and the backend's own
+%% allowed_fields/0; it can only remove fields, never add one, so an operator
+%% cannot use it to widen the surface. Leave a method unset to accept the
+%% backend's full default set. The value is a comma-separated list of field
+%% names. Example:
+%%   aws.auth_validation.allowed_fields.ldap = servers,port,user_dn,password_arn
+%% Unknown method names are rejected at translation time (see below); an
+%% unknown field name is not an error, it simply never matches during the
+%% runtime intersection.
+{mapping, "aws.auth_validation.allowed_fields.$method", "aws.auth_validation_allowed_fields",
+    [{datatype, string}]}.
+
+{translation, "aws.auth_validation_allowed_fields",
+ fun(Conf) ->
+     Valid = [<<"ldap">>, <<"http">>, <<"oauth">>, <<"tls">>],
+     Settings = cuttlefish_variable:filter_by_prefix("aws.auth_validation.allowed_fields", Conf),
+     [
+         begin
+             Method = list_to_binary(lists:last(Key)),
+             lists:member(Method, Valid) orelse
+                 cuttlefish:invalid(
+                     "aws.auth_validation.allowed_fields.~s: unknown method "
+                     "(valid methods: ldap, http, oauth, tls)",
+                     [Method]
+                 ),
+             Fields = [
+                 list_to_binary(string:trim(F))
+                 || F <- string:tokens(Value, ","), string:trim(F) =/= ""
+             ],
+             {Method, Fields}
+         end
+         || {Key, Value} <- Settings
+     ]
+ end}.
+
 %% Note: none of the settings below declare a schema {default, ...}. A
 %% defaulted mapping is emitted into every generated config, which breaks
 %% config_schema_SUITE's exact-match snippets. Effective defaults are

--- a/src/aws_auth_validate_registry.erl
+++ b/src/aws_auth_validate_registry.erl
@@ -41,17 +41,16 @@ lookup_backend(<<"tls">>) ->
 lookup_backend(_) ->
     {error, unknown_method}.
 
-%% The override narrows a method's allowed fields; it can never widen them,
-%% because every entry is intersected with the backend's own list.
-%%
-%% Keyed the same way as auth_validation_enabled_methods below: a single atom
-%% key holding a [{Method, Fields}] list. application:get_env/2 requires an
-%% atom parameter name, so a per-method key cannot be a {atom(), binary()}
-%% tuple.
+%% The operator override can only ever narrow BaseFields: every entry is kept
+%% only if it is already in the backend's own allowed_fields/0, so an unknown or
+%% widening entry is silently dropped by the intersection. The app env holds a
+%% [{Method, Fields}] list keyed by an atom, read the same way as
+%% auth_validation_enabled_methods below; the schema translation is the only
+%% supported way to populate it (aws.auth_validation.allowed_fields.$method).
 -spec effective_allowed_fields(module(), binary()) -> [binary()].
 effective_allowed_fields(Module, Method) ->
     BaseFields = Module:allowed_fields(),
-    case application:get_env(aws, auth_validation_allowed_fields_override) of
+    case application:get_env(aws, auth_validation_allowed_fields) of
         {ok, Overrides} when is_list(Overrides) ->
             case lists:keyfind(Method, 1, Overrides) of
                 {_, Override} when is_list(Override) ->

--- a/test/aws_auth_validate_tests.erl
+++ b/test/aws_auth_validate_tests.erl
@@ -97,21 +97,32 @@ registry_field_filter_override_test_() ->
         fun() ->
             application:set_env(
                 aws,
-                auth_validation_allowed_fields_override,
+                auth_validation_allowed_fields,
                 [{<<"ldap">>, [<<"servers">>, <<"port">>, <<"unknown">>]}]
             )
         end,
         fun(_) ->
-            application:unset_env(aws, auth_validation_allowed_fields_override)
+            application:unset_env(aws, auth_validation_allowed_fields)
         end,
         [
             fun() ->
+                %% ldap has an override: narrowed to the listed fields, and the
+                %% unknown entry is dropped by the intersection.
                 Effective = aws_auth_validate_registry:effective_allowed_fields(
                     aws_auth_validate_ldap, <<"ldap">>
                 ),
                 ?assert(lists:member(<<"servers">>, Effective)),
                 ?assert(lists:member(<<"port">>, Effective)),
-                ?assertNot(lists:member(<<"unknown">>, Effective))
+                ?assertNot(lists:member(<<"unknown">>, Effective)),
+                ?assertNot(lists:member(<<"user_dn">>, Effective))
+            end,
+            fun() ->
+                %% http has no entry in the override list, so it keeps the
+                %% backend's full default set.
+                Effective = aws_auth_validate_registry:effective_allowed_fields(
+                    aws_auth_validate_http, <<"http">>
+                ),
+                ?assertEqual(aws_auth_validate_http:allowed_fields(), Effective)
             end
         ]}.
 

--- a/test/config_schema_SUITE_data/aws.snippets
+++ b/test/config_schema_SUITE_data/aws.snippets
@@ -430,5 +430,10 @@
     {aws_auth_validation_enabled_methods,
         "aws.auth_validation.enabled_methods.ldap = true",
         [{aws, [{auth_validation_enabled_methods, [{<<"ldap">>, true}]}]}],
-        [aws_auth_validation_enabled_methods]}
+        [aws_auth_validation_enabled_methods]},
+
+    {aws_auth_validation_allowed_fields,
+        "aws.auth_validation.allowed_fields.ldap = servers,port,password_arn",
+        [{aws, [{auth_validation_allowed_fields, [{<<"ldap">>, [<<"servers">>, <<"port">>, <<"password_arn">>]}]}]}],
+        [aws_auth_validation_allowed_fields]}
 ].


### PR DESCRIPTION
Resolves #180 with option 2 (finish it): makes the per-method field allowlist a real operator-facing control.

Lands after #179 (`fix/dialyzer-warnings-and-ci`)

## Changes
- **`priv/schema/aws.schema`**: add `aws.auth_validation.allowed_fields.$method` mapping + translation, emitting the `[{Method, Fields}]` list into `auth_validation_allowed_fields_override` (mirrors `enabled_methods`). Unknown method names are rejected at config-generation time via `cuttlefish:invalid/2`, so a typo fails the boot instead of silently producing a never-matching override.
- **Tests**: extend the override unit test (add an un-listed-method case) and add a `config_schema` snippet.
- **`AUTH_VALIDATION.md`**: document the new key.

Narrow-only intersection semantics are unchanged: the override can only remove fields, never widen.

## Verification
- `ct-config_schema`: pass
- `eunit` (`aws_auth_validate_tests`): 183/183 pass
- Unknown-method rejection confirmed against the compiled schema
- `erlfmt -c`: clean
