### PR TITLE
Add Prometheus metrics for auth validation

### DIFF
--- a/AUTH_VALIDATION.md
+++ b/AUTH_VALIDATION.md
@@ -180,3 +180,52 @@ from it return 404 `method_disabled`. Its visibility is hard-coded to the
 `administrator` tag, so lowering `required_user_tag` does not make the tab
 appear for users holding the lowered tag, even though the endpoint accepts
 their requests.
+
+## Metrics
+
+When `aws.auth_validation.enabled = true`, the plugin registers a Prometheus
+collector that exposes the following metrics on the standard RabbitMQ
+`/api/metrics` endpoint. Amazon MQ bridges these to CloudWatch automatically.
+When the feature is disabled, no metrics are registered and the collector is
+absent from the Prometheus registry.
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `rabbitmq_aws_auth_validation_requests_total` | counter | `method`, `result` | Total number of auth-validation requests. |
+| `rabbitmq_aws_auth_validation_duration_milliseconds` | histogram | `method` | Duration of auth-validation requests in milliseconds. |
+| `rabbitmq_aws_auth_validation_capacity_exhausted_total` | counter | `method` | Total number of requests rejected due to semaphore capacity exhaustion (503). |
+| `rabbitmq_aws_auth_validation_semaphore_in_use` | gauge | (none) | Number of semaphore slots currently held by in-flight validations. |
+| `rabbitmq_aws_auth_validation_semaphore_capacity` | gauge | (none) | Configured maximum concurrent validation slots (`max_concurrent`). |
+
+### Labels
+
+- **`method`** -- the `:method` path segment (`ldap`, `http`, `oauth`, `tls`).
+- **`result`** -- the fixed response category atom (`success`, `input_invalid`,
+  `body_too_large`, `connection_failed`, `tls_failed`, `query_invalid`,
+  `auth_failed`, `config_conflict`, `authz_unverified`, `token_expired`,
+  `token_invalid`, `capacity_exhausted`, `unknown_method`, `method_disabled`,
+  `internal_error`).
+
+Metrics are **never** dimensioned by source IP, username, target host, URL, DN,
+or any secret/ARN -- this is a security invariant matching the audit trail
+policy.
+
+### Histogram bucket boundaries (milliseconds)
+
+```
+10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000
+```
+
+These cover the range from fast local validation (~10 ms for a parse-only check)
+through typical LDAP/HTTP round trips (~100-500 ms) to the connection timeout
+ceiling (5-10 s).
+
+### Implementation notes
+
+- The collector uses OTP `counters` with `write_concurrency` stored in
+  `persistent_term`, so the hot-path `observe/3` call adds negligible latency
+  (no message passing, no lock contention).
+- Semaphore gauges are read live from the semaphore gen_server at scrape time
+  (pull model), not stored in counters.
+- If the feature is disabled or the collector is deregistered, `observe/3` is a
+  silent no-op -- it never crashes the caller.

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ define PROJECT_ENV
 []
 endef
 
-DEPS = rabbit_common rabbit rabbitmq_management gun jose
+DEPS = rabbit_common rabbit rabbitmq_management prometheus gun jose
 TEST_DEPS = meck proper rabbitmq_ct_helpers rabbitmq_ct_client_helpers rabbitmq_auth_backend_ldap rabbitmq_auth_backend_http rabbitmq_auth_backend_oauth2
 LOCAL_DEPS = crypto inets ssl xmerl public_key eldap
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ define PROJECT_ENV
 []
 endef
 
-DEPS = rabbit_common rabbit rabbitmq_management prometheus gun jose
+DEPS = rabbit_common rabbit rabbitmq_management rabbitmq_prometheus gun jose
 TEST_DEPS = meck proper rabbitmq_ct_helpers rabbitmq_ct_client_helpers rabbitmq_auth_backend_ldap rabbitmq_auth_backend_http rabbitmq_auth_backend_oauth2
 LOCAL_DEPS = crypto inets ssl xmerl public_key eldap
 

--- a/src/aws_auth_validate_metrics.erl
+++ b/src/aws_auth_validate_metrics.erl
@@ -11,8 +11,14 @@
 %% just increments lock-free OTP `counters` stored in `persistent_term`.
 %%
 %% Counter layout (single counters ref, write_concurrency):
-%%   Slots 1..NUM_REQUESTS_SLOTS       -- requests_total per (method, category)
-%%   Slots HIST_BASE+1..HIST_BASE+NUM  -- histogram per method (buckets+sum+count)
+%%   Slots 1..75 (NUM_REQUESTS_SLOTS)  -- requests_total per (method, category)
+%%   Slots 76..140 (HIST_BASE+1..end)  -- histogram per method
+%%
+%% Per-method histogram (13 slots each):
+%%   Positions 1..10  -- finite bucket counters (le=10..10000)
+%%   Position 11      -- overflow bucket (le="+Inf", durations > 10000ms)
+%%   Position 12      -- sum of observed durations (NUM_BUCKETS+1)
+%%   Position 13      -- count of observations (NUM_BUCKETS+2)
 %%
 %% Semaphore gauges are read live from the semaphore gen_server at scrape time,
 %% not stored in counters.
@@ -24,7 +30,9 @@
 -export([deregister_cleanup/1, collect_mf/2]).
 
 -ifdef(TEST).
--export([counter_ref/0, method_index/1, category_index/1, histogram_base/0]).
+-export([
+    counter_ref/0, method_index/1, category_index/1, histogram_base/0, build_cumulative_buckets/2
+]).
 -endif.
 
 -import(prometheus_model_helpers, [create_mf/4]).
@@ -37,15 +45,19 @@
 
 %% Histogram bucket boundaries (milliseconds). Chosen to cover the range from
 %% fast local validation (~10ms) to slow DNS/TLS negotiation (~10s timeout).
+%% An 11th overflow bucket (slot 11) catches durations > 10000ms; emitted as
+%% le="+Inf" during scrape.
 -define(HISTOGRAM_BUCKETS, [10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000]).
--define(NUM_BUCKETS, 10).
+-define(NUM_BUCKETS, 11).
 
-%% Per-method histogram layout: 10 bucket counters + 1 sum + 1 count = 12 slots.
--define(SLOTS_PER_HIST, 12).
+%% Per-method histogram layout: 11 bucket counters + 1 sum + 1 count = 13 slots.
+-define(SLOTS_PER_HIST, 13).
 
-%% Methods -- indexed 0..3 for counter math.
--define(METHODS, [<<"ldap">>, <<"http">>, <<"oauth">>, <<"tls">>]).
--define(NUM_METHODS, 4).
+%% Methods -- indexed 0..4 for counter math. The synthetic "unknown" method
+%% (index 4) collects requests_total for unrecognized method paths without
+%% exposing the raw caller-supplied string as a label (fixed cardinality).
+-define(METHODS, [<<"ldap">>, <<"http">>, <<"oauth">>, <<"tls">>, <<"unknown">>]).
+-define(NUM_METHODS, 5).
 
 %% Result categories -- indexed 0..14. This is the full set of categories
 %% that can appear in the audit trail (see aws_auth_validate_mgmt).
@@ -69,9 +81,9 @@
 -define(NUM_CATEGORIES, 15).
 
 %% Total counter slots:
-%%   requests_total: NUM_METHODS * NUM_CATEGORIES = 4 * 15 = 60
-%%   histogram: NUM_METHODS * SLOTS_PER_HIST = 4 * 12 = 48
-%%   Grand total: 108
+%%   requests_total: NUM_METHODS * NUM_CATEGORIES = 5 * 15 = 75
+%%   histogram: NUM_METHODS * SLOTS_PER_HIST = 5 * 13 = 65
+%%   Grand total: 140
 -define(NUM_REQUESTS_SLOTS, (?NUM_METHODS * ?NUM_CATEGORIES)).
 -define(HIST_BASE, ?NUM_REQUESTS_SLOTS).
 -define(TOTAL_SLOTS, (?NUM_REQUESTS_SLOTS + ?NUM_METHODS * ?SLOTS_PER_HIST)).
@@ -85,8 +97,14 @@
 
 -spec register() -> ok.
 register() ->
-    Counters = counters:new(?TOTAL_SLOTS, [write_concurrency]),
-    persistent_term:put(?PT_COUNTERS, Counters),
+    case persistent_term:get(?PT_COUNTERS, undefined) of
+        undefined ->
+            Counters = counters:new(?TOTAL_SLOTS, [write_concurrency]),
+            persistent_term:put(?PT_COUNTERS, Counters);
+        _Existing ->
+            %% Counters already allocated -- preserve existing values.
+            ok
+    end,
     prometheus_registry:register_collector(?MODULE),
     ?AWS_LOG_INFO("auth_validate metrics: registered collector"),
     ok.
@@ -107,6 +125,12 @@ deregister() ->
 %% Called after each audit call in aws_auth_validate_mgmt. If metrics are not
 %% registered (feature disabled, or deregistered during shutdown), this is a
 %% silent no-op -- it never crashes the caller.
+%%
+%% Duration is recorded ONLY for categories representing actual backend/outbound
+%% work (see is_timed_category/1). Pre-connection rejects (input_invalid,
+%% body_too_large, config_conflict, capacity_exhausted, method_disabled,
+%% unknown_method, internal_error, query_invalid) are excluded so they do not
+%% contaminate latency percentiles with near-zero noise.
 -spec observe(binary(), atom(), non_neg_integer()) -> ok.
 observe(Method, Category, DurationMs) ->
     case persistent_term:get(?PT_COUNTERS, undefined) of
@@ -115,7 +139,10 @@ observe(Method, Category, DurationMs) ->
             ok;
         Counters ->
             observe_request(Counters, Method, Category),
-            observe_duration(Counters, Method, DurationMs),
+            case is_timed_category(Category) of
+                true -> observe_duration(Counters, Method, DurationMs);
+                false -> ok
+            end,
             ok
     end.
 
@@ -150,19 +177,41 @@ observe_request(Counters, Method, Category) ->
         Slot -> counters:add(Counters, Slot, 1)
     end.
 
+%% @doc Categories that represent actual backend/outbound work and should
+%% contribute to the duration histogram. Categories excluded are pure
+%% pre-connection rejects that complete without any network round-trip:
+%%   - input_invalid, body_too_large: request-body validation
+%%   - config_conflict: local config check
+%%   - capacity_exhausted: semaphore full
+%%   - method_disabled, unknown_method: routing reject
+%%   - internal_error: unexpected crash path
+%%   - query_invalid: LDAP query grammar parsing (happens inside parse_input,
+%%     step 1 of validate/1, before any eldap:open)
+-spec is_timed_category(atom()) -> boolean().
+is_timed_category(success) -> true;
+is_timed_category(auth_failed) -> true;
+is_timed_category(connection_failed) -> true;
+is_timed_category(tls_failed) -> true;
+is_timed_category(authz_unverified) -> true;
+is_timed_category(token_expired) -> true;
+is_timed_category(token_invalid) -> true;
+is_timed_category(_) -> false.
+
 observe_duration(Counters, Method, DurationMs) ->
-    case method_index(Method) of
+    case real_method_index(Method) of
         undefined ->
+            %% Unknown methods do not record duration -- only the four real
+            %% backends (ldap/http/oauth/tls) produce meaningful latency data.
             ok;
         MethodIdx ->
             BucketPos = find_bucket_pos(DurationMs),
             %% Increment the bucket counter (1-based within the method's histogram range).
             BucketSlot = ?HIST_BASE + MethodIdx * ?SLOTS_PER_HIST + BucketPos,
             counters:add(Counters, BucketSlot, 1),
-            %% Increment the sum slot (bucket positions are 1..NUM_BUCKETS, sum is NUM_BUCKETS+1).
+            %% Increment the sum slot (NUM_BUCKETS+1 = position 12).
             SumSlot = ?HIST_BASE + MethodIdx * ?SLOTS_PER_HIST + ?NUM_BUCKETS + 1,
             counters:add(Counters, SumSlot, DurationMs),
-            %% Increment the count slot (NUM_BUCKETS+2).
+            %% Increment the count slot (NUM_BUCKETS+2 = position 13).
             CountSlot = ?HIST_BASE + MethodIdx * ?SLOTS_PER_HIST + ?NUM_BUCKETS + 2,
             counters:add(Counters, CountSlot, 1)
     end.
@@ -206,13 +255,15 @@ emit_duration_histogram(Counters, Callback) ->
         fun(Method) ->
             MethodIdx = method_index(Method),
             Base = ?HIST_BASE + MethodIdx * ?SLOTS_PER_HIST,
+            %% Count slot is at position NUM_BUCKETS+2 (=13) within the method's range.
             Count = counters:get(Counters, Base + ?NUM_BUCKETS + 2),
             case Count of
                 0 ->
                     false;
                 _ ->
+                    %% Sum slot is at position NUM_BUCKETS+1 (=12).
                     Sum = counters:get(Counters, Base + ?NUM_BUCKETS + 1),
-                    %% Build cumulative bucket list: [{BoundaryValue, CumulativeCount}]
+                    %% Build cumulative bucket list including le="+Inf".
                     Buckets = build_cumulative_buckets(Counters, Base),
                     {true, {[{method, Method}], Buckets, Count, Sum}}
             end
@@ -284,13 +335,24 @@ emit_semaphore_gauges(Callback) ->
 %%--------------------------------------------------------------------
 
 %% @doc Map a method binary to a 0-based index. Returns `undefined` for
-%% unknown methods (they are not tracked in metrics).
+%% methods not in the fixed label set (caller decides how to handle).
 -spec method_index(binary()) -> non_neg_integer() | undefined.
 method_index(<<"ldap">>) -> 0;
 method_index(<<"http">>) -> 1;
 method_index(<<"oauth">>) -> 2;
 method_index(<<"tls">>) -> 3;
+method_index(<<"unknown">>) -> 4;
 method_index(_) -> undefined.
+
+%% @doc Map a method binary to a 0-based index for the four real backends
+%% only. Returns `undefined` for the synthetic "unknown" method and for
+%% truly unrecognized methods -- used to gate duration recording.
+-spec real_method_index(binary()) -> non_neg_integer() | undefined.
+real_method_index(<<"ldap">>) -> 0;
+real_method_index(<<"http">>) -> 1;
+real_method_index(<<"oauth">>) -> 2;
+real_method_index(<<"tls">>) -> 3;
+real_method_index(_) -> undefined.
 
 %% @doc Map a result category atom to a 0-based index.
 -spec category_index(atom()) -> non_neg_integer() | undefined.
@@ -312,16 +374,23 @@ category_index(internal_error) -> 14;
 category_index(_) -> undefined.
 
 %% @doc Compute the 1-based counter slot for a given (method, category) pair.
-%% Returns `undefined` if either method or category is unknown.
+%% Unknown methods are mapped to the synthetic "unknown" method index so they
+%% appear in requests_total. Returns `undefined` only for unknown categories.
 request_slot(Method, Category) ->
-    case {method_index(Method), category_index(Category)} of
-        {undefined, _} -> undefined;
-        {_, undefined} -> undefined;
-        {MethodIdx, CatIdx} -> MethodIdx * ?NUM_CATEGORIES + CatIdx + 1
+    MethodIdx =
+        case method_index(Method) of
+            undefined -> method_index(<<"unknown">>);
+            Idx -> Idx
+        end,
+    case category_index(Category) of
+        undefined -> undefined;
+        CatIdx -> MethodIdx * ?NUM_CATEGORIES + CatIdx + 1
     end.
 
 %% @doc Find which bucket a duration value falls into (1-based position).
 %% Bucket boundaries: 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000.
+%% Position 11 is the overflow bucket for durations > 10000ms (emitted as
+%% le="+Inf" at scrape time).
 %% A value of exactly the boundary goes into that bucket (less-than-or-equal).
 find_bucket_pos(Ms) when Ms =< 10 -> 1;
 find_bucket_pos(Ms) when Ms =< 25 -> 2;
@@ -332,33 +401,46 @@ find_bucket_pos(Ms) when Ms =< 500 -> 6;
 find_bucket_pos(Ms) when Ms =< 1000 -> 7;
 find_bucket_pos(Ms) when Ms =< 2500 -> 8;
 find_bucket_pos(Ms) when Ms =< 5000 -> 9;
-find_bucket_pos(_Ms) -> 10.
+find_bucket_pos(Ms) when Ms =< 10000 -> 10;
+find_bucket_pos(_Ms) -> 11.
 
 %% @doc Build cumulative bucket list from per-bucket counters.
 %% Prometheus histograms require cumulative counts: each bucket's count
-%% includes all observations in lower buckets.
+%% includes all observations in lower buckets. The final entry is
+%% {infinity, SampleCount} -- the mandatory le="+Inf" bucket.
+%%
+%% Slot positions are enumerated directly (1..length(HISTOGRAM_BUCKETS) for
+%% finite boundaries, position 11 for overflow) rather than re-deriving them
+%% through find_bucket_pos/1, so the layout is expressed once in the macros
+%% and cannot drift.
 build_cumulative_buckets(Counters, Base) ->
     Boundaries = ?HISTOGRAM_BUCKETS,
-    {Buckets, _} = lists:mapfoldl(
-        fun(Boundary, CumAcc) ->
-            Pos = find_bucket_pos(Boundary),
+    Indexed = lists:zip(Boundaries, lists:seq(1, length(Boundaries))),
+    {FiniteBuckets, CumAfterFinite} = lists:mapfoldl(
+        fun({Boundary, Pos}, CumAcc) ->
             Raw = counters:get(Counters, Base + Pos),
             NewCum = CumAcc + Raw,
             {{Boundary, NewCum}, NewCum}
         end,
         0,
-        Boundaries
+        Indexed
     ),
-    Buckets.
+    %% Overflow bucket (position 11): durations > 10000ms.
+    OverflowRaw = counters:get(Counters, Base + length(Boundaries) + 1),
+    InfCum = CumAfterFinite + OverflowRaw,
+    FiniteBuckets ++ [{infinity, InfCum}].
 
 %% @doc Read current semaphore usage without crashing. Returns
-%% {InUse, Capacity} or `unavailable` if the process is not running.
+%% {InUse, Capacity} or `unavailable` if the process is not running or
+%% any unexpected error occurs. A crash here would fail the entire
+%% /api/metrics scrape for every registered collector.
 try_semaphore_usage() ->
     try
         aws_auth_validate_semaphore:usage()
     catch
         exit:{noproc, _} -> unavailable;
-        exit:{timeout, _} -> unavailable
+        exit:{timeout, _} -> unavailable;
+        _:_ -> unavailable
     end.
 
 %% @doc Return the histogram base offset for test introspection.

--- a/src/aws_auth_validate_metrics.erl
+++ b/src/aws_auth_validate_metrics.erl
@@ -1,0 +1,373 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% Prometheus metrics collector for the auth-validation endpoint.
+%%
+%% Implements the `prometheus_collector` behaviour (pull-based): Prometheus
+%% scrapes /api/metrics, which invokes collect_mf/2 on every registered
+%% collector. No outbound calls are made on the request hot path -- observe/3
+%% just increments lock-free OTP `counters` stored in `persistent_term`.
+%%
+%% Counter layout (single counters ref, write_concurrency):
+%%   Slots 1..NUM_REQUESTS_SLOTS       -- requests_total per (method, category)
+%%   Slots HIST_BASE+1..HIST_BASE+NUM  -- histogram per method (buckets+sum+count)
+%%
+%% Semaphore gauges are read live from the semaphore gen_server at scrape time,
+%% not stored in counters.
+-module(aws_auth_validate_metrics).
+
+-behaviour(prometheus_collector).
+
+-export([register/0, deregister/0, observe/3]).
+-export([deregister_cleanup/1, collect_mf/2]).
+
+-ifdef(TEST).
+-export([counter_ref/0, method_index/1, category_index/1, histogram_base/0]).
+-endif.
+
+-import(prometheus_model_helpers, [create_mf/4]).
+
+-include("aws.hrl").
+
+%%--------------------------------------------------------------------
+%% Constants
+%%--------------------------------------------------------------------
+
+%% Histogram bucket boundaries (milliseconds). Chosen to cover the range from
+%% fast local validation (~10ms) to slow DNS/TLS negotiation (~10s timeout).
+-define(HISTOGRAM_BUCKETS, [10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000]).
+-define(NUM_BUCKETS, 10).
+
+%% Per-method histogram layout: 10 bucket counters + 1 sum + 1 count = 12 slots.
+-define(SLOTS_PER_HIST, 12).
+
+%% Methods -- indexed 0..3 for counter math.
+-define(METHODS, [<<"ldap">>, <<"http">>, <<"oauth">>, <<"tls">>]).
+-define(NUM_METHODS, 4).
+
+%% Result categories -- indexed 0..14. This is the full set of categories
+%% that can appear in the audit trail (see aws_auth_validate_mgmt).
+-define(CATEGORIES, [
+    success,
+    input_invalid,
+    body_too_large,
+    connection_failed,
+    tls_failed,
+    query_invalid,
+    auth_failed,
+    config_conflict,
+    authz_unverified,
+    token_expired,
+    token_invalid,
+    capacity_exhausted,
+    unknown_method,
+    method_disabled,
+    internal_error
+]).
+-define(NUM_CATEGORIES, 15).
+
+%% Total counter slots:
+%%   requests_total: NUM_METHODS * NUM_CATEGORIES = 4 * 15 = 60
+%%   histogram: NUM_METHODS * SLOTS_PER_HIST = 4 * 12 = 48
+%%   Grand total: 108
+-define(NUM_REQUESTS_SLOTS, (?NUM_METHODS * ?NUM_CATEGORIES)).
+-define(HIST_BASE, ?NUM_REQUESTS_SLOTS).
+-define(TOTAL_SLOTS, (?NUM_REQUESTS_SLOTS + ?NUM_METHODS * ?SLOTS_PER_HIST)).
+
+%% persistent_term keys
+-define(PT_COUNTERS, {?MODULE, counters}).
+
+%%--------------------------------------------------------------------
+%% Registration
+%%--------------------------------------------------------------------
+
+-spec register() -> ok.
+register() ->
+    Counters = counters:new(?TOTAL_SLOTS, [write_concurrency]),
+    persistent_term:put(?PT_COUNTERS, Counters),
+    prometheus_registry:register_collector(?MODULE),
+    ?AWS_LOG_INFO("auth_validate metrics: registered collector"),
+    ok.
+
+-spec deregister() -> ok.
+deregister() ->
+    prometheus_registry:deregister_collector(?MODULE),
+    persistent_term:erase(?PT_COUNTERS),
+    ?AWS_LOG_INFO("auth_validate metrics: deregistered collector"),
+    ok.
+
+%%--------------------------------------------------------------------
+%% Hot-path observation (called after every audit)
+%%--------------------------------------------------------------------
+
+%% @doc Record a completed validation request.
+%%
+%% Called after each audit call in aws_auth_validate_mgmt. If metrics are not
+%% registered (feature disabled, or deregistered during shutdown), this is a
+%% silent no-op -- it never crashes the caller.
+-spec observe(binary(), atom(), non_neg_integer()) -> ok.
+observe(Method, Category, DurationMs) ->
+    case persistent_term:get(?PT_COUNTERS, undefined) of
+        undefined ->
+            %% Metrics not registered -- silently skip.
+            ok;
+        Counters ->
+            observe_request(Counters, Method, Category),
+            observe_duration(Counters, Method, DurationMs),
+            ok
+    end.
+
+%%--------------------------------------------------------------------
+%% prometheus_collector callbacks
+%%--------------------------------------------------------------------
+
+deregister_cleanup(_Registry) ->
+    ok.
+
+%% @doc Called by the Prometheus registry on each scrape. Reads counters and
+%% the semaphore state, then emits metric families via Callback.
+collect_mf(_Registry, Callback) ->
+    case persistent_term:get(?PT_COUNTERS, undefined) of
+        undefined ->
+            ok;
+        Counters ->
+            emit_requests_total(Counters, Callback),
+            emit_duration_histogram(Counters, Callback),
+            emit_capacity_exhausted_total(Counters, Callback),
+            emit_semaphore_gauges(Callback),
+            ok
+    end.
+
+%%--------------------------------------------------------------------
+%% Internal: observation helpers
+%%--------------------------------------------------------------------
+
+observe_request(Counters, Method, Category) ->
+    case request_slot(Method, Category) of
+        undefined -> ok;
+        Slot -> counters:add(Counters, Slot, 1)
+    end.
+
+observe_duration(Counters, Method, DurationMs) ->
+    case method_index(Method) of
+        undefined ->
+            ok;
+        MethodIdx ->
+            BucketPos = find_bucket_pos(DurationMs),
+            %% Increment the bucket counter (1-based within the method's histogram range).
+            BucketSlot = ?HIST_BASE + MethodIdx * ?SLOTS_PER_HIST + BucketPos,
+            counters:add(Counters, BucketSlot, 1),
+            %% Increment the sum slot (bucket positions are 1..NUM_BUCKETS, sum is NUM_BUCKETS+1).
+            SumSlot = ?HIST_BASE + MethodIdx * ?SLOTS_PER_HIST + ?NUM_BUCKETS + 1,
+            counters:add(Counters, SumSlot, DurationMs),
+            %% Increment the count slot (NUM_BUCKETS+2).
+            CountSlot = ?HIST_BASE + MethodIdx * ?SLOTS_PER_HIST + ?NUM_BUCKETS + 2,
+            counters:add(Counters, CountSlot, 1)
+    end.
+
+%%--------------------------------------------------------------------
+%% Internal: emission helpers (called from collect_mf/2)
+%%--------------------------------------------------------------------
+
+emit_requests_total(Counters, Callback) ->
+    Metrics = lists:foldl(
+        fun(Method, Acc) ->
+            MethodIdx = method_index(Method),
+            lists:foldl(
+                fun(Category, InnerAcc) ->
+                    CatIdx = category_index(Category),
+                    Slot = MethodIdx * ?NUM_CATEGORIES + CatIdx + 1,
+                    Value = counters:get(Counters, Slot),
+                    case Value of
+                        0 -> InnerAcc;
+                        _ -> [{[{method, Method}, {result, Category}], Value} | InnerAcc]
+                    end
+                end,
+                Acc,
+                ?CATEGORIES
+            )
+        end,
+        [],
+        ?METHODS
+    ),
+    Callback(
+        create_mf(
+            rabbitmq_aws_auth_validation_requests_total,
+            "Total number of auth-validation requests",
+            counter,
+            Metrics
+        )
+    ).
+
+emit_duration_histogram(Counters, Callback) ->
+    Metrics = lists:filtermap(
+        fun(Method) ->
+            MethodIdx = method_index(Method),
+            Base = ?HIST_BASE + MethodIdx * ?SLOTS_PER_HIST,
+            Count = counters:get(Counters, Base + ?NUM_BUCKETS + 2),
+            case Count of
+                0 ->
+                    false;
+                _ ->
+                    Sum = counters:get(Counters, Base + ?NUM_BUCKETS + 1),
+                    %% Build cumulative bucket list: [{BoundaryValue, CumulativeCount}]
+                    Buckets = build_cumulative_buckets(Counters, Base),
+                    {true, {[{method, Method}], Buckets, Count, Sum}}
+            end
+        end,
+        ?METHODS
+    ),
+    Callback(
+        create_mf(
+            rabbitmq_aws_auth_validation_duration_milliseconds,
+            "Duration of auth-validation requests in milliseconds",
+            histogram,
+            Metrics
+        )
+    ).
+
+emit_capacity_exhausted_total(Counters, Callback) ->
+    %% capacity_exhausted is category index 11 (0-based). Read directly from
+    %% the requests_total counter slots for each method.
+    CatIdx = category_index(capacity_exhausted),
+    Metrics = lists:filtermap(
+        fun(Method) ->
+            MethodIdx = method_index(Method),
+            Slot = MethodIdx * ?NUM_CATEGORIES + CatIdx + 1,
+            Value = counters:get(Counters, Slot),
+            case Value of
+                0 -> false;
+                _ -> {true, {[{method, Method}], Value}}
+            end
+        end,
+        ?METHODS
+    ),
+    Callback(
+        create_mf(
+            rabbitmq_aws_auth_validation_capacity_exhausted_total,
+            "Total number of requests rejected due to semaphore capacity exhaustion",
+            counter,
+            Metrics
+        )
+    ).
+
+emit_semaphore_gauges(Callback) ->
+    %% Read live from the semaphore gen_server at scrape time. If the
+    %% semaphore is not running (feature disabled mid-flight or crashed),
+    %% emit nothing rather than crashing the scrape.
+    case try_semaphore_usage() of
+        {InUse, Capacity} ->
+            Callback(
+                create_mf(
+                    rabbitmq_aws_auth_validation_semaphore_in_use,
+                    "Number of semaphore slots currently held by in-flight validations",
+                    gauge,
+                    [{[], InUse}]
+                )
+            ),
+            Callback(
+                create_mf(
+                    rabbitmq_aws_auth_validation_semaphore_capacity,
+                    "Configured maximum concurrent validation slots",
+                    gauge,
+                    [{[], Capacity}]
+                )
+            );
+        unavailable ->
+            ok
+    end.
+
+%%--------------------------------------------------------------------
+%% Internal: index math
+%%--------------------------------------------------------------------
+
+%% @doc Map a method binary to a 0-based index. Returns `undefined` for
+%% unknown methods (they are not tracked in metrics).
+-spec method_index(binary()) -> non_neg_integer() | undefined.
+method_index(<<"ldap">>) -> 0;
+method_index(<<"http">>) -> 1;
+method_index(<<"oauth">>) -> 2;
+method_index(<<"tls">>) -> 3;
+method_index(_) -> undefined.
+
+%% @doc Map a result category atom to a 0-based index.
+-spec category_index(atom()) -> non_neg_integer() | undefined.
+category_index(success) -> 0;
+category_index(input_invalid) -> 1;
+category_index(body_too_large) -> 2;
+category_index(connection_failed) -> 3;
+category_index(tls_failed) -> 4;
+category_index(query_invalid) -> 5;
+category_index(auth_failed) -> 6;
+category_index(config_conflict) -> 7;
+category_index(authz_unverified) -> 8;
+category_index(token_expired) -> 9;
+category_index(token_invalid) -> 10;
+category_index(capacity_exhausted) -> 11;
+category_index(unknown_method) -> 12;
+category_index(method_disabled) -> 13;
+category_index(internal_error) -> 14;
+category_index(_) -> undefined.
+
+%% @doc Compute the 1-based counter slot for a given (method, category) pair.
+%% Returns `undefined` if either method or category is unknown.
+request_slot(Method, Category) ->
+    case {method_index(Method), category_index(Category)} of
+        {undefined, _} -> undefined;
+        {_, undefined} -> undefined;
+        {MethodIdx, CatIdx} -> MethodIdx * ?NUM_CATEGORIES + CatIdx + 1
+    end.
+
+%% @doc Find which bucket a duration value falls into (1-based position).
+%% Bucket boundaries: 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000.
+%% A value of exactly the boundary goes into that bucket (less-than-or-equal).
+find_bucket_pos(Ms) when Ms =< 10 -> 1;
+find_bucket_pos(Ms) when Ms =< 25 -> 2;
+find_bucket_pos(Ms) when Ms =< 50 -> 3;
+find_bucket_pos(Ms) when Ms =< 100 -> 4;
+find_bucket_pos(Ms) when Ms =< 250 -> 5;
+find_bucket_pos(Ms) when Ms =< 500 -> 6;
+find_bucket_pos(Ms) when Ms =< 1000 -> 7;
+find_bucket_pos(Ms) when Ms =< 2500 -> 8;
+find_bucket_pos(Ms) when Ms =< 5000 -> 9;
+find_bucket_pos(_Ms) -> 10.
+
+%% @doc Build cumulative bucket list from per-bucket counters.
+%% Prometheus histograms require cumulative counts: each bucket's count
+%% includes all observations in lower buckets.
+build_cumulative_buckets(Counters, Base) ->
+    Boundaries = ?HISTOGRAM_BUCKETS,
+    {Buckets, _} = lists:mapfoldl(
+        fun(Boundary, CumAcc) ->
+            Pos = find_bucket_pos(Boundary),
+            Raw = counters:get(Counters, Base + Pos),
+            NewCum = CumAcc + Raw,
+            {{Boundary, NewCum}, NewCum}
+        end,
+        0,
+        Boundaries
+    ),
+    Buckets.
+
+%% @doc Read current semaphore usage without crashing. Returns
+%% {InUse, Capacity} or `unavailable` if the process is not running.
+try_semaphore_usage() ->
+    try
+        aws_auth_validate_semaphore:usage()
+    catch
+        exit:{noproc, _} -> unavailable;
+        exit:{timeout, _} -> unavailable
+    end.
+
+%% @doc Return the histogram base offset for test introspection.
+-ifdef(TEST).
+histogram_base() -> ?HIST_BASE.
+-endif.
+
+%% @doc Return the counters ref for test introspection (returns undefined if
+%% not registered).
+-ifdef(TEST).
+counter_ref() -> persistent_term:get(?PT_COUNTERS, undefined).
+-endif.

--- a/src/aws_auth_validate_mgmt.erl
+++ b/src/aws_auth_validate_mgmt.erl
@@ -317,7 +317,10 @@ audit(Method, SourceIP, User, ResultCategory, T0) ->
     ?AWS_LOG_INFO(
         "auth_validate: method=~ts user=~ts source_ip=~ts result=~ts duration_ms=~B",
         [sanitize_log(Method), sanitize_log(User), format_ip(SourceIP), ResultCategory, Duration]
-    ).
+    ),
+    %% Emit Prometheus metrics for this request. observe/3 is a no-op when
+    %% the metrics collector is not registered, so this is always safe.
+    aws_auth_validate_metrics:observe(Method, ResultCategory, Duration).
 
 %% Strip control characters (CR, LF, TAB, any other byte < 0x20, and DEL) from a
 %% value before it is interpolated into the single-line audit record. Method

--- a/src/aws_auth_validate_semaphore.erl
+++ b/src/aws_auth_validate_semaphore.erl
@@ -10,7 +10,7 @@
 
 -behaviour(gen_server).
 
--export([start_link/1, acquire/0, release/1, current/0]).
+-export([start_link/1, acquire/0, release/1, current/0, usage/0]).
 
 -export([
     init/1,
@@ -46,6 +46,12 @@ release(Ref) ->
 -spec current() -> non_neg_integer().
 current() ->
     gen_server:call(?MODULE, get_current).
+
+%% @doc Return the current in-use count and the configured maximum capacity.
+%% Used by the metrics collector at scrape time to emit semaphore gauges.
+-spec usage() -> {non_neg_integer(), pos_integer()}.
+usage() ->
+    gen_server:call(?MODULE, usage).
 
 %%--------------------------------------------------------------------
 %% gen_server callbacks
@@ -93,6 +99,8 @@ handle_call(
     end;
 handle_call(get_current, _From, #sem_state{current = Current} = State) ->
     {reply, Current, State};
+handle_call(usage, _From, #sem_state{current = Current, max = Max} = State) ->
+    {reply, {Current, Max}, State};
 handle_call(_Request, _From, State) ->
     {reply, {error, unknown_request}, State}.
 

--- a/src/aws_sup.erl
+++ b/src/aws_sup.erl
@@ -41,8 +41,9 @@ auth_validation_children() ->
             %% Register the Prometheus metrics collector before starting the
             %% semaphore worker. The collector has no process (it is a callback
             %% module registered with prometheus_registry), so no child spec is
-            %% needed. prometheus is a declared dependency, so a failure here is
-            %% a real fault and must surface rather than be swallowed.
+            %% needed. rabbitmq_prometheus is a declared dependency (which
+            %% transitively pulls in prometheus), so a failure here is a real
+            %% fault and must surface rather than be swallowed.
             aws_auth_validate_metrics:register(),
             [semaphore_spec()];
         _ ->

--- a/src/aws_sup.erl
+++ b/src/aws_sup.erl
@@ -41,14 +41,9 @@ auth_validation_children() ->
             %% Register the Prometheus metrics collector before starting the
             %% semaphore worker. The collector has no process (it is a callback
             %% module registered with prometheus_registry), so no child spec is
-            %% needed. Registration is wrapped in try/catch so that a missing
-            %% prometheus dependency (unlikely -- transitive via
-            %% rabbitmq_management) does not prevent the feature from starting.
-            try
-                aws_auth_validate_metrics:register()
-            catch
-                _:_ -> ok
-            end,
+            %% needed. prometheus is a declared dependency, so a failure here is
+            %% a real fault and must surface rather than be swallowed.
+            aws_auth_validate_metrics:register(),
             [semaphore_spec()];
         _ ->
             []

--- a/src/aws_sup.erl
+++ b/src/aws_sup.erl
@@ -37,8 +37,21 @@ init([]) ->
 
 auth_validation_children() ->
     case application:get_env(aws, auth_validation_enabled, false) of
-        true -> [semaphore_spec()];
-        _ -> []
+        true ->
+            %% Register the Prometheus metrics collector before starting the
+            %% semaphore worker. The collector has no process (it is a callback
+            %% module registered with prometheus_registry), so no child spec is
+            %% needed. Registration is wrapped in try/catch so that a missing
+            %% prometheus dependency (unlikely -- transitive via
+            %% rabbitmq_management) does not prevent the feature from starting.
+            try
+                aws_auth_validate_metrics:register()
+            catch
+                _:_ -> ok
+            end,
+            [semaphore_spec()];
+        _ ->
+            []
     end.
 
 %% The concurrency semaphore bounds simultaneous outbound LDAP connections;

--- a/test/aws_auth_validate_metrics_SUITE.erl
+++ b/test/aws_auth_validate_metrics_SUITE.erl
@@ -8,10 +8,15 @@
 %% Tests cover:
 %%   - Counter increments for requests_total
 %%   - Histogram bucket population for duration
+%%   - Overflow (+Inf) bucket for durations > 10000ms
+%%   - Duration gating (pre-connection rejects excluded from histogram)
+%%   - Unknown method tracking in requests_total
 %%   - Dedicated capacity_exhausted counter
 %%   - Semaphore gauge reads at scrape time
+%%   - Semaphore exit catch-all (arbitrary exits degrade gracefully)
 %%   - No-op behaviour when metrics are not registered
 %%   - Crash safety (observe/3 never raises)
+%%   - register/0 idempotency (preserves counters on re-registration)
 -module(aws_auth_validate_metrics_SUITE).
 
 -include_lib("common_test/include/ct.hrl").
@@ -28,24 +33,34 @@
 -export([
     requests_total_increments/1,
     duration_histogram_records/1,
+    inf_bucket_exists/1,
+    duration_gating_excludes_fast_rejects/1,
+    unknown_method_counted/1,
     capacity_exhausted_increments/1,
     semaphore_gauges/1,
+    semaphore_exit_catch_all/1,
     no_state_when_disabled/1,
     crash_safety/1,
     unknown_method_no_crash/1,
-    unknown_category_no_crash/1
+    unknown_category_no_crash/1,
+    register_preserves_counters/1
 ]).
 
 all() ->
     [
         requests_total_increments,
         duration_histogram_records,
+        inf_bucket_exists,
+        duration_gating_excludes_fast_rejects,
+        unknown_method_counted,
         capacity_exhausted_increments,
         semaphore_gauges,
+        semaphore_exit_catch_all,
         no_state_when_disabled,
         crash_safety,
         unknown_method_no_crash,
-        unknown_category_no_crash
+        unknown_category_no_crash,
+        register_preserves_counters
     ].
 
 init_per_suite(Config) ->
@@ -78,6 +93,7 @@ end_per_testcase(crash_safety, _Config) ->
 end_per_testcase(_TestCase, _Config) ->
     %% Clean up: deregister collector and erase persistent_term.
     catch aws_auth_validate_metrics:deregister(),
+    catch meck:unload(aws_auth_validate_semaphore),
     ok.
 
 %%--------------------------------------------------------------------
@@ -107,10 +123,11 @@ requests_total_increments(_Config) ->
     ?assertEqual(1, counters:get(Counters, 40)),
     ok.
 
-%% Verify that observe/3 populates histogram buckets correctly.
+%% Verify that observe/3 populates histogram buckets correctly for timed
+%% categories. Uses the updated layout: SLOTS_PER_HIST=13, NUM_BUCKETS=11.
 duration_histogram_records(_Config) ->
-    %% Observe durations in different buckets:
-    %% 5ms -> bucket 1 (<=10), 75ms -> bucket 4 (<=100), 3000ms -> bucket 8 (<=5000)
+    %% Observe durations in different buckets (all with timed category `success`):
+    %% 5ms -> bucket 1 (<=10), 75ms -> bucket 4 (<=100), 3000ms -> bucket 9 (<=5000)
     aws_auth_validate_metrics:observe(<<"ldap">>, success, 5),
     aws_auth_validate_metrics:observe(<<"ldap">>, success, 75),
     aws_auth_validate_metrics:observe(<<"ldap">>, success, 3000),
@@ -118,17 +135,86 @@ duration_histogram_records(_Config) ->
     Counters = aws_auth_validate_metrics:counter_ref(),
     Base = aws_auth_validate_metrics:histogram_base(),
 
-    %% ldap is method_index 0, so its histogram starts at Base + 0*12.
-    %% Bucket 1 (<=10ms): slot = Base + 0*12 + 1 = Base + 1
+    %% ldap is method_index 0, so its histogram starts at Base + 0*13.
+    %% Bucket 1 (<=10ms): slot = Base + 0*13 + 1 = Base + 1
     ?assertEqual(1, counters:get(Counters, Base + 1)),
-    %% Bucket 4 (<=100ms): slot = Base + 0*12 + 4 = Base + 4
+    %% Bucket 4 (<=100ms): slot = Base + 0*13 + 4 = Base + 4
     ?assertEqual(1, counters:get(Counters, Base + 4)),
-    %% Bucket 9 (<=5000ms): slot = Base + 0*12 + 9 = Base + 9
+    %% Bucket 9 (<=5000ms): slot = Base + 0*13 + 9 = Base + 9
     ?assertEqual(1, counters:get(Counters, Base + 9)),
-    %% Sum slot: Base + 0*12 + 11 = Base + 11
-    ?assertEqual(5 + 75 + 3000, counters:get(Counters, Base + 11)),
-    %% Count slot: Base + 0*12 + 12 = Base + 12
-    ?assertEqual(3, counters:get(Counters, Base + 12)),
+    %% Sum slot: Base + 0*13 + 12 = Base + 12 (NUM_BUCKETS+1)
+    ?assertEqual(5 + 75 + 3000, counters:get(Counters, Base + 12)),
+    %% Count slot: Base + 0*13 + 13 = Base + 13 (NUM_BUCKETS+2)
+    ?assertEqual(3, counters:get(Counters, Base + 13)),
+    ok.
+
+%% Verify that durations > 10000ms land in the overflow bucket (position 11)
+%% and that the +Inf bucket is emitted with cumulative count = sample_count.
+inf_bucket_exists(_Config) ->
+    aws_auth_validate_metrics:observe(<<"ldap">>, success, 15000),
+    aws_auth_validate_metrics:observe(<<"ldap">>, success, 20000),
+    %% Also add one in a finite bucket to verify cumulation.
+    aws_auth_validate_metrics:observe(<<"ldap">>, success, 5),
+
+    Counters = aws_auth_validate_metrics:counter_ref(),
+    Base = aws_auth_validate_metrics:histogram_base(),
+
+    %% Overflow bucket slot: Base + 0*13 + 11 = Base + 11
+    ?assertEqual(2, counters:get(Counters, Base + 11)),
+    %% Finite bucket 1 (<=10ms): Base + 1
+    ?assertEqual(1, counters:get(Counters, Base + 1)),
+    %% Count slot: Base + 13 -- all three observations
+    ?assertEqual(3, counters:get(Counters, Base + 13)),
+    %% Sum slot: Base + 12
+    ?assertEqual(15000 + 20000 + 5, counters:get(Counters, Base + 12)),
+
+    %% Directly verify build_cumulative_buckets returns +Inf as last entry.
+    Buckets = aws_auth_validate_metrics:build_cumulative_buckets(Counters, Base),
+    %% Should be 11 entries: 10 finite boundaries + 1 infinity.
+    ?assertEqual(11, length(Buckets)),
+    %% Last bucket must be {infinity, 3} (total sample count).
+    ?assertEqual({infinity, 3}, lists:last(Buckets)),
+    %% First bucket (le=10) should be cumulative 1 (the 5ms observation).
+    ?assertEqual({10, 1}, hd(Buckets)),
+
+    %% Also verify collect_mf/2 does not crash.
+    Collected = collect_all_mf(),
+    ?assert(length(Collected) >= 1),
+    ok.
+
+%% Verify that pre-connection reject categories increment requests_total
+%% but do NOT record duration in the histogram.
+duration_gating_excludes_fast_rejects(_Config) ->
+    aws_auth_validate_metrics:observe(<<"ldap">>, input_invalid, 50),
+    aws_auth_validate_metrics:observe(<<"ldap">>, body_too_large, 20),
+    aws_auth_validate_metrics:observe(<<"ldap">>, query_invalid, 30),
+
+    Counters = aws_auth_validate_metrics:counter_ref(),
+    Base = aws_auth_validate_metrics:histogram_base(),
+
+    %% requests_total should have incremented for each.
+    %% ldap + input_invalid: slot = 0*15 + 1 + 1 = 2
+    ?assertEqual(1, counters:get(Counters, 2)),
+    %% ldap + body_too_large: slot = 0*15 + 2 + 1 = 3
+    ?assertEqual(1, counters:get(Counters, 3)),
+    %% ldap + query_invalid: slot = 0*15 + 5 + 1 = 6
+    ?assertEqual(1, counters:get(Counters, 6)),
+
+    %% Duration histogram count for ldap must remain 0 -- none of these are
+    %% timed categories.
+    CountSlot = Base + 0 * 13 + 13,
+    ?assertEqual(0, counters:get(Counters, CountSlot)),
+    ok.
+
+%% Verify that requests with an unrecognized method are counted under the
+%% synthetic method="unknown" label in requests_total.
+unknown_method_counted(_Config) ->
+    aws_auth_validate_metrics:observe(<<"bogus">>, unknown_method, 10),
+
+    Counters = aws_auth_validate_metrics:counter_ref(),
+    %% unknown method_index=4, unknown_method category_index=12
+    %% slot = 4*15 + 12 + 1 = 73
+    ?assertEqual(1, counters:get(Counters, 73)),
     ok.
 
 %% Verify that capacity_exhausted observations increment the correct counter.
@@ -164,6 +250,21 @@ semaphore_gauges(_Config) ->
     gen_server:stop(Pid),
     ok.
 
+%% Verify that an arbitrary (non-standard) exit from the semaphore does not
+%% crash the metrics scrape -- it degrades gracefully to unavailable.
+semaphore_exit_catch_all(_Config) ->
+    meck:new(aws_auth_validate_semaphore, [passthrough]),
+    meck:expect(aws_auth_validate_semaphore, usage, fun() -> exit({killed, test_reason}) end),
+
+    %% collect_mf/2 should complete without crashing.
+    Ref = make_ref(),
+    Self = self(),
+    Callback = fun(MF) -> Self ! {Ref, MF} end,
+    ?assertEqual(ok, aws_auth_validate_metrics:collect_mf(default, Callback)),
+
+    meck:unload(aws_auth_validate_semaphore),
+    ok.
+
 %% Verify that when metrics are not registered, no persistent_term entries exist.
 no_state_when_disabled(_Config) ->
     ?assertEqual(undefined, persistent_term:get({aws_auth_validate_metrics, counters}, undefined)),
@@ -185,3 +286,42 @@ unknown_method_no_crash(_Config) ->
 unknown_category_no_crash(_Config) ->
     ?assertEqual(ok, aws_auth_validate_metrics:observe(<<"ldap">>, some_unknown_category, 100)),
     ok.
+
+%% Verify that calling register/0 a second time does not reset existing
+%% counter values (get-or-create semantics).
+register_preserves_counters(_Config) ->
+    %% Observe something first.
+    aws_auth_validate_metrics:observe(<<"ldap">>, success, 50),
+
+    Counters1 = aws_auth_validate_metrics:counter_ref(),
+    %% ldap + success: slot 1
+    Val1 = counters:get(Counters1, 1),
+    ?assertEqual(1, Val1),
+
+    %% Re-register -- must NOT reset counters.
+    aws_auth_validate_metrics:register(),
+
+    Counters2 = aws_auth_validate_metrics:counter_ref(),
+    ?assertEqual(Counters1, Counters2),
+    Val2 = counters:get(Counters2, 1),
+    ?assertEqual(1, Val2),
+    ok.
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+%% Invoke collect_mf/2 and return the list of all metric families emitted.
+collect_all_mf() ->
+    Ref = make_ref(),
+    Self = self(),
+    Callback = fun(MF) -> Self ! {Ref, MF} end,
+    aws_auth_validate_metrics:collect_mf(default, Callback),
+    collect_all_mf_loop(Ref, []).
+
+collect_all_mf_loop(Ref, Acc) ->
+    receive
+        {Ref, MF} -> collect_all_mf_loop(Ref, [MF | Acc])
+    after 100 ->
+        lists:reverse(Acc)
+    end.

--- a/test/aws_auth_validate_metrics_SUITE.erl
+++ b/test/aws_auth_validate_metrics_SUITE.erl
@@ -1,0 +1,187 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+%% vim:ft=erlang:
+%% -*- mode: erlang; -*-
+
+%% Common Test suite for aws_auth_validate_metrics.
+%%
+%% Tests cover:
+%%   - Counter increments for requests_total
+%%   - Histogram bucket population for duration
+%%   - Dedicated capacity_exhausted counter
+%%   - Semaphore gauge reads at scrape time
+%%   - No-op behaviour when metrics are not registered
+%%   - Crash safety (observe/3 never raises)
+-module(aws_auth_validate_metrics_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-export([
+    all/0,
+    init_per_suite/1,
+    end_per_suite/1,
+    init_per_testcase/2,
+    end_per_testcase/2
+]).
+
+-export([
+    requests_total_increments/1,
+    duration_histogram_records/1,
+    capacity_exhausted_increments/1,
+    semaphore_gauges/1,
+    no_state_when_disabled/1,
+    crash_safety/1,
+    unknown_method_no_crash/1,
+    unknown_category_no_crash/1
+]).
+
+all() ->
+    [
+        requests_total_increments,
+        duration_histogram_records,
+        capacity_exhausted_increments,
+        semaphore_gauges,
+        no_state_when_disabled,
+        crash_safety,
+        unknown_method_no_crash,
+        unknown_category_no_crash
+    ].
+
+init_per_suite(Config) ->
+    %% Start applications that prometheus_registry needs.
+    {ok, _} = application:ensure_all_started(prometheus),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_testcase(no_state_when_disabled, Config) ->
+    %% Ensure metrics are NOT registered for this test case.
+    _ = persistent_term:erase({aws_auth_validate_metrics, counters}),
+    Config;
+init_per_testcase(crash_safety, Config) ->
+    %% Ensure metrics are NOT registered for this test case.
+    _ = persistent_term:erase({aws_auth_validate_metrics, counters}),
+    Config;
+init_per_testcase(_TestCase, Config) ->
+    %% Ensure clean state: deregister any prior collector and erase counters.
+    catch aws_auth_validate_metrics:deregister(),
+    %% Register metrics fresh for each test case.
+    aws_auth_validate_metrics:register(),
+    Config.
+
+end_per_testcase(no_state_when_disabled, _Config) ->
+    ok;
+end_per_testcase(crash_safety, _Config) ->
+    ok;
+end_per_testcase(_TestCase, _Config) ->
+    %% Clean up: deregister collector and erase persistent_term.
+    catch aws_auth_validate_metrics:deregister(),
+    ok.
+
+%%--------------------------------------------------------------------
+%% Test cases
+%%--------------------------------------------------------------------
+
+%% Verify that observe/3 increments the requests_total counter for multiple
+%% (method, category) combinations.
+requests_total_increments(_Config) ->
+    aws_auth_validate_metrics:observe(<<"ldap">>, success, 50),
+    aws_auth_validate_metrics:observe(<<"ldap">>, success, 30),
+    aws_auth_validate_metrics:observe(<<"ldap">>, auth_failed, 100),
+    aws_auth_validate_metrics:observe(<<"http">>, connection_failed, 200),
+    aws_auth_validate_metrics:observe(<<"oauth">>, token_expired, 500),
+
+    %% Read counters directly to verify.
+    Counters = aws_auth_validate_metrics:counter_ref(),
+    ?assertNotEqual(undefined, Counters),
+
+    %% ldap + success: method_index=0, category_index=0, slot = 0*15 + 0 + 1 = 1
+    ?assertEqual(2, counters:get(Counters, 1)),
+    %% ldap + auth_failed: method_index=0, category_index=6, slot = 0*15 + 6 + 1 = 7
+    ?assertEqual(1, counters:get(Counters, 7)),
+    %% http + connection_failed: method_index=1, category_index=3, slot = 1*15 + 3 + 1 = 19
+    ?assertEqual(1, counters:get(Counters, 19)),
+    %% oauth + token_expired: method_index=2, category_index=9, slot = 2*15 + 9 + 1 = 40
+    ?assertEqual(1, counters:get(Counters, 40)),
+    ok.
+
+%% Verify that observe/3 populates histogram buckets correctly.
+duration_histogram_records(_Config) ->
+    %% Observe durations in different buckets:
+    %% 5ms -> bucket 1 (<=10), 75ms -> bucket 4 (<=100), 3000ms -> bucket 8 (<=5000)
+    aws_auth_validate_metrics:observe(<<"ldap">>, success, 5),
+    aws_auth_validate_metrics:observe(<<"ldap">>, success, 75),
+    aws_auth_validate_metrics:observe(<<"ldap">>, success, 3000),
+
+    Counters = aws_auth_validate_metrics:counter_ref(),
+    Base = aws_auth_validate_metrics:histogram_base(),
+
+    %% ldap is method_index 0, so its histogram starts at Base + 0*12.
+    %% Bucket 1 (<=10ms): slot = Base + 0*12 + 1 = Base + 1
+    ?assertEqual(1, counters:get(Counters, Base + 1)),
+    %% Bucket 4 (<=100ms): slot = Base + 0*12 + 4 = Base + 4
+    ?assertEqual(1, counters:get(Counters, Base + 4)),
+    %% Bucket 9 (<=5000ms): slot = Base + 0*12 + 9 = Base + 9
+    ?assertEqual(1, counters:get(Counters, Base + 9)),
+    %% Sum slot: Base + 0*12 + 11 = Base + 11
+    ?assertEqual(5 + 75 + 3000, counters:get(Counters, Base + 11)),
+    %% Count slot: Base + 0*12 + 12 = Base + 12
+    ?assertEqual(3, counters:get(Counters, Base + 12)),
+    ok.
+
+%% Verify that capacity_exhausted observations increment the correct counter.
+capacity_exhausted_increments(_Config) ->
+    aws_auth_validate_metrics:observe(<<"ldap">>, capacity_exhausted, 10),
+    aws_auth_validate_metrics:observe(<<"ldap">>, capacity_exhausted, 20),
+    aws_auth_validate_metrics:observe(<<"http">>, capacity_exhausted, 15),
+
+    Counters = aws_auth_validate_metrics:counter_ref(),
+    %% ldap + capacity_exhausted: method_index=0, category_index=11, slot = 0*15 + 11 + 1 = 12
+    ?assertEqual(2, counters:get(Counters, 12)),
+    %% http + capacity_exhausted: method_index=1, category_index=11, slot = 1*15 + 11 + 1 = 27
+    ?assertEqual(1, counters:get(Counters, 27)),
+    ok.
+
+%% Verify that semaphore gauges reflect live state from the semaphore worker.
+semaphore_gauges(_Config) ->
+    %% Start a semaphore with max=3.
+    {ok, Pid} = aws_auth_validate_semaphore:start_link(#{max => 3}),
+
+    %% Acquire two slots.
+    {ok, Ref1} = aws_auth_validate_semaphore:acquire(),
+    {ok, _Ref2} = aws_auth_validate_semaphore:acquire(),
+
+    %% Verify usage/0 returns current state.
+    {2, 3} = aws_auth_validate_semaphore:usage(),
+
+    %% Release one.
+    ok = aws_auth_validate_semaphore:release(Ref1),
+    {1, 3} = aws_auth_validate_semaphore:usage(),
+
+    %% Clean up.
+    gen_server:stop(Pid),
+    ok.
+
+%% Verify that when metrics are not registered, no persistent_term entries exist.
+no_state_when_disabled(_Config) ->
+    ?assertEqual(undefined, persistent_term:get({aws_auth_validate_metrics, counters}, undefined)),
+    ok.
+
+%% Verify that calling observe/3 when not registered does not crash.
+crash_safety(_Config) ->
+    %% Should be a no-op, not a crash.
+    ?assertEqual(ok, aws_auth_validate_metrics:observe(<<"ldap">>, success, 100)),
+    ?assertEqual(ok, aws_auth_validate_metrics:observe(<<"http">>, auth_failed, 50)),
+    ok.
+
+%% Verify that observing an unknown method does not crash.
+unknown_method_no_crash(_Config) ->
+    ?assertEqual(ok, aws_auth_validate_metrics:observe(<<"unknown_method">>, success, 100)),
+    ok.
+
+%% Verify that observing an unknown category does not crash.
+unknown_category_no_crash(_Config) ->
+    ?assertEqual(ok, aws_auth_validate_metrics:observe(<<"ldap">>, some_unknown_category, 100)),
+    ok.


### PR DESCRIPTION
Adds Prometheus metrics for the auth-validation endpoint so operators can observe call volume, outcome mix, latency, and capacity pressure.

Metrics are emitted at the single point every request passes through (the audit log call site), dimensioned only by method and the fixed result-category set. No source IP, user, target, or secret material is ever used as a label.

Emitted via the `prometheus_collector` behaviour (the same pull-based pattern other RabbitMQ plugins use): the hot path is a lock-free counter update, and formatting happens only on scrape.

- `..._requests_total` (counter), `..._duration_ms` (histogram), `..._capacity_exhausted_total` (counter)
- semaphore in-use / capacity gauges
- Metrics register only when the feature is enabled; no state exists when it is off.

Adds new dependency, `prometheus`, to DEPS. However, it is already listed as a dependency in rabbitmq_prometheus, [which already exists within rabbitmq-server.](https://github.com/sdewhitt/rabbitmq-server/blob/aws/ldap-integration/deps/rabbitmq_prometheus/Makefile)

### Tests
CT suite covering counter increments per outcome, duration recording, capacity signalling, gauge behaviour, disabled-state, and crash-safety. All green.