### PR TITLE
Deregister Prometheus collectors on application stop

### DIFF
--- a/src/aws_app.erl
+++ b/src/aws_app.erl
@@ -29,6 +29,7 @@ start(normal, _StartArgs) ->
     aws_sup:start_link().
 
 stop(_State) ->
+    aws_sup:deregister_collectors(),
     ok.
 
 boot_step(aws_arn_config) ->

--- a/src/aws_sup.erl
+++ b/src/aws_sup.erl
@@ -9,7 +9,8 @@
 
 -export([
     start_link/0,
-    init/1
+    init/1,
+    deregister_collectors/0
 ]).
 
 start_link() ->
@@ -38,16 +39,37 @@ init([]) ->
 auth_validation_children() ->
     case application:get_env(aws, auth_validation_enabled, false) of
         true ->
-            %% Register the Prometheus metrics collector before starting the
-            %% semaphore worker. The collector has no process (it is a callback
-            %% module registered with prometheus_registry), so no child spec is
-            %% needed. rabbitmq_prometheus is a declared dependency (which
-            %% transitively pulls in prometheus), so a failure here is a real
-            %% fault and must surface rather than be swallowed.
-            aws_auth_validate_metrics:register(),
+            register_collectors(),
             [semaphore_spec()];
         _ ->
             []
+    end.
+
+%% Register the Prometheus collectors this plugin owns. A collector has no
+%% process (it is a callback module registered with prometheus_registry), so no
+%% child spec is needed. rabbitmq_prometheus is a declared dependency (which
+%% transitively pulls in prometheus), so a failure here is a real fault and must
+%% surface rather than be swallowed.
+register_collectors() ->
+    aws_auth_validate_metrics:register().
+
+%% Tear down every collector register_collectors/0 owns so none outlives the
+%% application: an orphan stays on the default registry and keeps running
+%% collect_mf/2 on every scrape. Called from aws_app:stop/1.
+deregister_collectors() ->
+    lists:foreach(fun deregister_collector/1, [aws_auth_validate_metrics]).
+
+%% Deregister one collector if it is currently registered. Driven by actual
+%% registration state rather than the feature toggle, so a still-registered
+%% collector is torn down even if the toggle no longer reads true; deregister/0
+%% is idempotent. The catch tolerates prometheus not being started, in which
+%% case nothing was ever registered.
+deregister_collector(Mod) ->
+    try prometheus_registry:collector_registeredp(Mod) of
+        true -> Mod:deregister();
+        false -> ok
+    catch
+        _:_ -> ok
     end.
 
 %% The concurrency semaphore bounds simultaneous outbound LDAP connections;

--- a/test/aws_auth_validate_metrics_SUITE.erl
+++ b/test/aws_auth_validate_metrics_SUITE.erl
@@ -43,7 +43,11 @@
     crash_safety/1,
     unknown_method_no_crash/1,
     unknown_category_no_crash/1,
-    register_preserves_counters/1
+    register_preserves_counters/1,
+    deregister_collectors_removes_registered/1,
+    deregister_collectors_ignores_feature_toggle/1,
+    deregister_collectors_not_registered_noop/1,
+    app_stop_deregisters/1
 ]).
 
 all() ->
@@ -60,7 +64,11 @@ all() ->
         crash_safety,
         unknown_method_no_crash,
         unknown_category_no_crash,
-        register_preserves_counters
+        register_preserves_counters,
+        deregister_collectors_removes_registered,
+        deregister_collectors_ignores_feature_toggle,
+        deregister_collectors_not_registered_noop,
+        app_stop_deregisters
     ].
 
 init_per_suite(Config) ->
@@ -71,12 +79,13 @@ init_per_suite(Config) ->
 end_per_suite(_Config) ->
     ok.
 
-init_per_testcase(no_state_when_disabled, Config) ->
+init_per_testcase(TestCase, Config) when
+    TestCase =:= no_state_when_disabled;
+    TestCase =:= crash_safety;
+    TestCase =:= deregister_collectors_not_registered_noop
+->
     %% Ensure metrics are NOT registered for this test case.
-    _ = persistent_term:erase({aws_auth_validate_metrics, counters}),
-    Config;
-init_per_testcase(crash_safety, Config) ->
-    %% Ensure metrics are NOT registered for this test case.
+    catch aws_auth_validate_metrics:deregister(),
     _ = persistent_term:erase({aws_auth_validate_metrics, counters}),
     Config;
 init_per_testcase(_TestCase, Config) ->
@@ -86,9 +95,11 @@ init_per_testcase(_TestCase, Config) ->
     aws_auth_validate_metrics:register(),
     Config.
 
-end_per_testcase(no_state_when_disabled, _Config) ->
-    ok;
-end_per_testcase(crash_safety, _Config) ->
+end_per_testcase(TestCase, _Config) when
+    TestCase =:= no_state_when_disabled;
+    TestCase =:= crash_safety;
+    TestCase =:= deregister_collectors_not_registered_noop
+->
     ok;
 end_per_testcase(_TestCase, _Config) ->
     %% Clean up: deregister collector and erase persistent_term.
@@ -306,6 +317,43 @@ register_preserves_counters(_Config) ->
     Val2 = counters:get(Counters2, 1),
     ?assertEqual(1, Val2),
     ok.
+
+%% A registered collector is removed from the registry and its counters erased,
+%% symmetric with the boot-time registration.
+deregister_collectors_removes_registered(_Config) ->
+    ?assert(prometheus_registry:collector_registeredp(aws_auth_validate_metrics)),
+    ?assertEqual(ok, aws_sup:deregister_collectors()),
+    ?assertNot(prometheus_registry:collector_registeredp(aws_auth_validate_metrics)),
+    ?assertEqual(undefined, aws_auth_validate_metrics:counter_ref()).
+
+%% Teardown is driven by registration state, not the feature toggle: a
+%% registered collector is torn down even when the toggle reads false, the
+%% orphan case a toggle-gated teardown would miss.
+deregister_collectors_ignores_feature_toggle(_Config) ->
+    ?assert(prometheus_registry:collector_registeredp(aws_auth_validate_metrics)),
+    application:set_env(aws, auth_validation_enabled, false),
+    try
+        ?assertEqual(ok, aws_sup:deregister_collectors()),
+        ?assertNot(prometheus_registry:collector_registeredp(aws_auth_validate_metrics))
+    after
+        application:unset_env(aws, auth_validation_enabled)
+    end.
+
+%% With no collector registered, teardown is a safe no-op: it returns ok without
+%% raising and touches nothing (deregister/0 is never called, so no spurious
+%% deregistration log is emitted on a feature-off shutdown).
+deregister_collectors_not_registered_noop(_Config) ->
+    ?assertNot(prometheus_registry:collector_registeredp(aws_auth_validate_metrics)),
+    ?assertEqual(ok, aws_sup:deregister_collectors()),
+    ?assertNot(prometheus_registry:collector_registeredp(aws_auth_validate_metrics)).
+
+%% aws_app:stop/1 drives the teardown, so a registered collector does not
+%% outlive the application.
+app_stop_deregisters(_Config) ->
+    ?assert(prometheus_registry:collector_registeredp(aws_auth_validate_metrics)),
+    ?assertEqual(ok, aws_app:stop(undefined)),
+    ?assertNot(prometheus_registry:collector_registeredp(aws_auth_validate_metrics)),
+    ?assertEqual(undefined, aws_auth_validate_metrics:counter_ref()).
 
 %%--------------------------------------------------------------------
 %% Helpers


### PR DESCRIPTION
> [!NOTE]
> This PR was written by Claude (Anthropic's Claude Code) under the direction of @lukebakken, who reviewed it before opening.

## Summary

`aws_sup:init/1` registers the auth-validation metrics collector as a boot side effect, but nothing deregistered it. The collector therefore outlived the `aws` application: on `application:stop(aws)` (or a plugin disable) it stayed on the default Prometheus registry and kept running `collect_mf/2` on every scrape.

This adds a symmetric teardown:

- `aws_sup:register_collectors/0` and `aws_sup:deregister_collectors/0` form the paired lifecycle, driven from a single collector list.
- `aws_app:stop/1` calls `deregister_collectors/0`, so a collector never outlives the application.

## Teardown is driven by registration state, not the feature toggle

`deregister_collectors/0` deregisters each collector that is actually registered rather than re-reading the `auth_validation_enabled` toggle. `deregister/0` is idempotent, so this tears a collector down even if the toggle no longer reads true (an orphan left by a runtime env change or a prior incarnation), and it does not emit a spurious deregistration log on a normal feature-off shutdown. The check is wrapped so prometheus not being started degrades to a no-op (nothing was registered in that case).

## Coverage

New `aws_auth_validate_metrics_SUITE` cases:

- `deregister_collectors_removes_registered` - a registered collector is removed and its counters erased
- `deregister_collectors_ignores_feature_toggle` - a registered collector is torn down even with the toggle set to `false` (the orphan case a toggle-gated teardown would miss)
- `deregister_collectors_not_registered_noop` - safe no-op when nothing is registered
- `app_stop_deregisters` - `aws_app:stop/1` drives the teardown

The existing `aws_app_tests:stop_test` now also exercises the prometheus-not-started path.

## Scope

Only the auth-validation collector exists on `main` today. The node-health collector (`aws_node_health_metrics`) referenced in #190 lives in the unmerged #188; `register_collectors/0` and the `deregister_collectors/0` list are the single place it plugs into (one line each).

## Verification

Run locally in `deps/aws` on this branch:

- `erlfmt -c` clean
- `make ct-aws_auth_validate_metrics` - 17 Ok, 0 Failed
- `make eunit EUNIT_MODS=aws_app_tests` - 2 passed
- `make xref` clean
- `make dialyze` passed

Closes #190
