### PR TITLE
Add optional credentialed-probe mode to HTTP auth validation

### DIFF
--- a/AUTH_VALIDATION.md
+++ b/AUTH_VALIDATION.md
@@ -15,7 +15,9 @@ The `:method` path segment selects the backend to validate. Supported methods:
 - `ldap` - LDAP simple bind, optional StartTLS, optional post-bind DN lookup and
   authorization-query checks (mirrors `rabbitmq_auth_backend_ldap`).
 - `http` - HTTP auth backend reachability, including mTLS (client
-  certificate/key) to the auth service.
+  certificate/key) to the auth service. Optionally accepts `username` and
+  `password_arn` for a credentialed probe that asserts `user_path` returns
+  `allow` for the supplied credentials (see below).
 - `oauth` - OAuth2/OIDC: JWKS reachability and, when an access token is
   supplied, signature and `exp`/`aud` verification plus optional
   scope/authorization evaluation. `nbf` is deliberately not checked, matching
@@ -129,7 +131,9 @@ aws.arns.assume_role_arn = arn:aws:iam::111122223333:role/rabbitmq-auth-validati
 
 Without it, requests to those two methods fail with 422 `config_conflict` even
 when otherwise correct. The `http` and `oauth` methods need it only when the
-request references ARN-backed TLS material.
+request references ARN-backed TLS material -- with the exception of `http`
+credentialed-probe mode (see below), which always requires it because the
+`password_arn` must be resolved.
 
 Additional tuning keys (each has an effective default applied in code, so the
 key only needs to be set to override it):
@@ -180,6 +184,54 @@ from it return 404 `method_disabled`. Its visibility is hard-coded to the
 `administrator` tag, so lowering `required_user_tag` does not make the tab
 appear for users holding the lowered tag, even though the endpoint accepts
 their requests.
+
+## HTTP method: credentialed-probe mode
+
+By default the `http` method operates in reachability-only mode: it confirms
+each configured `*_path` is reachable and speaks the auth protocol (an allow or
+deny response), using a synthetic probe principal. A `deny` for the probe is a
+success -- it proves the endpoint is an auth backend.
+
+When both `username` and `password_arn` are supplied in the request body, the
+method switches to **credentialed-probe mode**:
+
+```json
+{
+  "user_path": "https://auth.example.com/auth/user",
+  "username": "alice",
+  "password_arn": "arn:aws:secretsmanager:us-east-1:111122223333:secret:rabbit-pw",
+  "http_method": "post"
+}
+```
+
+In credentialed mode the `user_path` probe sends the real username and resolved
+password (matching `rabbit_auth_backend_http`'s user-check request shape) and
+**asserts the response is `allow`**. A `deny` from the auth server means the
+credential was rejected -- reported as 422 `auth_failed` with the reason "HTTP
+auth server denied the supplied credentials". Other configured paths
+(`vhost_path`, `resource_path`, `topic_path`) remain reachability-only even
+when credentials are supplied.
+
+### Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `username` | string | No* | The username to authenticate. |
+| `password_arn` | string | No* | A Secrets Manager ARN referencing the password. |
+
+*Both must be supplied together or both omitted. Supplying only one returns 400
+`input_invalid` with "username and password_arn must be supplied together".
+
+### Requirements
+
+- A configured `aws.arns.assume_role_arn` is **mandatory** when `password_arn`
+  is supplied, regardless of whether `ssl_options` references any TLS-material
+  ARNs. Without it, the request returns 422 `config_conflict`.
+- The password is supplied by ARN reference only (never inline) -- the resolved
+  secret is fetched server-side under the operator's configured role.
+- The resolved password is never logged, returned in any response, or exposed
+  in crash reports.
+- Reachability-only mode is completely unchanged when credentials are omitted.
 
 ## Metrics
 

--- a/src/aws_auth_validate_http.erl
+++ b/src/aws_auth_validate_http.erl
@@ -296,46 +296,25 @@ validate(Body) when is_map(Body) ->
 %% into Params. Runs after all pure input validation has passed, so a malformed
 %% request never triggers an STS AssumeRole call (ARN-first ordering).
 %%
-%% Mirrors the LDAP backend's guardrail (resolve_request_state/1 there): when the
-%% request resolves ANY ARN, a configured `aws.arns.assume_role_arn' is
-%% MANDATORY. We assume that role -- the SAME role the plugin already assumes at
-%% boot to resolve every configured ARN (aws_arn_config:maybe_assume_role/1) --
-%% into a request-local aws_lib state and resolve the TLS-material ARNs under it.
-%% This is operator config, not caller input, so it raises no confused-deputy
-%% concern.
-%%
-%% When NO role is configured we do NOT fall back to a default aws_lib state:
-%% that would resolve ARNs with the broker's ambient (EC2 instance) credentials,
-%% which on Amazon MQ can be far more privileged than the role a customer would
-%% attach to their own secret/bucket, so a validate request could resolve ARNs
-%% the caller's intended role never could -- a least-privilege pitfall. We never
-%% use the instance role: with an ARN referenced and no assume_role configured,
-%% refuse with config_conflict before any secret fetch or outbound connection.
-%%
-%% For the credentialed mode (username + password_arn): the password_arn will be
+%% Delegates to the shared aws_auth_validate_ssl:resolve_request_state/2 for both
+%% modes. In credentialed mode (username + password_arn) the password_arn will be
 %% resolved under the assumed role, so an assume_role_arn is MANDATORY regardless
-%% of whether TLS material ARNs are also referenced. This matches the LDAP
-%% backend where password_arn always forces the role. For reachability-only mode,
-%% the behaviour is unchanged: ARNs are only required when TLS material is
-%% referenced.
+%% of whether TLS material ARNs are also referenced -- the `force_assume_role'
+%% flag in the opts map achieves this by skipping the request_references_arn check
+%% and always requiring the configured role.
 %%
-%% Delegates to the shared aws_auth_validate_ssl helper for reachability mode.
-%% The no-ARN branch there stores the `none' credential sentinel (which
-%% resolve_arn/2 refuses), matching the fail-closed contract PR #116 introduced
-%% -- a customer request can never resolve an ARN under the broker's ambient EC2
-%% instance role.
+%% For reachability-only mode the behaviour is unchanged: the shared helper checks
+%% whether any ARN key is present in ssl_options before requiring a role. The
+%% no-ARN branch stores the `none' credential sentinel (which resolve_arn/2
+%% refuses), matching the fail-closed contract PR #116 introduced -- a customer
+%% request can never resolve an ARN under the broker's ambient EC2 instance role.
 resolve_request_state(#{credential_mode := credentialed} = Params) ->
     %% Credentialed mode resolves password_arn, so assume_role is mandatory
-    %% regardless of whether TLS material ARNs are also referenced.
-    case aws_auth_validate_ssl:configured_assume_role_arn() of
-        none ->
-            {error, config_conflict, ?REASON_NO_ASSUME_ROLE};
-        RoleArn ->
-            case aws_iam:assume_role(RoleArn, aws_lib:new()) of
-                {ok, State} -> {ok, Params#{aws_state => State}};
-                {error, _} -> {error, input_invalid, ?REASON_ASSUME_ROLE}
-            end
-    end;
+    %% regardless of whether TLS material ARNs are also referenced. The shared
+    %% helper's force_assume_role flag skips the request_references_arn check and
+    %% always requires/assumes the configured role.
+    Opts = (ssl_opts())#{force_assume_role => true},
+    aws_auth_validate_ssl:resolve_request_state(Params, Opts);
 resolve_request_state(Params) ->
     aws_auth_validate_ssl:resolve_request_state(Params, ssl_opts()).
 
@@ -600,7 +579,18 @@ probe_one(Key, Url, Params, SslOpts, Profile) ->
         {ok, PinnedUrl, Host} ->
             UrlStr = maps:get(url_string, PinnedUrl),
             {Query, Classifier} = probe_query_and_classifier(Key, Params),
-            Request = build_request(Method, UrlStr, Query, Host),
+            %% Force POST for credentialed probes: a GET would append the
+            %% resolved password to the URL query string, leaking it into auth
+            %% server access logs and any intermediate proxy/LB logs. POST puts
+            %% credentials in the request body where they are not logged by
+            %% standard infrastructure. Reachability probes use whatever method
+            %% the operator configured (default GET) -- they carry no secret.
+            EffectiveMethod =
+                case maps:get(credential_mode, Params, reachability) of
+                    credentialed -> post;
+                    _ -> Method
+                end,
+            Request = build_request(EffectiveMethod, UrlStr, Query, Host),
             HttpOpts =
                 [
                     {timeout, Timeout},
@@ -610,7 +600,9 @@ probe_one(Key, Url, Params, SslOpts, Profile) ->
                     %% do not re-vet the Location target).
                     {autoredirect, false}
                 ] ++ ssl_http_opt(Url, Host, SslOpts),
-            case httpc:request(Method, Request, HttpOpts, [{body_format, binary}], Profile) of
+            case
+                httpc:request(EffectiveMethod, Request, HttpOpts, [{body_format, binary}], Profile)
+            of
                 {ok, {{_Vsn, Code, _Phrase}, _Headers, Body}} ->
                     case lists:member(Code, ?AUTH_RESPONSE_CODES) of
                         %% A usable status is necessary but not sufficient: the
@@ -641,11 +633,13 @@ probe_query_and_classifier(Key, _Params) ->
 
 %% Build the query string for a credentialed user_path probe, matching the
 %% fields rabbit_auth_backend_http sends for a user check (username + password).
+%% Uses rabbit_http_util:quote_plus/1 -- the same encoder the real backend uses
+%% in rabbit_auth_backend_http:q/1 -- to ensure byte-for-byte encoding parity.
+%% uri_string:compose_query would re-encode non-ASCII bytes as UTF-8 codepoints
+%% (double-encoding), producing different percent-sequences for multi-byte chars.
 credentialed_query_for(#{username := Username, password := Password}) ->
-    uri_string:compose_query([
-        {"username", binary_to_list(Username)},
-        {"password", binary_to_list(Password)}
-    ]).
+    "username=" ++ rabbit_http_util:quote_plus(Username) ++
+        "&password=" ++ rabbit_http_util:quote_plus(Password).
 
 %% Map an httpc transport error to a fixed category (shared classifier). A
 %% TLS/cert failure -> tls_failed; everything else -> connection_failed. The raw
@@ -689,13 +683,21 @@ classify_response(Key, Body) ->
 
 %% In credentialed mode, only `allow' is success. A well-formed `deny' means
 %% the credential was rejected -- the operator expected it to work, so this is
-%% auth_failed. A non-auth-shaped body is also auth_failed (same as a deny: the
-%% server did not grant access for the supplied credentials).
+%% auth_failed with REASON_AUTH_DENIED. A body matching NEITHER allow NOR deny
+%% means the endpoint is not an auth server at all -- report REASON_ENDPOINT (the
+%% same distinction the reachability classifier makes), so the operator is not
+%% misled into thinking their credentials are wrong when the path simply points at
+%% the wrong endpoint.
 classify_credentialed_response(Body) ->
     Normalized = normalize_resp(Body),
     case is_keyword_prefix(<<"allow">>, Normalized) of
-        true -> ok;
-        false -> {error, auth_failed, ?REASON_AUTH_DENIED}
+        true ->
+            ok;
+        false ->
+            case is_keyword_prefix(<<"deny">>, Normalized) of
+                true -> {error, auth_failed, ?REASON_AUTH_DENIED};
+                false -> {error, auth_failed, ?REASON_ENDPOINT}
+            end
     end.
 
 %% Normalize exactly as rabbit_auth_backend_http does: strip leading/trailing

--- a/src/aws_auth_validate_http.erl
+++ b/src/aws_auth_validate_http.erl
@@ -26,22 +26,17 @@
 %% section below); that complexity is the price of fidelity, not an arbitrary
 %% choice.
 %%
-%% Scope: REACHABILITY-ONLY (deliberate first cut). An HTTP auth server, by
-%% contract, answers `allow'/`deny' for a specific {user, vhost, resource}
-%% tuple -- a `deny' is a correctly-working server, not a misconfiguration. So
-%% we do NOT assert that any particular principal is authorized. Instead we
-%% confirm each configured `*_path' is reachable over (m)TLS and answers like
-%% an auth server -- a usable HTTP status (200/201) AND a body matching
-%% rabbit_auth_backend_http's allow/deny grammar. That catches the actual pain
-%% (wrong URL, TLS/CA misconfig, unreachable host, path pointing at a service
-%% that is not an auth backend) without needing a real test credential or an
-%% authz-semantics judgement. We check the SHAPE of the response, not its
-%% verdict: a `deny' for our synthetic probe principal is a success, since a
-%% well-formed deny still proves the endpoint speaks the auth protocol.
-%%
-%% A future credentialed-probe mode (assert user_path returns `allow' for a
-%% supplied username + password_arn) is intentionally out of scope for this
-%% initial reachability-only implementation.
+%% Two modes:
+%%   * Reachability-only (default, no credentials supplied): confirms each
+%%     configured *_path is reachable over (m)TLS and answers like an auth
+%%     server -- a usable HTTP status (200/201) AND a body matching
+%%     rabbit_auth_backend_http's allow/deny grammar. A deny for the synthetic
+%%     probe principal is a success, since a well-formed deny still proves the
+%%     endpoint speaks the auth protocol.
+%%   * Credentialed-probe (username + password_arn supplied): resolves the ARN,
+%%     probes user_path with the real credentials, and asserts the response is
+%%     allow. A deny becomes auth_failed (422). Other paths remain
+%%     reachability-only.
 %%
 %% Category mapping (reuses the existing aws_auth_validate_backend categories;
 %% no new category is introduced -- the fixed set is kept small so responses
@@ -81,7 +76,10 @@
     is_tls_error/1,
     classify_response/2,
     query_for/1,
-    params_for/1
+    params_for/1,
+    credentialed_query_for/1,
+    classify_credentialed_response/1,
+    parse_credentials/2
 ]).
 -endif.
 
@@ -165,6 +163,10 @@
     "auth validation requires an assume_role to be configured; "
     "set aws.arns.assume_role_arn"
 >>).
+-define(REASON_CREDENTIAL_INCOMPLETE,
+    <<"username and password_arn must be supplied together">>
+).
+-define(REASON_AUTH_DENIED, <<"HTTP auth server denied the supplied credentials">>).
 
 %% HTTP status codes rabbit_auth_backend_http treats as a usable auth response
 %% (it accepts 200 and 201). We accept the same set as "the endpoint answered
@@ -261,7 +263,9 @@ allowed_fields() ->
         <<"resource_path">>,
         <<"topic_path">>,
         <<"http_method">>,
-        <<"ssl_options">>
+        <<"ssl_options">>,
+        <<"username">>,
+        <<"password_arn">>
     ].
 
 -spec validate(map()) -> aws_auth_validate_backend:result().
@@ -277,15 +281,20 @@ validate(Body) when is_map(Body) ->
             Err;
         {ok, Params} ->
             case resolve_request_state(Params) of
-                {error, _, _} = Err -> Err;
-                {ok, Params1} -> do_http_validate(Params1)
+                {error, _, _} = Err ->
+                    Err;
+                {ok, Params1} ->
+                    case resolve_credential(Params1) of
+                        {error, _, _} = Err -> Err;
+                        {ok, Params2} -> do_http_validate(Params2)
+                    end
             end
     end.
 
 %% Build the per-request aws_lib state used for every ARN fetch in this request
-%% (cacertfile_arn / certfile_arn / keyfile_arn), and thread it into Params.
-%% Runs after all pure input validation has passed, so a malformed request never
-%% triggers an STS AssumeRole call (ARN-first ordering).
+%% (cacertfile_arn / certfile_arn / keyfile_arn / password_arn), and thread it
+%% into Params. Runs after all pure input validation has passed, so a malformed
+%% request never triggers an STS AssumeRole call (ARN-first ordering).
 %%
 %% Mirrors the LDAP backend's guardrail (resolve_request_state/1 there): when the
 %% request resolves ANY ARN, a configured `aws.arns.assume_role_arn' is
@@ -303,17 +312,49 @@ validate(Body) when is_map(Body) ->
 %% use the instance role: with an ARN referenced and no assume_role configured,
 %% refuse with config_conflict before any secret fetch or outbound connection.
 %%
-%% Unlike LDAP (where password_arn is mandatory, so every request resolves an
-%% ARN), the HTTP backend resolves ARNs only when the request supplies TLS
-%% material. A plain reachability / (m)TLS probe that references no ARN performs
-%% no AWS call, so it needs no role and gets a default state that is never used
-%% to resolve an ARN -- preserving the credential-free reachability check.
-%% Delegates to the shared aws_auth_validate_ssl helper. The no-ARN branch there
-%% stores the `none' credential sentinel (which resolve_arn/2 refuses), matching
-%% the fail-closed contract PR #116 introduced -- a customer request can never
-%% resolve an ARN under the broker's ambient EC2 instance role.
+%% For the credentialed mode (username + password_arn): the password_arn will be
+%% resolved under the assumed role, so an assume_role_arn is MANDATORY regardless
+%% of whether TLS material ARNs are also referenced. This matches the LDAP
+%% backend where password_arn always forces the role. For reachability-only mode,
+%% the behaviour is unchanged: ARNs are only required when TLS material is
+%% referenced.
+%%
+%% Delegates to the shared aws_auth_validate_ssl helper for reachability mode.
+%% The no-ARN branch there stores the `none' credential sentinel (which
+%% resolve_arn/2 refuses), matching the fail-closed contract PR #116 introduced
+%% -- a customer request can never resolve an ARN under the broker's ambient EC2
+%% instance role.
+resolve_request_state(#{credential_mode := credentialed} = Params) ->
+    %% Credentialed mode resolves password_arn, so assume_role is mandatory
+    %% regardless of whether TLS material ARNs are also referenced.
+    case aws_auth_validate_ssl:configured_assume_role_arn() of
+        none ->
+            {error, config_conflict, ?REASON_NO_ASSUME_ROLE};
+        RoleArn ->
+            case aws_iam:assume_role(RoleArn, aws_lib:new()) of
+                {ok, State} -> {ok, Params#{aws_state => State}};
+                {error, _} -> {error, input_invalid, ?REASON_ASSUME_ROLE}
+            end
+    end;
 resolve_request_state(Params) ->
     aws_auth_validate_ssl:resolve_request_state(Params, ssl_opts()).
+
+%% Resolve the password ARN for credentialed mode. Runs after
+%% resolve_request_state/1 (which established the aws_state under the
+%% configured assume_role), so the secret is fetched under the operator's
+%% role -- not the broker's ambient instance credentials. The resolved
+%% password is stored in the params map and never logged or returned.
+resolve_credential(#{credential_mode := reachability} = Params) ->
+    {ok, Params};
+resolve_credential(
+    #{credential_mode := credentialed, password_arn := Arn, aws_state := State} = Params
+) ->
+    case aws_auth_validate_ssl:resolve_arn(Arn, State) of
+        {ok, Password} ->
+            {ok, Params#{password => Password}};
+        {error, _} ->
+            {error, input_invalid, aws_auth_validate_ssl:arn_resolve_reason([<<"password_arn">>])}
+    end.
 
 %%--------------------------------------------------------------------
 %% Input parsing (pure, no network)
@@ -322,6 +363,7 @@ resolve_request_state(Params) ->
 parse_input(Body) ->
     Steps = [
         fun parse_paths/2,
+        fun parse_credentials/2,
         fun parse_http_method/2,
         fun parse_ssl_options/2,
         %% SSRF guard runs in the pure phase so a disallowed target is rejected
@@ -364,6 +406,29 @@ collect_paths([Key | Rest], Body, Acc, Paths) ->
             end;
         _ ->
             {error, input_invalid, ?REASON_BAD_PATH_VALUE}
+    end.
+
+%% Credential-mode parsing: determines whether this request is a reachability-
+%% only probe (the default) or a credentialed probe (username + password_arn).
+%% Both-or-neither enforcement: supplying only one of the pair is input_invalid.
+parse_credentials(Body, Acc) ->
+    Username = maps:get(<<"username">>, Body, undefined),
+    PasswordArn = maps:get(<<"password_arn">>, Body, undefined),
+    HasUser = aws_auth_validate_ssl:is_nonempty_binary(Username),
+    HasArn = aws_auth_validate_ssl:is_nonempty_binary(PasswordArn),
+    case {HasUser, HasArn} of
+        {false, false} ->
+            %% Neither supplied: reachability-only mode (the default path).
+            {ok, Acc#{credential_mode => reachability}};
+        {true, true} ->
+            %% Both supplied: credentialed-probe mode.
+            {ok, Acc#{
+                credential_mode => credentialed, username => Username, password_arn => PasswordArn
+            }};
+        _ ->
+            %% Only one of the pair is present (or one is present but not a
+            %% non-empty binary): reject.
+            {error, input_invalid, ?REASON_CREDENTIAL_INCOMPLETE}
     end.
 
 %% Parse + minimally validate an http(s) URL via the shared
@@ -523,7 +588,8 @@ probe_paths([{Key, Url} | Rest], Params, SslOpts, Profile) ->
         {error, _, _} = Err -> Err
     end.
 
-probe_one(Key, Url, #{http_method := Method, timeout := Timeout}, SslOpts, Profile) ->
+probe_one(Key, Url, Params, SslOpts, Profile) ->
+    #{http_method := Method, timeout := Timeout} = Params,
     %% Resolve the host and classify every resolved address against the infra
     %% denylist BEFORE connecting, then connect to the pinned IP so httpc cannot
     %% re-resolve to a different (possibly denied) address (DNS-rebinding /
@@ -533,7 +599,7 @@ probe_one(Key, Url, #{http_method := Method, timeout := Timeout}, SslOpts, Profi
             Err;
         {ok, PinnedUrl, Host} ->
             UrlStr = maps:get(url_string, PinnedUrl),
-            Query = query_for(Key),
+            {Query, Classifier} = probe_query_and_classifier(Key, Params),
             Request = build_request(Method, UrlStr, Query, Host),
             HttpOpts =
                 [
@@ -552,13 +618,34 @@ probe_one(Key, Url, #{http_method := Method, timeout := Timeout}, SslOpts, Profi
                         %% allow/deny grammar, or any 200-returning service
                         %% (health check, HTML page, proxy) would pass as an
                         %% auth backend. See classify_response/2.
-                        true -> classify_response(Key, Body);
+                        true -> Classifier(Body);
                         false -> {error, auth_failed, ?REASON_ENDPOINT}
                     end;
                 {error, Reason} ->
                     classify_http_error(Reason)
             end
     end.
+
+%% Choose the query parameters and the response classifier for a given path.
+%% In credentialed mode on user_path, use the real credentials and require
+%% allow; in all other cases use the existing reachability query and contract
+%% check. Separating this decision from the probe keeps probe_one/5 generic.
+probe_query_and_classifier(<<"user_path">>, #{credential_mode := credentialed} = Params) ->
+    Query = credentialed_query_for(Params),
+    Classifier = fun classify_credentialed_response/1,
+    {Query, Classifier};
+probe_query_and_classifier(Key, _Params) ->
+    Query = query_for(Key),
+    Classifier = fun(Body) -> classify_response(Key, Body) end,
+    {Query, Classifier}.
+
+%% Build the query string for a credentialed user_path probe, matching the
+%% fields rabbit_auth_backend_http sends for a user check (username + password).
+credentialed_query_for(#{username := Username, password := Password}) ->
+    uri_string:compose_query([
+        {"username", binary_to_list(Username)},
+        {"password", binary_to_list(Password)}
+    ]).
 
 %% Map an httpc transport error to a fixed category (shared classifier). A
 %% TLS/cert failure -> tls_failed; everything else -> connection_failed. The raw
@@ -598,6 +685,17 @@ classify_response(Key, Body) ->
     case response_matches_contract(Key, normalize_resp(Body)) of
         true -> ok;
         false -> {error, auth_failed, ?REASON_ENDPOINT}
+    end.
+
+%% In credentialed mode, only `allow' is success. A well-formed `deny' means
+%% the credential was rejected -- the operator expected it to work, so this is
+%% auth_failed. A non-auth-shaped body is also auth_failed (same as a deny: the
+%% server did not grant access for the supplied credentials).
+classify_credentialed_response(Body) ->
+    Normalized = normalize_resp(Body),
+    case is_keyword_prefix(<<"allow">>, Normalized) of
+        true -> ok;
+        false -> {error, auth_failed, ?REASON_AUTH_DENIED}
     end.
 
 %% Normalize exactly as rabbit_auth_backend_http does: strip leading/trailing
@@ -727,11 +825,12 @@ params_for(<<"topic_path">>) ->
 %% (aws_auth_validate_ssl); only the SNI key spelling (<<"sni">>) is
 %% backend-specific.
 build_client_ssl_opts(#{ssl_options := Map} = Params) ->
-    %% every ARN fetch here. A request that references no ARN carries the `none'
-    %% sentinel, which the shared resolve_arn/2 refuses -- so even if an ARN fetch
-    %% were reached on that path it fails closed instead of falling back to the
-    %% instance role. Default to `none' (never a usable state) if the key is
-    %% somehow absent, preserving the fail-closed contract.
+    %% State is used for every ARN fetch in this function. A request that
+    %% references no ARN carries the `none' sentinel, which the shared
+    %% resolve_arn/2 refuses -- so even if an ARN fetch were reached on that
+    %% path it fails closed instead of falling back to the instance role.
+    %% Default to `none' (never a usable state) if the key is somehow absent,
+    %% preserving the fail-closed contract.
     State = maps:get(aws_state, Params, none),
     %% Resolves the CA bundle and the mTLS pair together so a response can name
     %% every ARN field that failed, not just the first.

--- a/src/aws_auth_validate_ssl.erl
+++ b/src/aws_auth_validate_ssl.erl
@@ -102,12 +102,17 @@
 %%   reasons    :: map()      -- backend-specific fixed reason binaries, keyed by
 %%                 the atoms below (so each backend keeps its own fixed-response
 %%                 wording). See reason/2.
+%%   force_assume_role :: boolean() -- optional; when true, require/assume the
+%%                 configured role even if the request references no ARN (the
+%%                 http credentialed probe sets this because password_arn always
+%%                 resolves). Defaults to false when absent.
 -type opts() :: #{
     arn_keys := [binary()],
     ssl_option_keys := [binary()],
     sni_key := binary(),
     client_cert := boolean(),
-    reasons := map()
+    reasons := map(),
+    force_assume_role => boolean()
 }.
 
 -export_type([opts/0]).

--- a/src/aws_auth_validate_ssl.erl
+++ b/src/aws_auth_validate_ssl.erl
@@ -148,7 +148,10 @@ configured_assume_role_arn() ->
 -spec resolve_request_state(map(), opts()) ->
     {ok, map()} | {error, aws_auth_validate_backend:error_category(), binary()}.
 resolve_request_state(Params, Opts) ->
-    case request_references_arn(Params, Opts) of
+    MustAssume =
+        maps:get(force_assume_role, Opts, false) orelse
+            request_references_arn(Params, Opts),
+    case MustAssume of
         false ->
             %% No ARN is referenced, so this request resolves nothing and needs
             %% no credentials. Do NOT hand out a usable aws_lib:new() state here:

--- a/test/aws_auth_validate_http_SUITE.erl
+++ b/test/aws_auth_validate_http_SUITE.erl
@@ -58,7 +58,14 @@ groups() ->
             mtls_client_cert_presented_returns_ok,
             mtls_client_cert_missing_returns_tls_failed,
             hostname_pin_preserves_host_ok,
-            hostname_resolving_to_infra_denied
+            hostname_resolving_to_infra_denied,
+            %% Credentialed-probe path integration tests (F4/F5).
+            credentialed_allow_returns_ok,
+            credentialed_deny_returns_auth_denied,
+            credentialed_non_auth_returns_endpoint,
+            credentialed_no_assume_role_returns_config_conflict,
+            credentialed_assume_role_failure_returns_input_invalid,
+            credentialed_password_never_in_error
         ]}
     ].
 
@@ -372,6 +379,155 @@ hostname_resolving_to_infra_denied(_Config) ->
         )
     after
         meck:unload(inet)
+    end.
+
+%%--------------------------------------------------------------------
+%% Credentialed-probe integration tests (F4: end-to-end wiring, F5: guardrails)
+%%--------------------------------------------------------------------
+%%
+%% These exercise the full validate/1 -> probe_query_and_classifier ->
+%% credentialed_query_for -> classify_credentialed_response wiring through the
+%% in-process httpd stub. They mock ARN resolution (aws_arn_util:resolve_arn)
+%% to return a fixed password, since no real Secrets Manager is available, but
+%% the rest of the path -- including the POST override, the response classifier,
+%% and the assume-role guardrails -- runs for real.
+
+credentialed_allow_returns_ok(Config) ->
+    %% Stub returns "allow" on user_path -> credentialed probe should succeed.
+    ok = meck:new(aws_arn_util, [passthrough]),
+    try
+        meck:expect(aws_arn_util, resolve_arn, fun(_Arn, State) ->
+            {ok, <<"test-password">>, State}
+        end),
+        Port = ?config(http_port, Config),
+        Url = iolist_to_binary(["http://127.0.0.1:", integer_to_list(Port), "/ok200"]),
+        Body = #{
+            <<"user_path">> => Url,
+            <<"http_method">> => <<"get">>,
+            <<"username">> => <<"alice">>,
+            <<"password_arn">> => <<"arn:aws:secretsmanager:us-east-1:111:secret:pw">>
+        },
+        ?assertEqual(ok, validate(Body))
+    after
+        meck:unload(aws_arn_util)
+    end.
+
+credentialed_deny_returns_auth_denied(Config) ->
+    %% Stub returns "deny" on user_path -> credentialed probe reports auth_denied.
+    ok = meck:new(aws_arn_util, [passthrough]),
+    try
+        meck:expect(aws_arn_util, resolve_arn, fun(_Arn, State) ->
+            {ok, <<"test-password">>, State}
+        end),
+        Port = ?config(http_port, Config),
+        Url = iolist_to_binary(["http://127.0.0.1:", integer_to_list(Port), "/denyok"]),
+        Body = #{
+            <<"user_path">> => Url,
+            <<"http_method">> => <<"get">>,
+            <<"username">> => <<"alice">>,
+            <<"password_arn">> => <<"arn:aws:secretsmanager:us-east-1:111:secret:pw">>
+        },
+        ?assertEqual(
+            {error, auth_failed, <<"HTTP auth server denied the supplied credentials">>},
+            validate(Body)
+        )
+    after
+        meck:unload(aws_arn_util)
+    end.
+
+credentialed_non_auth_returns_endpoint(Config) ->
+    %% Stub returns non-auth body ("hello") on user_path -> report REASON_ENDPOINT
+    %% (not an auth server), distinct from a credential denial. Tests F3's fix.
+    ok = meck:new(aws_arn_util, [passthrough]),
+    try
+        meck:expect(aws_arn_util, resolve_arn, fun(_Arn, State) ->
+            {ok, <<"test-password">>, State}
+        end),
+        Port = ?config(http_port, Config),
+        Url = iolist_to_binary(["http://127.0.0.1:", integer_to_list(Port), "/notauth"]),
+        Body = #{
+            <<"user_path">> => Url,
+            <<"http_method">> => <<"get">>,
+            <<"username">> => <<"alice">>,
+            <<"password_arn">> => <<"arn:aws:secretsmanager:us-east-1:111:secret:pw">>
+        },
+        ?assertEqual(
+            {error, auth_failed, <<"HTTP auth server did not return a usable response">>},
+            validate(Body)
+        )
+    after
+        meck:unload(aws_arn_util)
+    end.
+
+credentialed_no_assume_role_returns_config_conflict(_Config) ->
+    %% F5: credentialed mode with NO assume_role_arn configured -> config_conflict.
+    %% Temporarily remove the arn_config env (set in init_per_group) and unmeck
+    %% aws_iam so the real code path runs.
+    OldArn = application:get_env(aws, arn_config),
+    application:unset_env(aws, arn_config),
+    try
+        Body = #{
+            <<"user_path">> => <<"http://8.8.8.8/auth">>,
+            <<"http_method">> => <<"get">>,
+            <<"username">> => <<"alice">>,
+            <<"password_arn">> => <<"arn:aws:secretsmanager:us-east-1:111:secret:pw">>
+        },
+        ?assertMatch(
+            {error, config_conflict, _},
+            validate(Body)
+        )
+    after
+        case OldArn of
+            {ok, V} -> application:set_env(aws, arn_config, V);
+            undefined -> ok
+        end
+    end.
+
+credentialed_assume_role_failure_returns_input_invalid(_Config) ->
+    %% F5: assume-role failure -> input_invalid. Temporarily override the aws_iam
+    %% mock to return an error.
+    meck:expect(aws_iam, assume_role, fun(_RoleArn, _State) -> {error, sts_error} end),
+    try
+        Body = #{
+            <<"user_path">> => <<"http://8.8.8.8/auth">>,
+            <<"http_method">> => <<"get">>,
+            <<"username">> => <<"alice">>,
+            <<"password_arn">> => <<"arn:aws:secretsmanager:us-east-1:111:secret:pw">>
+        },
+        ?assertMatch(
+            {error, input_invalid, _},
+            validate(Body)
+        )
+    after
+        %% Restore the success mock for remaining tests.
+        meck:expect(aws_iam, assume_role, fun(_RoleArn, State) -> {ok, State} end)
+    end.
+
+credentialed_password_never_in_error(Config) ->
+    %% F5: the resolved password must NEVER appear in any error tuple returned by
+    %% the validator (security invariant R6). Drive a credentialed request whose
+    %% endpoint returns "deny" (an auth_failed error) and assert the password
+    %% binary does not appear as a substring of the reason.
+    ResolvedPassword = <<"SuperS3cret!P@ssword#123">>,
+    ok = meck:new(aws_arn_util, [passthrough]),
+    try
+        meck:expect(aws_arn_util, resolve_arn, fun(_Arn, State) ->
+            {ok, ResolvedPassword, State}
+        end),
+        Port = ?config(http_port, Config),
+        Url = iolist_to_binary(["http://127.0.0.1:", integer_to_list(Port), "/denyok"]),
+        Body = #{
+            <<"user_path">> => Url,
+            <<"http_method">> => <<"post">>,
+            <<"username">> => <<"alice">>,
+            <<"password_arn">> => <<"arn:aws:secretsmanager:us-east-1:111:secret:pw">>
+        },
+        Result = validate(Body),
+        %% Result is {error, auth_failed, Reason}; assert password not in Reason.
+        {error, _, Reason} = Result,
+        ?assertEqual(nomatch, binary:match(Reason, ResolvedPassword))
+    after
+        meck:unload(aws_arn_util)
     end.
 
 %% Route a resolve_arn call to the right PEM by ARN. The validator passes the

--- a/test/aws_auth_validate_http_credentialed_tests.erl
+++ b/test/aws_auth_validate_http_credentialed_tests.erl
@@ -103,11 +103,20 @@ classify_credentialed_response_deny_with_reason_test() ->
         aws_auth_validate_http:classify_credentialed_response(<<"deny bad password">>)
     ).
 
-%% Non-auth-shaped body -> auth_failed (same as deny -- server did not grant).
+%% Non-auth-shaped body -> auth_failed with REASON_ENDPOINT (not an auth server),
+%% distinct from a well-formed deny (which uses REASON_AUTH_DENIED). This lets the
+%% operator distinguish "wrong endpoint" from "credentials rejected".
 classify_credentialed_response_garbage_test() ->
     ?assertMatch(
-        {error, auth_failed, <<"HTTP auth server denied the supplied credentials">>},
+        {error, auth_failed, <<"HTTP auth server did not return a usable response">>},
         aws_auth_validate_http:classify_credentialed_response(<<"hello">>)
+    ).
+
+%% Empty body -> auth_failed with REASON_ENDPOINT (not an auth server).
+classify_credentialed_response_empty_test() ->
+    ?assertMatch(
+        {error, auth_failed, <<"HTTP auth server did not return a usable response">>},
+        aws_auth_validate_http:classify_credentialed_response(<<>>)
     ).
 
 %%--------------------------------------------------------------------

--- a/test/aws_auth_validate_http_credentialed_tests.erl
+++ b/test/aws_auth_validate_http_credentialed_tests.erl
@@ -127,9 +127,14 @@ credentialed_query_parity_test() ->
 credentialed_query_encoding_test() ->
     Params = #{username => <<"user@host">>, password => <<"p&ss=w0rd">>},
     Query = aws_auth_validate_http:credentialed_query_for(Params),
-    %% The raw characters should NOT appear (they should be percent-encoded)
+    %% The special characters inside the values are percent-encoded: @ -> %40,
+    %% and the password's literal & and = become %26 and %3D. The single
+    %% unencoded `&' separating username= from password= is the legitimate
+    %% parameter delimiter, so we assert on the encoded forms rather than the
+    %% raw characters' total absence.
     ?assertEqual(nomatch, string:find(Query, "@")),
-    ?assertEqual(nomatch, string:find(Query, "&")),
+    ?assertNotEqual(nomatch, string:find(Query, "%40")),
+    ?assertNotEqual(nomatch, string:find(Query, "p%26ss%3Dw0rd")),
     ?assertEqual(nomatch, string:find(Query, "=w0rd")).
 
 %%--------------------------------------------------------------------

--- a/test/aws_auth_validate_http_credentialed_tests.erl
+++ b/test/aws_auth_validate_http_credentialed_tests.erl
@@ -1,0 +1,149 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% Unit tests for the credentialed-probe mode added to aws_auth_validate_http.
+%% Tests cover credential-pair parsing (both-or-neither enforcement), the
+%% credentialed response classifier, query-string shape, and the
+%% no-password-in-error security invariant.
+%%
+%% Tests that exercise the full validate/1 path mock external dependencies
+%% (aws_auth_validate_net, aws_auth_validate_ssl, aws_iam, etc.) to isolate
+%% the parse logic.
+-module(aws_auth_validate_http_credentialed_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%%--------------------------------------------------------------------
+%% parse_credentials/2 tests (exported under -ifdef(TEST))
+%%--------------------------------------------------------------------
+
+%% Both username and password_arn supplied -- credentialed mode.
+parse_credentials_both_present_test() ->
+    Body = #{
+        <<"username">> => <<"alice">>,
+        <<"password_arn">> => <<"arn:aws:secretsmanager:us-east-1:111:secret:pw">>
+    },
+    Acc = #{},
+    {ok, Result} = aws_auth_validate_http:parse_credentials(Body, Acc),
+    ?assertEqual(credentialed, maps:get(credential_mode, Result)),
+    ?assertEqual(<<"alice">>, maps:get(username, Result)),
+    ?assertEqual(
+        <<"arn:aws:secretsmanager:us-east-1:111:secret:pw">>,
+        maps:get(password_arn, Result)
+    ).
+
+%% Neither username nor password_arn supplied -- reachability mode.
+parse_credentials_neither_present_test() ->
+    Body = #{<<"user_path">> => <<"https://8.8.8.8/auth">>},
+    Acc = #{},
+    {ok, Result} = aws_auth_validate_http:parse_credentials(Body, Acc),
+    ?assertEqual(reachability, maps:get(credential_mode, Result)).
+
+%% Only username supplied -- input_invalid.
+parse_credentials_only_username_test() ->
+    Body = #{<<"username">> => <<"alice">>},
+    Acc = #{},
+    ?assertMatch(
+        {error, input_invalid, <<"username and password_arn must be supplied together">>},
+        aws_auth_validate_http:parse_credentials(Body, Acc)
+    ).
+
+%% Only password_arn supplied -- input_invalid.
+parse_credentials_only_password_arn_test() ->
+    Body = #{<<"password_arn">> => <<"arn:aws:secretsmanager:us-east-1:111:secret:pw">>},
+    Acc = #{},
+    ?assertMatch(
+        {error, input_invalid, <<"username and password_arn must be supplied together">>},
+        aws_auth_validate_http:parse_credentials(Body, Acc)
+    ).
+
+%% Empty binary username with valid password_arn -- input_invalid.
+parse_credentials_empty_username_test() ->
+    Body = #{
+        <<"username">> => <<>>,
+        <<"password_arn">> => <<"arn:aws:secretsmanager:us-east-1:111:secret:pw">>
+    },
+    Acc = #{},
+    ?assertMatch(
+        {error, input_invalid, <<"username and password_arn must be supplied together">>},
+        aws_auth_validate_http:parse_credentials(Body, Acc)
+    ).
+
+%%--------------------------------------------------------------------
+%% classify_credentialed_response/1 tests
+%%--------------------------------------------------------------------
+
+%% "allow" body -> ok.
+classify_credentialed_response_allow_test() ->
+    ?assertEqual(ok, aws_auth_validate_http:classify_credentialed_response(<<"allow">>)).
+
+%% "allow administrator" (allow with tags) -> ok.
+classify_credentialed_response_allow_tags_test() ->
+    ?assertEqual(
+        ok, aws_auth_validate_http:classify_credentialed_response(<<"allow administrator">>)
+    ).
+
+%% "Allow" (mixed case) -> ok (normalize lowercases).
+classify_credentialed_response_allow_uppercase_test() ->
+    ?assertEqual(ok, aws_auth_validate_http:classify_credentialed_response(<<"Allow">>)).
+
+%% "deny" body -> auth_failed.
+classify_credentialed_response_deny_test() ->
+    ?assertMatch(
+        {error, auth_failed, <<"HTTP auth server denied the supplied credentials">>},
+        aws_auth_validate_http:classify_credentialed_response(<<"deny">>)
+    ).
+
+%% "deny bad password" body -> auth_failed.
+classify_credentialed_response_deny_with_reason_test() ->
+    ?assertMatch(
+        {error, auth_failed, _},
+        aws_auth_validate_http:classify_credentialed_response(<<"deny bad password">>)
+    ).
+
+%% Non-auth-shaped body -> auth_failed (same as deny -- server did not grant).
+classify_credentialed_response_garbage_test() ->
+    ?assertMatch(
+        {error, auth_failed, <<"HTTP auth server denied the supplied credentials">>},
+        aws_auth_validate_http:classify_credentialed_response(<<"hello">>)
+    ).
+
+%%--------------------------------------------------------------------
+%% credentialed_query_for/1 tests
+%%--------------------------------------------------------------------
+
+%% Query contains username= and password= (matching rabbit_auth_backend_http's
+%% user check). The query parameters are URI-encoded.
+credentialed_query_parity_test() ->
+    Params = #{username => <<"alice">>, password => <<"s3cr3t">>},
+    Query = aws_auth_validate_http:credentialed_query_for(Params),
+    %% Must contain both fields
+    ?assertNotEqual(nomatch, string:find(Query, "username=alice")),
+    ?assertNotEqual(nomatch, string:find(Query, "password=s3cr3t")).
+
+%% Verify special characters are properly encoded in the query.
+credentialed_query_encoding_test() ->
+    Params = #{username => <<"user@host">>, password => <<"p&ss=w0rd">>},
+    Query = aws_auth_validate_http:credentialed_query_for(Params),
+    %% The raw characters should NOT appear (they should be percent-encoded)
+    ?assertEqual(nomatch, string:find(Query, "@")),
+    ?assertEqual(nomatch, string:find(Query, "&")),
+    ?assertEqual(nomatch, string:find(Query, "=w0rd")).
+
+%%--------------------------------------------------------------------
+%% Security: password never appears in error tuples
+%%--------------------------------------------------------------------
+
+%% When resolve_credential fails (e.g. ARN resolution error), the error tuple
+%% must not contain the resolved password value.
+password_never_in_error_test() ->
+    %% The ARN-resolve reason is fixed and field-attributed; it never contains
+    %% the resolved content. Verify the reason string names the field, not a
+    %% password value.
+    Reason = aws_auth_validate_ssl:arn_resolve_reason([<<"password_arn">>]),
+    ?assertNotEqual(nomatch, string:find(Reason, "password_arn")),
+    %% A hypothetical resolved password should never appear in this reason:
+    ?assertEqual(nomatch, string:find(Reason, "s3cr3t")),
+    ?assertEqual(nomatch, string:find(Reason, "secret")).

--- a/test/aws_auth_validate_http_parity_tests.erl
+++ b/test/aws_auth_validate_http_parity_tests.erl
@@ -114,6 +114,39 @@ query_encoding_special_chars_test_() ->
     end.
 
 %%--------------------------------------------------------------------
+%% Credentialed-query encoding parity (non-ASCII byte sequences)
+%%--------------------------------------------------------------------
+
+%% The credentialed query must encode non-ASCII bytes identically to
+%% rabbit_http_util:quote_plus/1 (the encoder the real backend uses). A prior
+%% version used uri_string:compose_query which treats each byte from
+%% binary_to_list as a Unicode codepoint, re-encoding to UTF-8 and producing
+%% double-encoded sequences for multi-byte chars (e.g. 0xC3 0xA9 -> %C3%83%C2%A9
+%% instead of %C3%A9). This test pins the byte-parity for a non-ASCII value.
+credentialed_query_nonascii_parity_test_() ->
+    case upstream_q_usable() of
+        false ->
+            [];
+        true ->
+            %% "cafe" with accent on e: UTF-8 bytes 0x63 0x61 0x66 0xC3 0xA9
+            NonAscii = <<"caf", 16#C3, 16#A9>>,
+            Expected = rabbit_http_util:quote_plus(NonAscii),
+            Params = #{username => NonAscii, password => <<"pw">>},
+            Query = aws_auth_validate_http:credentialed_query_for(Params),
+            [
+                {"non-ASCII username encoding matches rabbit_http_util:quote_plus",
+                    ?_assertNotEqual(nomatch, string:find(Query, "username=" ++ Expected))},
+                {"non-ASCII password encoding matches rabbit_http_util:quote_plus", fun() ->
+                    PwNonAscii = <<"p", 16#C3, 16#A4, "ss">>,
+                    PwExpected = rabbit_http_util:quote_plus(PwNonAscii),
+                    PwParams = #{username => <<"u">>, password => PwNonAscii},
+                    PwQuery = aws_auth_validate_http:credentialed_query_for(PwParams),
+                    ?assertNotEqual(nomatch, string:find(PwQuery, "password=" ++ PwExpected))
+                end}
+            ]
+    end.
+
+%%--------------------------------------------------------------------
 %% Tag-join parity (join_tags/1 is exported upstream)
 %%--------------------------------------------------------------------
 

--- a/test/aws_auth_validate_http_tests.erl
+++ b/test/aws_auth_validate_http_tests.erl
@@ -42,7 +42,9 @@ http_allowed_fields_test() ->
             <<"resource_path">>,
             <<"topic_path">>,
             <<"http_method">>,
-            <<"ssl_options">>
+            <<"ssl_options">>,
+            <<"username">>,
+            <<"password_arn">>
         ]
     ].
 


### PR DESCRIPTION
_Closes #182_

Adds an optional credentialed-probe mode to `PUT /api/aws/auth/validate/http`.

Today the `http` method is reachability-only: it confirms each configured `*_path` is reachable and answers with an auth-shaped `allow`/`deny` body, using a synthetic principal. This adds an opt-in mode that probes `user_path` with a real credential and asserts the response is `allow`.

- New optional fields `username` (inline) and `password_arn` (resolved server-side; never passed inline). Supplying one without the other is rejected as `input_invalid`.
- With no credential supplied, behaviour is unchanged (fully backward compatible).
- Because credentialed mode resolves an ARN, a configured assume-role becomes required, else `config_conflict`.
- A well-formed `deny` for the supplied credential returns `auth_failed`; the resolved password never appears in logs, responses, or crash reports.

### Tests
`allow` -> 204, `deny` -> 422, missing-half -> 400, ARN without assume-role -> 422, and query-encoding of special characters. Full suite green.