### PR TITLE
Include referenced ARNs in auth-validation audit log

### DIFF
--- a/AUTH_VALIDATION.md
+++ b/AUTH_VALIDATION.md
@@ -108,16 +108,46 @@ request body from a bounded key set: `password_arn`, `cacertfile_arn`,
 `certfile_arn`, `keyfile_arn`. ARN references are safe to log per the R6 security
 invariant -- they are identifiers, not the resolved secret/certificate content,
 which is never logged. Multiple ARN references are comma-separated; when no ARN
-keys are present in the request, `arns=none` is emitted.
+keys are present in the request (or all are empty strings), `arns=none` is
+emitted.
 
 For pre-decode failures (`body_too_large`, malformed JSON), `arns=none` is
 emitted since no body was parsed at that point.
 
 Nested TLS-material ARN keys inside `ssl_options` (e.g.
 `ssl_options.cacertfile_arn`) are also included when the parent `ssl_options`
-field is allowed for the backend. Each ARN value is sanitized before
-interpolation to prevent log-injection attacks (control characters are replaced
-with U+FFFD).
+field is allowed for the backend. The set of ssl_options ARN keys is per-method:
+for `tls` only `cacertfile_arn` is reported (the tls backend validates local CA
+material, not client certs for outbound mTLS); for `ldap` and `http` all three
+keys (`cacertfile_arn`, `certfile_arn`, `keyfile_arn`) are reported.
+
+### Value encoding
+
+Each ARN value is percent-encoded before interpolation to prevent log-injection
+attacks. The following bytes are encoded as `%XX` (uppercase hex):
+
+| Byte    | Encoding | Reason                                    |
+|---------|----------|-------------------------------------------|
+| < 0x20  | `%XX`    | Control characters (prevent line splitting)|
+| 0x20    | `%20`    | Space (field delimiter in the log format)  |
+| 0x25    | `%25`    | Percent (encoding self-escape)             |
+| 0x2C    | `%2C`    | Comma (ARN value separator)               |
+| 0x3D    | `%3D`    | Equals (key=value delimiter)              |
+| 0x7F    | `%7F`    | DEL control character                      |
+
+This encoding is reversible (standard percent-decoding) and makes values
+unambiguous and greppable. All other bytes (including UTF-8 multi-byte
+sequences) pass through unchanged.
+
+### Length cap and non-ARN detection
+
+Each logged ARN value is capped at 2048 bytes. Values exceeding this limit are
+truncated and appended with `...[truncated]`. Real ARNs are well under this cap;
+it exists to prevent unbounded log lines from maliciously large input.
+
+A value that does not start with the `arn:` prefix is logged as
+`[non-arn:<first-128-bytes-percent-encoded>]` so it cannot masquerade as a real
+ARN identifier but is still attributable for forensic purposes.
 
 ## Enabling the endpoint
 

--- a/AUTH_VALIDATION.md
+++ b/AUTH_VALIDATION.md
@@ -93,6 +93,32 @@ to caller-supplied targets, and every method can cause the broker to assume the
 configured role and fetch ARN-backed material, so treat access to it
 accordingly.
 
+## Audit logging
+
+Every validation request emits a single-line structured log entry containing the
+method, authenticated user, source IP, result category, duration, and the ARN
+references the request carried:
+
+```
+auth_validate: method=ldap user=admin source_ip=10.0.0.5 result=success duration_ms=247 arns=arn:aws:secretsmanager:us-east-1:123456789012:secret:pw
+```
+
+The `arns=` field lists the ARN reference strings (identifiers) found in the
+request body from a bounded key set: `password_arn`, `cacertfile_arn`,
+`certfile_arn`, `keyfile_arn`. ARN references are safe to log per the R6 security
+invariant -- they are identifiers, not the resolved secret/certificate content,
+which is never logged. Multiple ARN references are comma-separated; when no ARN
+keys are present in the request, `arns=none` is emitted.
+
+For pre-decode failures (`body_too_large`, malformed JSON), `arns=none` is
+emitted since no body was parsed at that point.
+
+Nested TLS-material ARN keys inside `ssl_options` (e.g.
+`ssl_options.cacertfile_arn`) are also included when the parent `ssl_options`
+field is allowed for the backend. Each ARN value is sanitized before
+interpolation to prevent log-injection attacks (control characters are replaced
+with U+FFFD).
+
 ## Enabling the endpoint
 
 The feature is **opt-in and disabled by default**. Two levels of toggle are

--- a/src/aws_auth_validate_mgmt.erl
+++ b/src/aws_auth_validate_mgmt.erl
@@ -32,8 +32,18 @@
 %% sanitize_log/1 strips control chars from a caller-influenceable audit field;
 %% username/1 extracts the authenticated principal (or the `unknown' fallback);
 %% referenced_arns/2 extracts known ARN reference strings from the request body
-%% for audit logging (never resolved content, only identifiers).
--export([status_for_category/1, max_body_size/0, sanitize_log/1, username/1, referenced_arns/2]).
+%% for audit logging (never resolved content, only identifiers);
+%% encode_arn_value/1 percent-encodes ambiguous bytes for the audit format;
+%% prepare_arn_value/1 validates, caps, and encodes a single ARN value for logging.
+-export([
+    status_for_category/1,
+    max_body_size/0,
+    sanitize_log/1,
+    username/1,
+    referenced_arns/2,
+    encode_arn_value/1,
+    prepare_arn_value/1
+]).
 -endif.
 
 -include_lib("rabbitmq_web_dispatch/include/rabbitmq_web_dispatch_records.hrl").
@@ -42,6 +52,11 @@
 
 -define(DEFAULT_MAX_BODY_SIZE, 65_536).
 -define(DEFAULT_REQUIRED_USER_TAG, administrator).
+%% Maximum byte length of a single ARN value in the audit log. Real ARNs are
+%% well under this limit; the cap prevents a maliciously large value from
+%% producing an unbounded log line. Values exceeding this are truncated with
+%% a "...[truncated]" marker.
+-define(MAX_ARN_LOG_LEN, 2048).
 
 dispatcher() -> [{"/aws/auth/validate/:method", ?MODULE, []}].
 
@@ -356,6 +371,43 @@ sanitize_byte(B) when B < 16#20; B =:= 16#7F ->
 sanitize_byte(B) ->
     <<B>>.
 
+%% Percent-encode bytes that would be ambiguous in the space/comma-delimited
+%% audit format: space (0x20), equals (0x3D), comma (0x2C), percent (0x25),
+%% and control bytes (< 0x20, 0x7F). The encoding is reversible and greppable.
+encode_arn_value(Bin) when is_binary(Bin) ->
+    <<<<(encode_arn_byte(B))/binary>> || <<B>> <= Bin>>.
+
+encode_arn_byte(B) when B < 16#20 -> percent_hex(B);
+encode_arn_byte(16#20) -> <<"%20">>;
+encode_arn_byte(16#25) -> <<"%25">>;
+encode_arn_byte(16#2C) -> <<"%2C">>;
+encode_arn_byte(16#3D) -> <<"%3D">>;
+encode_arn_byte(16#7F) -> <<"%7F">>;
+encode_arn_byte(B) -> <<B>>.
+
+percent_hex(B) ->
+    <<$%, (hex_digit(B bsr 4)), (hex_digit(B band 16#0F))>>.
+
+hex_digit(N) when N < 10 -> $0 + N;
+hex_digit(N) -> $A + N - 10.
+
+%% Prepare an ARN value for audit logging: validate shape, cap length,
+%% percent-encode ambiguous bytes. A value exceeding MAX_ARN_LOG_LEN is
+%% truncated with a marker. A value not starting with "arn:" is wrapped
+%% in [non-arn:...] so it cannot masquerade as a real ARN identifier.
+prepare_arn_value(Bin) when byte_size(Bin) > ?MAX_ARN_LOG_LEN ->
+    Truncated = binary:part(Bin, 0, ?MAX_ARN_LOG_LEN),
+    <<(encode_arn_value(Truncated))/binary, "...[truncated]">>;
+prepare_arn_value(<<"arn:", _/binary>> = Bin) ->
+    encode_arn_value(Bin);
+prepare_arn_value(Bin) ->
+    Prefix =
+        case byte_size(Bin) > 128 of
+            true -> binary:part(Bin, 0, 128);
+            false -> Bin
+        end,
+    <<"[non-arn:", (encode_arn_value(Prefix))/binary, "]">>.
+
 %% The authenticated management user's name, for the audit trail. This endpoint
 %% is admin-gated and makes outbound connections to caller-chosen targets (an
 %% SSRF surface), so the acting principal -- not just the TCP peer IP, which
@@ -387,48 +439,63 @@ format_ip(_) ->
 %% Extracts the ARN reference strings that the request body carries, for inclusion
 %% in the audit log. Only a bounded set of known ARN keys is inspected --
 %% password_arn, cacertfile_arn, certfile_arn, keyfile_arn -- so arbitrary body
-%% fields are never leaked. Each value is sanitized before interpolation (log-
-%% injection guard). Returns a comma-joined binary of the ARN identifiers, or
-%% <<"none">> if no relevant ARN keys are present. ARN references are identifiers
-%% (safe to log per R6); resolved secret/cert content is never logged.
+%% fields are never leaked. Each value is percent-encoded (space, equals, comma,
+%% percent, control bytes) to prevent log injection and field forgery (F1/F4),
+%% capped at MAX_ARN_LOG_LEN bytes with a truncation marker (F2), and validated
+%% for the "arn:" prefix -- non-ARN values are wrapped in [non-arn:...] so they
+%% cannot masquerade as real identifiers (F2). Empty-string values are treated as
+%% absent (F3). Returns a comma-joined binary of the prepared ARN values, or
+%% <<"none">> if no relevant ARN keys are present.
+%%
+%% ARN references are identifiers (safe to log per R6); resolved secret/cert
+%% content is never logged.
 %%
 %% Top-level ARN keys are included only if they appear in the backend's
 %% effective_allowed_fields. TLS-material ARN keys nested one level inside
 %% ssl_options are included when ssl_options itself is an allowed field (the
 %% parent's presence is sufficient; sub-keys are not individually listed in
-%% effective_allowed_fields).
+%% effective_allowed_fields). The set of ssl_options ARN keys is per-method:
+%% the tls backend accepts only cacertfile_arn (it validates local CA material,
+%% not client certs for outbound mTLS), while ldap/http accept all three (F6).
 referenced_arns(Method, BodyMap) ->
     KnownArnKeys = [
         <<"password_arn">>, <<"cacertfile_arn">>, <<"certfile_arn">>, <<"keyfile_arn">>
     ],
-    TlsArnKeys = [<<"cacertfile_arn">>, <<"certfile_arn">>, <<"keyfile_arn">>],
     case aws_auth_validate_registry:lookup_backend(Method) of
         {error, unknown_method} ->
             <<"none">>;
         {ok, Module} ->
+            %% NOTE: this duplicates the lookup_backend + effective_allowed_fields
+            %% work that dispatch/2 performs moments later. Threading the resolved
+            %% module through the pipeline would tangle the mgmt->registry boundary
+            %% for marginal savings; left as-is deliberately.
             AllowedFields = aws_auth_validate_registry:effective_allowed_fields(Module, Method),
             %% Collect top-level ARN values that are in both the known set and
             %% the effective allowed fields for this backend.
             TopLevelArns = [
-                sanitize_log(V)
+                prepare_arn_value(V)
              || K <- KnownArnKeys,
                 lists:member(K, AllowedFields),
                 V <- [maps:get(K, BodyMap, undefined)],
-                is_binary(V)
+                is_binary(V),
+                V =/= <<>>
             ],
             %% Walk one level into ssl_options for TLS-material ARN keys. The
             %% parent ssl_options being an allowed field is sufficient -- the
             %% sub-keys are not individually gated by effective_allowed_fields.
+            %% The key set is method-specific (see ssl_arn_keys_for_method/1).
             SslArns =
                 case lists:member(<<"ssl_options">>, AllowedFields) of
                     true ->
                         case maps:get(<<"ssl_options">>, BodyMap, undefined) of
                             SslMap when is_map(SslMap) ->
+                                SslArnKeys = ssl_arn_keys_for_method(Method),
                                 [
-                                    sanitize_log(V)
-                                 || K <- TlsArnKeys,
+                                    prepare_arn_value(V)
+                                 || K <- SslArnKeys,
                                     V <- [maps:get(K, SslMap, undefined)],
-                                    is_binary(V)
+                                    is_binary(V),
+                                    V =/= <<>>
                                 ];
                             _ ->
                                 []
@@ -441,6 +508,16 @@ referenced_arns(Method, BodyMap) ->
                 Collected -> iolist_to_binary(lists:join(<<",">>, Collected))
             end
     end.
+
+%% Per-method ssl_options ARN keys that the backend actually processes.
+%% The tls backend validates only the CA bundle (cacertfile_arn); certfile_arn
+%% and keyfile_arn under ssl_options are for client-cert mTLS to a remote auth
+%% service, which ldap and http support but tls (a local-material check) does
+%% not.
+ssl_arn_keys_for_method(<<"tls">>) ->
+    [<<"cacertfile_arn">>];
+ssl_arn_keys_for_method(_) ->
+    [<<"cacertfile_arn">>, <<"certfile_arn">>, <<"keyfile_arn">>].
 
 %%--------------------------------------------------------------------
 %% Configuration accessors

--- a/src/aws_auth_validate_mgmt.erl
+++ b/src/aws_auth_validate_mgmt.erl
@@ -30,8 +30,10 @@
 %% to an HTTP status, including the catch-all for an unexpected category;
 %% max_body_size/0 resolves the configured body-size limit against its bounds;
 %% sanitize_log/1 strips control chars from a caller-influenceable audit field;
-%% username/1 extracts the authenticated principal (or the `unknown' fallback).
--export([status_for_category/1, max_body_size/0, sanitize_log/1, username/1]).
+%% username/1 extracts the authenticated principal (or the `unknown' fallback);
+%% referenced_arns/2 extracts known ARN reference strings from the request body
+%% for audit logging (never resolved content, only identifiers).
+-export([status_for_category/1, max_body_size/0, sanitize_log/1, username/1, referenced_arns/2]).
 -endif.
 
 -include_lib("rabbitmq_web_dispatch/include/rabbitmq_web_dispatch_records.hrl").
@@ -105,17 +107,17 @@ with_body(T0, SourceIP, User, Method, Req0, Context) ->
     MaxBytes = max_body_size(),
     case read_body(Req0, MaxBytes) of
         {error, body_too_large, Req1} ->
-            audit(Method, SourceIP, User, body_too_large, T0),
+            audit(Method, SourceIP, User, body_too_large, <<"none">>, T0),
             reply_error(400, body_too_large, <<"Request body too large">>, Req1, Context);
         {ok, RawBody, Req1} ->
             case decode_json(RawBody) of
                 {error, _} ->
-                    audit(Method, SourceIP, User, input_invalid, T0),
+                    audit(Method, SourceIP, User, input_invalid, <<"none">>, T0),
                     reply_error(400, input_invalid, <<"Invalid JSON body">>, Req1, Context);
                 {ok, BodyMap} when is_map(BodyMap) ->
                     with_semaphore(T0, SourceIP, User, Method, BodyMap, Req1, Context);
                 {ok, _NotMap} ->
-                    audit(Method, SourceIP, User, input_invalid, T0),
+                    audit(Method, SourceIP, User, input_invalid, <<"none">>, T0),
                     reply_error(
                         400, input_invalid, <<"JSON body must be an object">>, Req1, Context
                     )
@@ -130,9 +132,10 @@ with_semaphore(T0, SourceIP, User, Method, BodyMap, Req, Context) ->
     %% atomic acquire IS the liveness check, so there is no time-of-check vs
     %% time-of-use window -- and map it to the same graceful 503 as a full
     %% semaphore. Any other exit propagates (it is a genuine fault).
+    Arns = referenced_arns(Method, BodyMap),
     case try_acquire() of
         not_ready ->
-            audit(Method, SourceIP, User, capacity_exhausted, T0),
+            audit(Method, SourceIP, User, capacity_exhausted, Arns, T0),
             reply_error(
                 503,
                 capacity_exhausted,
@@ -141,7 +144,7 @@ with_semaphore(T0, SourceIP, User, Method, BodyMap, Req, Context) ->
                 Context
             );
         {error, full} ->
-            audit(Method, SourceIP, User, capacity_exhausted, T0),
+            audit(Method, SourceIP, User, capacity_exhausted, Arns, T0),
             reply_error(503, capacity_exhausted, <<"Service at capacity">>, Req, Context);
         {ok, Ref} ->
             try
@@ -159,11 +162,11 @@ with_semaphore(T0, SourceIP, User, Method, BodyMap, Req, Context) ->
                 %% Report it as a 500 rather than a 400 connection_failed, which
                 %% would wrongly tell the caller their LDAP server is unreachable.
                 Result = aws_auth_validate_registry:dispatch(Method, BodyMap),
-                audit(Method, SourceIP, User, result_category(Result), T0),
+                audit(Method, SourceIP, User, result_category(Result), Arns, T0),
                 respond(Result, Req, Context)
             catch
                 _Class:_Reason:_Stack ->
-                    audit(Method, SourceIP, User, internal_error, T0),
+                    audit(Method, SourceIP, User, internal_error, Arns, T0),
                     reply_error(
                         500,
                         internal_error,
@@ -312,11 +315,23 @@ decode_json(<<>>) ->
 decode_json(Raw) ->
     rabbit_json:try_decode(Raw).
 
-audit(Method, SourceIP, User, ResultCategory, T0) ->
+%% Emit a single-line audit record for every validation request. The arns= field
+%% lists the ARN reference strings the request carried (identifiers, not resolved
+%% content -- safe to log per the R6 no-credential-leakage invariant). For
+%% pre-decode failures (body_too_large, malformed JSON) arns=none is emitted since
+%% no body was parsed.
+audit(Method, SourceIP, User, ResultCategory, Arns, T0) ->
     Duration = erlang:monotonic_time(millisecond) - T0,
     ?AWS_LOG_INFO(
-        "auth_validate: method=~ts user=~ts source_ip=~ts result=~ts duration_ms=~B",
-        [sanitize_log(Method), sanitize_log(User), format_ip(SourceIP), ResultCategory, Duration]
+        "auth_validate: method=~ts user=~ts source_ip=~ts result=~ts duration_ms=~B arns=~ts",
+        [
+            sanitize_log(Method),
+            sanitize_log(User),
+            format_ip(SourceIP),
+            ResultCategory,
+            Duration,
+            Arns
+        ]
     ),
     %% Emit Prometheus metrics for this request. observe/3 is a no-op when
     %% the metrics collector is not registered, so this is always safe.
@@ -368,6 +383,64 @@ format_ip(IP) when is_tuple(IP) ->
     end;
 format_ip(_) ->
     <<"unknown">>.
+
+%% Extracts the ARN reference strings that the request body carries, for inclusion
+%% in the audit log. Only a bounded set of known ARN keys is inspected --
+%% password_arn, cacertfile_arn, certfile_arn, keyfile_arn -- so arbitrary body
+%% fields are never leaked. Each value is sanitized before interpolation (log-
+%% injection guard). Returns a comma-joined binary of the ARN identifiers, or
+%% <<"none">> if no relevant ARN keys are present. ARN references are identifiers
+%% (safe to log per R6); resolved secret/cert content is never logged.
+%%
+%% Top-level ARN keys are included only if they appear in the backend's
+%% effective_allowed_fields. TLS-material ARN keys nested one level inside
+%% ssl_options are included when ssl_options itself is an allowed field (the
+%% parent's presence is sufficient; sub-keys are not individually listed in
+%% effective_allowed_fields).
+referenced_arns(Method, BodyMap) ->
+    KnownArnKeys = [
+        <<"password_arn">>, <<"cacertfile_arn">>, <<"certfile_arn">>, <<"keyfile_arn">>
+    ],
+    TlsArnKeys = [<<"cacertfile_arn">>, <<"certfile_arn">>, <<"keyfile_arn">>],
+    case aws_auth_validate_registry:lookup_backend(Method) of
+        {error, unknown_method} ->
+            <<"none">>;
+        {ok, Module} ->
+            AllowedFields = aws_auth_validate_registry:effective_allowed_fields(Module, Method),
+            %% Collect top-level ARN values that are in both the known set and
+            %% the effective allowed fields for this backend.
+            TopLevelArns = [
+                sanitize_log(V)
+             || K <- KnownArnKeys,
+                lists:member(K, AllowedFields),
+                V <- [maps:get(K, BodyMap, undefined)],
+                is_binary(V)
+            ],
+            %% Walk one level into ssl_options for TLS-material ARN keys. The
+            %% parent ssl_options being an allowed field is sufficient -- the
+            %% sub-keys are not individually gated by effective_allowed_fields.
+            SslArns =
+                case lists:member(<<"ssl_options">>, AllowedFields) of
+                    true ->
+                        case maps:get(<<"ssl_options">>, BodyMap, undefined) of
+                            SslMap when is_map(SslMap) ->
+                                [
+                                    sanitize_log(V)
+                                 || K <- TlsArnKeys,
+                                    V <- [maps:get(K, SslMap, undefined)],
+                                    is_binary(V)
+                                ];
+                            _ ->
+                                []
+                        end;
+                    false ->
+                        []
+                end,
+            case TopLevelArns ++ SslArns of
+                [] -> <<"none">>;
+                Collected -> iolist_to_binary(lists:join(<<",">>, Collected))
+            end
+    end.
 
 %%--------------------------------------------------------------------
 %% Configuration accessors

--- a/test/aws_auth_validate_tests.erl
+++ b/test/aws_auth_validate_tests.erl
@@ -1114,6 +1114,14 @@ tls_body(CacertArn) ->
 %% referenced_arns/2 -- ARN extraction for audit log
 %%--------------------------------------------------------------------
 
+%% An unrecognized method (lookup_backend returns {error, unknown_method})
+%% yields <<"none">> without calling effective_allowed_fields.
+referenced_arns_unknown_method_test() ->
+    Result = aws_auth_validate_mgmt:referenced_arns(
+        <<"garbage">>, #{<<"password_arn">> => <<"arn:aws:sm:us-east-1:123:secret:x">>}
+    ),
+    ?assertEqual(<<"none">>, Result).
+
 %% A request with a top-level password_arn in the body (and in the effective
 %% allowed fields) surfaces that ARN in the audit output.
 referenced_arns_top_level_password_arn_test_() ->

--- a/test/aws_auth_validate_tests.erl
+++ b/test/aws_auth_validate_tests.erl
@@ -1197,7 +1197,7 @@ referenced_arns_none_test_() ->
             [?_assertEqual(<<"none">>, Result)]
         end}.
 
-%% An ARN value containing CR/LF is sanitized (replaced with U+FFFD).
+%% An ARN value containing CR/LF is percent-encoded (no raw control chars in output).
 referenced_arns_sanitizes_crlf_test_() ->
     {setup,
         fun() ->
@@ -1220,7 +1220,10 @@ referenced_arns_sanitizes_crlf_test_() ->
             Result = aws_auth_validate_mgmt:referenced_arns(<<"ldap">>, Body),
             [
                 ?_assertEqual(nomatch, binary:match(Result, <<"\r">>)),
-                ?_assertEqual(nomatch, binary:match(Result, <<"\n">>))
+                ?_assertEqual(nomatch, binary:match(Result, <<"\n">>)),
+                %% Control chars are percent-encoded.
+                ?_assertNotEqual(nomatch, binary:match(Result, <<"%0D">>)),
+                ?_assertNotEqual(nomatch, binary:match(Result, <<"%0A">>))
             ]
         end}.
 
@@ -1291,6 +1294,167 @@ referenced_arns_no_secret_leakage_test_() ->
                 ?_assertEqual(nomatch, binary:match(Result, <<"ldap.example.com">>)),
                 ?_assertEqual(nomatch, binary:match(Result, <<"cn=admin">>)),
                 ?_assertEqual(nomatch, binary:match(Result, <<"should-never-appear">>))
+            ]
+        end}.
+
+%%--------------------------------------------------------------------
+%% encode_arn_value/1 -- percent-encoding for audit safety (F1/F4)
+%%--------------------------------------------------------------------
+
+encode_arn_value_plain_passthrough_test() ->
+    In = <<"arn:aws:secretsmanager:us-east-1:123456789012:secret:pw">>,
+    ?assertEqual(In, aws_auth_validate_mgmt:encode_arn_value(In)).
+
+encode_arn_value_encodes_space_test() ->
+    ?assertEqual(<<"arn:aws:x%20y">>, aws_auth_validate_mgmt:encode_arn_value(<<"arn:aws:x y">>)).
+
+encode_arn_value_encodes_equals_test() ->
+    ?assertEqual(<<"a%3Db">>, aws_auth_validate_mgmt:encode_arn_value(<<"a=b">>)).
+
+encode_arn_value_encodes_comma_test() ->
+    ?assertEqual(<<"a%2Cb">>, aws_auth_validate_mgmt:encode_arn_value(<<"a,b">>)).
+
+encode_arn_value_encodes_percent_test() ->
+    ?assertEqual(<<"100%2525">>, aws_auth_validate_mgmt:encode_arn_value(<<"100%25">>)).
+
+encode_arn_value_encodes_control_chars_test() ->
+    ?assertEqual(<<"%0D%0A">>, aws_auth_validate_mgmt:encode_arn_value(<<"\r\n">>)).
+
+encode_arn_value_encodes_del_test() ->
+    ?assertEqual(<<"%7F">>, aws_auth_validate_mgmt:encode_arn_value(<<127>>)).
+
+%%--------------------------------------------------------------------
+%% prepare_arn_value/1 -- length cap, non-ARN detection (F2)
+%%--------------------------------------------------------------------
+
+prepare_arn_value_normal_arn_test() ->
+    In = <<"arn:aws:secretsmanager:us-east-1:123456789012:secret:pw">>,
+    ?assertEqual(In, aws_auth_validate_mgmt:prepare_arn_value(In)).
+
+prepare_arn_value_truncates_overlength_test() ->
+    %% A value exceeding 2048 bytes is truncated with a marker.
+    Long = iolist_to_binary([<<"arn:aws:sm:">>, binary:copy(<<"x">>, 2100)]),
+    Result = aws_auth_validate_mgmt:prepare_arn_value(Long),
+    ?assert(byte_size(Result) < byte_size(Long)),
+    ?assertNotEqual(nomatch, binary:match(Result, <<"...[truncated]">>)).
+
+prepare_arn_value_non_arn_prefix_test() ->
+    %% A value not starting with "arn:" is wrapped.
+    Result = aws_auth_validate_mgmt:prepare_arn_value(<<"not-an-arn-value">>),
+    ?assertNotEqual(nomatch, binary:match(Result, <<"[non-arn:">>)),
+    ?assertNotEqual(nomatch, binary:match(Result, <<"]">>)).
+
+prepare_arn_value_non_arn_caps_at_128_test() ->
+    %% A long non-ARN value only includes the first 128 bytes.
+    Long = binary:copy(<<"x">>, 500),
+    Result = aws_auth_validate_mgmt:prepare_arn_value(Long),
+    %% [non-arn: + 128 x's + ] = 138 bytes + prefix/suffix
+    ?assert(byte_size(Result) < 200).
+
+prepare_arn_value_injection_attempt_test() ->
+    %% An injection attempt is encoded so spaces/equals don't forge fields.
+    Injected = <<"arn:aws:x result=success user=root">>,
+    Result = aws_auth_validate_mgmt:prepare_arn_value(Injected),
+    %% No raw space or equals in the output.
+    ?assertEqual(nomatch, binary:match(Result, <<" ">>)),
+    %% The encoded version has %20 and %3D.
+    ?assertNotEqual(nomatch, binary:match(Result, <<"%20">>)),
+    ?assertNotEqual(nomatch, binary:match(Result, <<"%3D">>)).
+
+%%--------------------------------------------------------------------
+%% referenced_arns/2 -- additional edge cases (F3, F4, F6)
+%%--------------------------------------------------------------------
+
+%% An empty-string ARN value is treated as absent (F3).
+referenced_arns_empty_string_yields_none_test_() ->
+    {setup,
+        fun() ->
+            ok = meck:new(aws_auth_validate_registry, [passthrough]),
+            meck:expect(aws_auth_validate_registry, lookup_backend, fun(<<"ldap">>) ->
+                {ok, some_module}
+            end),
+            meck:expect(aws_auth_validate_registry, effective_allowed_fields, fun(
+                some_module, <<"ldap">>
+            ) ->
+                [<<"password_arn">>, <<"servers">>]
+            end),
+            ok
+        end,
+        fun(_) ->
+            meck:unload(aws_auth_validate_registry)
+        end,
+        fun(_) ->
+            Body = #{<<"password_arn">> => <<>>},
+            Result = aws_auth_validate_mgmt:referenced_arns(<<"ldap">>, Body),
+            [?_assertEqual(<<"none">>, Result)]
+        end}.
+
+%% A comma within a value is percent-encoded, not confused with the separator (F4).
+referenced_arns_comma_in_value_encoded_test_() ->
+    {setup,
+        fun() ->
+            ok = meck:new(aws_auth_validate_registry, [passthrough]),
+            meck:expect(aws_auth_validate_registry, lookup_backend, fun(<<"ldap">>) ->
+                {ok, some_module}
+            end),
+            meck:expect(aws_auth_validate_registry, effective_allowed_fields, fun(
+                some_module, <<"ldap">>
+            ) ->
+                [<<"password_arn">>, <<"servers">>]
+            end),
+            ok
+        end,
+        fun(_) ->
+            meck:unload(aws_auth_validate_registry)
+        end,
+        fun(_) ->
+            %% A single ARN value containing a comma must not split into two entries.
+            Body = #{<<"password_arn">> => <<"arn:aws:sm:us-east-1:123:secret:a,b">>},
+            Result = aws_auth_validate_mgmt:referenced_arns(<<"ldap">>, Body),
+            [
+                %% The raw comma is encoded as %2C.
+                ?_assertNotEqual(nomatch, binary:match(Result, <<"%2C">>)),
+                %% Splitting on comma yields exactly one element (the whole value).
+                ?_assertEqual(1, length(binary:split(Result, <<",">>, [global])))
+            ]
+        end}.
+
+%% The tls method only reports cacertfile_arn, not certfile_arn/keyfile_arn (F6).
+referenced_arns_tls_only_cacertfile_test_() ->
+    {setup,
+        fun() ->
+            ok = meck:new(aws_auth_validate_registry, [passthrough]),
+            meck:expect(aws_auth_validate_registry, lookup_backend, fun(<<"tls">>) ->
+                {ok, some_module}
+            end),
+            meck:expect(aws_auth_validate_registry, effective_allowed_fields, fun(
+                some_module, <<"tls">>
+            ) ->
+                [<<"ssl_options">>, <<"target">>]
+            end),
+            ok
+        end,
+        fun(_) ->
+            meck:unload(aws_auth_validate_registry)
+        end,
+        fun(_) ->
+            CaArn = <<"arn:aws:acm-pca:us-east-1:123:ca/abc">>,
+            CertArn = <<"arn:aws:sm:us-east-1:123:secret:cert">>,
+            KeyArn = <<"arn:aws:sm:us-east-1:123:secret:key">>,
+            Body = #{
+                <<"ssl_options">> => #{
+                    <<"cacertfile_arn">> => CaArn,
+                    <<"certfile_arn">> => CertArn,
+                    <<"keyfile_arn">> => KeyArn
+                }
+            },
+            Result = aws_auth_validate_mgmt:referenced_arns(<<"tls">>, Body),
+            [
+                %% Only cacertfile_arn is reported.
+                ?_assertNotEqual(nomatch, binary:match(Result, <<"acm-pca">>)),
+                %% certfile and keyfile are NOT reported.
+                ?_assertEqual(nomatch, binary:match(Result, <<"secret:cert">>)),
+                ?_assertEqual(nomatch, binary:match(Result, <<"secret:key">>))
             ]
         end}.
 

--- a/test/aws_auth_validate_tests.erl
+++ b/test/aws_auth_validate_tests.erl
@@ -1111,6 +1111,182 @@ tls_body(CacertArn) ->
     }.
 
 %%--------------------------------------------------------------------
+%% referenced_arns/2 -- ARN extraction for audit log
+%%--------------------------------------------------------------------
+
+%% A request with a top-level password_arn in the body (and in the effective
+%% allowed fields) surfaces that ARN in the audit output.
+referenced_arns_top_level_password_arn_test_() ->
+    {setup,
+        fun() ->
+            ok = meck:new(aws_auth_validate_registry, [passthrough]),
+            meck:expect(aws_auth_validate_registry, lookup_backend, fun(<<"ldap">>) ->
+                {ok, some_module}
+            end),
+            meck:expect(aws_auth_validate_registry, effective_allowed_fields, fun(
+                some_module, <<"ldap">>
+            ) ->
+                [<<"password_arn">>, <<"servers">>]
+            end),
+            ok
+        end,
+        fun(_) ->
+            meck:unload(aws_auth_validate_registry)
+        end,
+        fun(_) ->
+            Arn = <<"arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret">>,
+            Body = #{<<"password_arn">> => Arn},
+            Result = aws_auth_validate_mgmt:referenced_arns(<<"ldap">>, Body),
+            [?_assertEqual(Arn, Result)]
+        end}.
+
+%% A nested ssl_options.cacertfile_arn appears when ssl_options is an allowed field.
+referenced_arns_nested_ssl_options_test_() ->
+    {setup,
+        fun() ->
+            ok = meck:new(aws_auth_validate_registry, [passthrough]),
+            meck:expect(aws_auth_validate_registry, lookup_backend, fun(<<"ldap">>) ->
+                {ok, some_module}
+            end),
+            meck:expect(aws_auth_validate_registry, effective_allowed_fields, fun(
+                some_module, <<"ldap">>
+            ) ->
+                [<<"ssl_options">>, <<"servers">>]
+            end),
+            ok
+        end,
+        fun(_) ->
+            meck:unload(aws_auth_validate_registry)
+        end,
+        fun(_) ->
+            Arn = <<"arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/abc">>,
+            Body = #{<<"ssl_options">> => #{<<"cacertfile_arn">> => Arn}},
+            Result = aws_auth_validate_mgmt:referenced_arns(<<"ldap">>, Body),
+            [?_assertEqual(Arn, Result)]
+        end}.
+
+%% A request body with no ARN fields returns <<"none">>.
+referenced_arns_none_test_() ->
+    {setup,
+        fun() ->
+            ok = meck:new(aws_auth_validate_registry, [passthrough]),
+            meck:expect(aws_auth_validate_registry, lookup_backend, fun(<<"ldap">>) ->
+                {ok, some_module}
+            end),
+            meck:expect(aws_auth_validate_registry, effective_allowed_fields, fun(
+                some_module, <<"ldap">>
+            ) ->
+                [<<"servers">>, <<"port">>]
+            end),
+            ok
+        end,
+        fun(_) ->
+            meck:unload(aws_auth_validate_registry)
+        end,
+        fun(_) ->
+            Body = #{<<"servers">> => [<<"ldap.example.com">>]},
+            Result = aws_auth_validate_mgmt:referenced_arns(<<"ldap">>, Body),
+            [?_assertEqual(<<"none">>, Result)]
+        end}.
+
+%% An ARN value containing CR/LF is sanitized (replaced with U+FFFD).
+referenced_arns_sanitizes_crlf_test_() ->
+    {setup,
+        fun() ->
+            ok = meck:new(aws_auth_validate_registry, [passthrough]),
+            meck:expect(aws_auth_validate_registry, lookup_backend, fun(<<"ldap">>) ->
+                {ok, some_module}
+            end),
+            meck:expect(aws_auth_validate_registry, effective_allowed_fields, fun(
+                some_module, <<"ldap">>
+            ) ->
+                [<<"password_arn">>, <<"servers">>]
+            end),
+            ok
+        end,
+        fun(_) ->
+            meck:unload(aws_auth_validate_registry)
+        end,
+        fun(_) ->
+            Body = #{<<"password_arn">> => <<"arn:aws:sm:us-east-1:123:secret\r\ninjected">>},
+            Result = aws_auth_validate_mgmt:referenced_arns(<<"ldap">>, Body),
+            [
+                ?_assertEqual(nomatch, binary:match(Result, <<"\r">>)),
+                ?_assertEqual(nomatch, binary:match(Result, <<"\n">>))
+            ]
+        end}.
+
+%% The access_token field (oauth secret) is NEVER included -- it is not in the
+%% known ARN key set (password_arn, cacertfile_arn, certfile_arn, keyfile_arn).
+referenced_arns_excludes_access_token_test_() ->
+    {setup,
+        fun() ->
+            ok = meck:new(aws_auth_validate_registry, [passthrough]),
+            meck:expect(aws_auth_validate_registry, lookup_backend, fun(<<"oauth">>) ->
+                {ok, some_module}
+            end),
+            meck:expect(aws_auth_validate_registry, effective_allowed_fields, fun(
+                some_module, <<"oauth">>
+            ) ->
+                [<<"access_token">>, <<"resource_server_id">>, <<"ssl_options">>]
+            end),
+            ok
+        end,
+        fun(_) ->
+            meck:unload(aws_auth_validate_registry)
+        end,
+        fun(_) ->
+            Body = #{
+                <<"access_token">> => <<"secret_token_value">>,
+                <<"resource_server_id">> => <<"my-resource">>
+            },
+            Result = aws_auth_validate_mgmt:referenced_arns(<<"oauth">>, Body),
+            [
+                ?_assertEqual(<<"none">>, Result),
+                %% Double-check the token value does not appear in the result.
+                ?_assertEqual(nomatch, binary:match(Result, <<"secret_token_value">>))
+            ]
+        end}.
+
+%% Only ARN reference identifiers from the known key set appear -- never arbitrary
+%% body field values that might be resolved secrets or other sensitive content.
+referenced_arns_no_secret_leakage_test_() ->
+    {setup,
+        fun() ->
+            ok = meck:new(aws_auth_validate_registry, [passthrough]),
+            meck:expect(aws_auth_validate_registry, lookup_backend, fun(<<"ldap">>) ->
+                {ok, some_module}
+            end),
+            meck:expect(aws_auth_validate_registry, effective_allowed_fields, fun(
+                some_module, <<"ldap">>
+            ) ->
+                [<<"password_arn">>, <<"servers">>, <<"user_dn">>, <<"ssl_options">>]
+            end),
+            ok
+        end,
+        fun(_) ->
+            meck:unload(aws_auth_validate_registry)
+        end,
+        fun(_) ->
+            Arn = <<"arn:aws:secretsmanager:us-east-1:123456789012:secret:pw">>,
+            Body = #{
+                <<"password_arn">> => Arn,
+                <<"servers">> => [<<"ldap.example.com">>],
+                <<"user_dn">> => <<"cn=admin,dc=example,dc=com">>,
+                <<"some_unknown_field">> => <<"should-never-appear">>
+            },
+            Result = aws_auth_validate_mgmt:referenced_arns(<<"ldap">>, Body),
+            [
+                %% Only the password_arn value appears (it is the only known ARN key present).
+                ?_assertEqual(Arn, Result),
+                %% Arbitrary body values never appear.
+                ?_assertEqual(nomatch, binary:match(Result, <<"ldap.example.com">>)),
+                ?_assertEqual(nomatch, binary:match(Result, <<"cn=admin">>)),
+                ?_assertEqual(nomatch, binary:match(Result, <<"should-never-appear">>))
+            ]
+        end}.
+
+%%--------------------------------------------------------------------
 %% LDAP query DSL parser (aws_auth_validate_ldap_query)
 %%--------------------------------------------------------------------
 


### PR DESCRIPTION
Includes the ARN references a validation request carried in its audit-log line.

An ARN is an identifier, not a secret, so logging it is safe and gives operators an attributable record of which secret/certificate a given validation attempt referenced. The resolved secret content itself is never logged.

- New `arns=` field lists the ARN references found in a bounded key set (`password_arn`, `cacertfile_arn`, `certfile_arn`, `keyfile_arn`), including one level into `ssl_options`; emits `arns=none` when there are none.
- Each value is sanitized before interpolation to prevent log injection.
- Inline tokens are never treated as ARNs and never logged.

### Tests
Top-level and nested extraction, `arns=none`, control-character sanitization, token exclusion, and a no-secret-leakage check. Full suite green.