### PR TITLE
Use ?MODULE_STRING in the logging macros

### DIFF
--- a/include/aws.hrl
+++ b/include/aws.hrl
@@ -10,29 +10,29 @@
 ).
 
 -define(AWS_LOG_DEBUG(Fmt, Args),
-    ?LOG_DEBUG("~tp: " ++ Fmt, [?MODULE | Args])
+    ?LOG_DEBUG(?MODULE_STRING ": " ++ Fmt, Args)
 ).
 
 -define(AWS_LOG_WARNING(Arg),
-    ?LOG_WARNING("~tp: ~ts", [?MODULE, Arg])
+    ?LOG_WARNING(?MODULE_STRING ": ~ts", [Arg])
 ).
 
 -define(AWS_LOG_WARNING(Fmt, Args),
-    ?LOG_WARNING("~tp: " ++ Fmt, [?MODULE | Args])
+    ?LOG_WARNING(?MODULE_STRING ": " ++ Fmt, Args)
 ).
 
 -define(AWS_LOG_ERROR(Arg),
-    ?LOG_ERROR("~tp: ~tp", [?MODULE, Arg])
+    ?LOG_ERROR(?MODULE_STRING ": ~tp", [Arg])
 ).
 
 -define(AWS_LOG_ERROR(Fmt, Args),
-    ?LOG_ERROR("~tp: " ++ Fmt, [?MODULE | Args])
+    ?LOG_ERROR(?MODULE_STRING ": " ++ Fmt, Args)
 ).
 
 -define(AWS_LOG_INFO(Arg),
-    ?LOG_INFO("~tp: ~ts", [?MODULE, Arg])
+    ?LOG_INFO(?MODULE_STRING ": ~ts", [Arg])
 ).
 
 -define(AWS_LOG_INFO(Fmt, Args),
-    ?LOG_INFO("~tp: " ++ Fmt, [?MODULE | Args])
+    ?LOG_INFO(?MODULE_STRING ": " ++ Fmt, Args)
 ).


### PR DESCRIPTION
> [!NOTE]
> This PR was written by Claude (Anthropic's Claude Code) under the direction of @lukebakken, who reviewed it before opening.

## Summary

Completes the `?MODULE_STRING` conversion that the-mikedavis suggested in the PR #2 review. That suggestion was applied to `?AWS_LOG_DEBUG/1` at the time; the remaining seven `?AWS_LOG_*` macros in `include/aws.hrl` still formatted `?MODULE` through `~tp` at runtime. This changes them to embed the `?MODULE_STRING` compile-time constant and drop a format argument from each.

## Behavior

The rendered output is unchanged. A module name is always an unquoted atom, so `~tp` of `?MODULE` and the `?MODULE_STRING` literal both produce the same `module_name: ` prefix.

## Verification

- `erlfmt -c include/aws.hrl` clean
- Full plugin compiles with no new warnings, so every `?AWS_LOG_*` call site builds against the changed macros
- No test couples to the log-prefix format

Closes #5
